### PR TITLE
fix(ci): update codecov-action to v5 for proper token handling (#21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DevBoy Tools
 
 [![CI](https://github.com/meteora-pro/devboy-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/meteora-pro/devboy-tools/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/gh/meteora-pro/devboy-tools/branch/main/graph/badge.svg)](https://codecov.io/gh/meteora-pro/devboy-tools)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Fast and efficient Open Source MCP server written in Rust. Designed for coding agents with plugin system (API providers + LLM-optimized pipeline) and project-scoped isolation (1 server = 1 project).
@@ -155,6 +156,12 @@ cargo build --release
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## Coverage Report
+
+[![Codecov](https://codecov.io/gh/meteora-pro/devboy-tools/branch/main/graph/badge.svg)](https://codecov.io/gh/meteora-pro/devboy-tools)
+
+Detailed coverage reports are available on [Codecov](https://codecov.io/gh/meteora-pro/devboy-tools).
 
 ## License
 


### PR DESCRIPTION
- Upgrade codecov-action from v4 to v5
- v5 correctly handles token via 'with:' parameter
- Fixes \"Token required - not valid tokenless upload\" error

Note: CODECOV_TOKEN secret must still be configured in repo settings.

Closes https://github.com/meteora-pro/devboy-tools/issues/21