### PR TITLE
feat: add configuration to disable built-in tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ devboy issues                           # List issues
 devboy mrs                              # List merge requests
 devboy test <provider>                  # Test provider connection
 devboy mcp                              # Start MCP server (stdio)
+devboy tools                            # Interactive tool management (TUI)
+devboy tools list                       # List tools with enabled/disabled status
+devboy tools disable <names...>         # Disable specific built-in tools
+devboy tools enable <names...>          # Re-enable specific tools
+devboy tools reset                      # Reset all filtering
+devboy tools call <name> [args]         # Call a built-in tool directly
 ```
 
 ## Development

--- a/crates/devboy-cli/Cargo.toml
+++ b/crates/devboy-cli/Cargo.toml
@@ -25,9 +25,11 @@ clap.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 anyhow.workspace = true
+dialoguer = "0.11"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tempfile.workspace = true
 async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -7,13 +7,18 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use devboy_clickup::ClickUpClient;
 use devboy_core::{
-    Config, ContextConfig, IssueFilter, IssueProvider, MergeRequestProvider, MrFilter, Provider,
+    BuiltinToolsConfig, Config, ContextConfig, IssueFilter, IssueProvider, MergeRequestProvider,
+    MrFilter, Provider,
 };
 use devboy_github::GitHubClient;
 use devboy_gitlab::GitLabClient;
 use devboy_jira::JiraClient;
-use devboy_mcp::{McpProxyClient, McpServer, ProxyManager, ProxyTransport};
+use devboy_mcp::{
+    JsonRpcRequest, McpProxyClient, McpServer, ProxyManager, ProxyTransport, RequestId,
+    JSONRPC_VERSION, KNOWN_BUILTIN_TOOLS,
+};
 use devboy_storage::{CredentialStore, KeychainStore};
+use dialoguer::MultiSelect;
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
@@ -78,6 +83,12 @@ enum Commands {
         #[command(subcommand)]
         command: ProxyCommands,
     },
+
+    /// Manage built-in tools (enable/disable). Interactive mode when run without subcommand.
+    Tools {
+        #[command(subcommand)]
+        command: Option<ToolsCommands>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -137,6 +148,34 @@ enum ContextCommands {
     Use { name: String },
 }
 
+#[derive(Subcommand)]
+enum ToolsCommands {
+    /// List all built-in tools and their status (enabled/disabled)
+    List,
+    /// Disable specific built-in tools
+    Disable {
+        /// Tool names to disable
+        #[arg(required = true, num_args = 1..)]
+        names: Vec<String>,
+    },
+    /// Enable specific built-in tools (remove from disabled list)
+    Enable {
+        /// Tool names to enable
+        #[arg(required = true, num_args = 1..)]
+        names: Vec<String>,
+    },
+    /// Reset all built-in tools filtering (re-enable everything)
+    Reset,
+    /// Call a built-in tool directly
+    Call {
+        /// Tool name (e.g., get_issues, list_contexts)
+        name: String,
+        /// JSON arguments (optional)
+        #[arg(default_value = "{}")]
+        args: String,
+    },
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -177,6 +216,10 @@ async fn main() -> Result<()> {
 
         Some(Commands::Proxy { command }) => {
             handle_proxy_command(command).await?;
+        }
+
+        Some(Commands::Tools { command }) => {
+            handle_tools_command(command).await?;
         }
 
         None => {
@@ -665,6 +708,15 @@ async fn handle_mcp_command() -> Result<()> {
     let store = KeychainStore::new();
 
     let mut server = McpServer::new();
+
+    // Apply built-in tools filtering config.
+    if !config.builtin_tools.is_empty() {
+        config.builtin_tools.warn_unknown_tools(KNOWN_BUILTIN_TOOLS);
+        server
+            .set_builtin_tools_config(config.builtin_tools.clone())
+            .context("Invalid builtin_tools configuration")?;
+    }
+
     let mut any_provider_added = false;
 
     // Add configured named contexts.
@@ -936,4 +988,434 @@ fn add_context_providers(
     }
 
     added
+}
+
+// =============================================================================
+// Tools Command
+// =============================================================================
+
+async fn handle_tools_command(command: Option<ToolsCommands>) -> Result<()> {
+    match command {
+        None => handle_tools_interactive()?,
+        Some(ToolsCommands::List) => handle_tools_list()?,
+        Some(ToolsCommands::Disable { names }) => handle_tools_disable(names)?,
+        Some(ToolsCommands::Enable { names }) => handle_tools_enable(names)?,
+        Some(ToolsCommands::Reset) => handle_tools_reset()?,
+        Some(ToolsCommands::Call { name, args }) => handle_tools_call(&name, &args).await?,
+    }
+    Ok(())
+}
+
+fn handle_tools_interactive() -> Result<()> {
+    let (mut config, config_path) = load_runtime_config()?;
+
+    let tools: Vec<&str> = KNOWN_BUILTIN_TOOLS.to_vec();
+
+    // Determine which tools are currently enabled
+    let defaults: Vec<bool> = tools
+        .iter()
+        .map(|name| config.builtin_tools.is_tool_allowed(name))
+        .collect();
+
+    let selections = MultiSelect::new()
+        .with_prompt("Select enabled built-in tools (Space to toggle, Enter to confirm)")
+        .items(&tools)
+        .defaults(&defaults)
+        .interact()
+        .context("Interactive selection cancelled")?;
+
+    // Collect disabled tools list
+    let disabled: Vec<String> = tools
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !selections.contains(i))
+        .map(|(_, name)| name.to_string())
+        .collect();
+
+    config.builtin_tools = if disabled.is_empty() {
+        BuiltinToolsConfig::default()
+    } else {
+        BuiltinToolsConfig {
+            disabled,
+            enabled: Vec::new(),
+        }
+    };
+
+    config
+        .save_to(&config_path)
+        .context("Failed to save config")?;
+
+    // Print summary
+    let enabled_count = selections.len();
+    let disabled_count = tools.len() - enabled_count;
+    println!(
+        "Saved: {} tools enabled, {} disabled ({})",
+        enabled_count,
+        disabled_count,
+        config_path.display()
+    );
+
+    Ok(())
+}
+
+fn handle_tools_list() -> Result<()> {
+    let (config, _) = load_runtime_config()?;
+    print_tools_list(&config);
+    Ok(())
+}
+
+fn print_tools_list(config: &Config) {
+    println!("Built-in tools:");
+    println!();
+    for name in KNOWN_BUILTIN_TOOLS {
+        let status = if config.builtin_tools.is_tool_allowed(name) {
+            "enabled"
+        } else {
+            "disabled"
+        };
+        println!("  {} [{}]", name, status);
+    }
+
+    if !config.builtin_tools.disabled.is_empty() {
+        println!();
+        println!(
+            "Mode: blacklist (disabled: {})",
+            config.builtin_tools.disabled.join(", ")
+        );
+    } else if !config.builtin_tools.enabled.is_empty() {
+        println!();
+        println!(
+            "Mode: whitelist (enabled: {})",
+            config.builtin_tools.enabled.join(", ")
+        );
+    }
+}
+
+fn handle_tools_disable(names: Vec<String>) -> Result<()> {
+    let (mut config, config_path) = load_runtime_config()?;
+    apply_tools_disable(&mut config, &names)?;
+    config
+        .save_to(&config_path)
+        .context("Failed to save config")?;
+    println!("Disabled tools: {}", names.join(", "));
+    Ok(())
+}
+
+fn apply_tools_disable(config: &mut Config, names: &[String]) -> Result<()> {
+    for name in names {
+        if !KNOWN_BUILTIN_TOOLS.contains(&name.as_str()) {
+            eprintln!("Warning: unknown tool '{}'", name);
+        }
+    }
+
+    if !config.builtin_tools.enabled.is_empty() {
+        anyhow::bail!(
+            "Cannot use 'disable' when whitelist (enabled) mode is active. Use 'reset' first."
+        );
+    }
+
+    for name in names {
+        if !config.builtin_tools.disabled.contains(name) {
+            config.builtin_tools.disabled.push(name.clone());
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_tools_enable(names: Vec<String>) -> Result<()> {
+    let (mut config, config_path) = load_runtime_config()?;
+    apply_tools_enable(&mut config, &names)?;
+    config
+        .save_to(&config_path)
+        .context("Failed to save config")?;
+    println!("Enabled tools: {}", names.join(", "));
+    Ok(())
+}
+
+fn apply_tools_enable(config: &mut Config, names: &[String]) -> Result<()> {
+    for name in names {
+        if !KNOWN_BUILTIN_TOOLS.contains(&name.as_str()) {
+            eprintln!("Warning: unknown tool '{}'", name);
+        }
+    }
+
+    if !config.builtin_tools.enabled.is_empty() {
+        anyhow::bail!(
+            "Cannot use 'enable' when whitelist (enabled) mode is active. Use 'reset' first."
+        );
+    }
+
+    config.builtin_tools.disabled.retain(|n| !names.contains(n));
+
+    Ok(())
+}
+
+fn handle_tools_reset() -> Result<()> {
+    let (mut config, config_path) = load_runtime_config()?;
+    apply_tools_reset(&mut config);
+    config
+        .save_to(&config_path)
+        .context("Failed to save config")?;
+    println!("All built-in tools filtering has been reset (all tools enabled).");
+    Ok(())
+}
+
+fn apply_tools_reset(config: &mut Config) {
+    config.builtin_tools = BuiltinToolsConfig::default();
+}
+
+async fn handle_tools_call(name: &str, args: &str) -> Result<()> {
+    let arguments: serde_json::Value =
+        serde_json::from_str(args).context("Invalid JSON arguments")?;
+
+    let (config, _) = load_runtime_config()?;
+    let store = KeychainStore::new();
+
+    let mut server = McpServer::new();
+
+    // Apply built-in tools filtering
+    if !config.builtin_tools.is_empty() {
+        server
+            .set_builtin_tools_config(config.builtin_tools.clone())
+            .context("Invalid builtin_tools configuration")?;
+    }
+
+    // Add providers (same as handle_mcp_command)
+    for (context_name, context) in &config.contexts {
+        server.ensure_context(context_name);
+        add_context_providers(&mut server, &store, context_name, context);
+    }
+    if !config.contexts.contains_key(Config::DEFAULT_CONTEXT_NAME) {
+        if let Some(default_context) = config.legacy_default_context() {
+            add_context_providers(
+                &mut server,
+                &store,
+                Config::DEFAULT_CONTEXT_NAME,
+                &default_context,
+            );
+        }
+    }
+    if let Some(active) = config.resolve_active_context_name() {
+        let _ = server.set_active_context(&active);
+    }
+
+    let req = JsonRpcRequest {
+        jsonrpc: JSONRPC_VERSION.to_string(),
+        id: RequestId::Number(1),
+        method: "tools/call".to_string(),
+        params: Some(serde_json::json!({
+            "name": name,
+            "arguments": arguments,
+        })),
+    };
+
+    let resp = server.handle_request(req).await;
+
+    if let Some(error) = resp.error {
+        eprintln!("Error: {}", error.message);
+        std::process::exit(1);
+    }
+
+    if let Some(result) = resp.result {
+        let json = serde_json::to_string_pretty(&result)?;
+        println!("{}", json);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn config_with_disabled(names: &[&str]) -> Config {
+        let mut config = Config::default();
+        config.builtin_tools.disabled = names.iter().map(|s| s.to_string()).collect();
+        config
+    }
+
+    fn config_with_enabled(names: &[&str]) -> Config {
+        let mut config = Config::default();
+        config.builtin_tools.enabled = names.iter().map(|s| s.to_string()).collect();
+        config
+    }
+
+    // -- disable tests --
+
+    #[test]
+    fn test_disable_adds_tools_to_disabled_list() {
+        let mut config = Config::default();
+        let names = vec!["get_issues".to_string(), "create_issue".to_string()];
+
+        apply_tools_disable(&mut config, &names).unwrap();
+
+        assert_eq!(config.builtin_tools.disabled, names);
+        assert!(config.builtin_tools.enabled.is_empty());
+    }
+
+    #[test]
+    fn test_disable_does_not_duplicate() {
+        let mut config = config_with_disabled(&["get_issues"]);
+        let names = vec!["get_issues".to_string(), "create_issue".to_string()];
+
+        apply_tools_disable(&mut config, &names).unwrap();
+
+        assert_eq!(
+            config.builtin_tools.disabled,
+            vec!["get_issues".to_string(), "create_issue".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_disable_fails_when_whitelist_active() {
+        let mut config = config_with_enabled(&["get_issues"]);
+        let names = vec!["create_issue".to_string()];
+
+        let result = apply_tools_disable(&mut config, &names);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("whitelist (enabled) mode is active"));
+    }
+
+    // -- enable tests --
+
+    #[test]
+    fn test_enable_removes_from_disabled_list() {
+        let mut config = config_with_disabled(&["get_issues", "create_issue", "update_issue"]);
+        let names = vec!["get_issues".to_string(), "update_issue".to_string()];
+
+        apply_tools_enable(&mut config, &names).unwrap();
+
+        assert_eq!(
+            config.builtin_tools.disabled,
+            vec!["create_issue".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_enable_noop_if_not_disabled() {
+        let mut config = config_with_disabled(&["create_issue"]);
+        let names = vec!["get_issues".to_string()];
+
+        apply_tools_enable(&mut config, &names).unwrap();
+
+        // create_issue stays disabled, get_issues was not in the list
+        assert_eq!(
+            config.builtin_tools.disabled,
+            vec!["create_issue".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_enable_fails_when_whitelist_active() {
+        let mut config = config_with_enabled(&["get_issues"]);
+        let names = vec!["create_issue".to_string()];
+
+        let result = apply_tools_enable(&mut config, &names);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("whitelist (enabled) mode is active"));
+    }
+
+    // -- reset tests --
+
+    #[test]
+    fn test_reset_clears_disabled() {
+        let mut config = config_with_disabled(&["get_issues", "create_issue"]);
+
+        apply_tools_reset(&mut config);
+
+        assert!(config.builtin_tools.disabled.is_empty());
+        assert!(config.builtin_tools.enabled.is_empty());
+    }
+
+    #[test]
+    fn test_reset_clears_enabled() {
+        let mut config = config_with_enabled(&["get_issues"]);
+
+        apply_tools_reset(&mut config);
+
+        assert!(config.builtin_tools.disabled.is_empty());
+        assert!(config.builtin_tools.enabled.is_empty());
+    }
+
+    // -- persistence round-trip --
+
+    #[test]
+    fn test_disable_persists_to_file() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp).unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let mut config = Config::default();
+        apply_tools_disable(
+            &mut config,
+            &["get_issues".to_string(), "create_issue".to_string()],
+        )
+        .unwrap();
+        config.save_to(&path).unwrap();
+
+        let loaded = Config::load_from(&path).unwrap();
+        assert_eq!(
+            loaded.builtin_tools.disabled,
+            vec!["get_issues".to_string(), "create_issue".to_string()]
+        );
+        assert!(!loaded.builtin_tools.is_tool_allowed("get_issues"));
+        assert!(loaded.builtin_tools.is_tool_allowed("update_issue"));
+    }
+
+    #[test]
+    fn test_reset_persists_to_file() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp).unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let config = config_with_disabled(&["get_issues"]);
+        config.save_to(&path).unwrap();
+
+        let mut config = Config::load_from(&path).unwrap();
+        apply_tools_reset(&mut config);
+        config.save_to(&path).unwrap();
+
+        let loaded = Config::load_from(&path).unwrap();
+        assert!(loaded.builtin_tools.is_empty());
+    }
+
+    // -- sequential workflow --
+
+    #[test]
+    fn test_disable_then_enable_workflow() {
+        let mut config = Config::default();
+
+        // Disable 3 tools
+        apply_tools_disable(
+            &mut config,
+            &[
+                "get_issues".to_string(),
+                "create_issue".to_string(),
+                "update_issue".to_string(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(config.builtin_tools.disabled.len(), 3);
+        assert!(!config.builtin_tools.is_tool_allowed("get_issues"));
+
+        // Re-enable one tool
+        apply_tools_enable(&mut config, &["get_issues".to_string()]).unwrap();
+        assert_eq!(config.builtin_tools.disabled.len(), 2);
+        assert!(config.builtin_tools.is_tool_allowed("get_issues"));
+        assert!(!config.builtin_tools.is_tool_allowed("create_issue"));
+
+        // Reset everything
+        apply_tools_reset(&mut config);
+        assert!(config.builtin_tools.is_empty());
+        assert!(config.builtin_tools.is_tool_allowed("create_issue"));
+    }
 }

--- a/crates/devboy-core/src/config.rs
+++ b/crates/devboy-core/src/config.rs
@@ -71,6 +71,10 @@ pub struct Config {
     /// Upstream MCP servers to proxy.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub proxy_mcp_servers: Vec<ProxyMcpServerConfig>,
+
+    /// Built-in tools filtering configuration.
+    #[serde(default, skip_serializing_if = "BuiltinToolsConfig::is_empty")]
+    pub builtin_tools: BuiltinToolsConfig,
 }
 
 /// Configuration for an upstream MCP server to proxy.
@@ -163,6 +167,63 @@ pub struct JiraConfig {
     pub project_key: String,
     /// User email (required for Jira auth)
     pub email: String,
+}
+
+/// Configuration for controlling which built-in tools are available.
+///
+/// Supports two mutually exclusive modes:
+/// - `disabled`: blacklist specific tools (all others remain enabled)
+/// - `enabled`: whitelist specific tools (all others are disabled)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BuiltinToolsConfig {
+    /// List of tool names to disable (blacklist mode).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub disabled: Vec<String>,
+
+    /// List of tool names to enable (whitelist mode). All others are disabled.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub enabled: Vec<String>,
+}
+
+impl BuiltinToolsConfig {
+    /// Check whether the config is empty (no filtering).
+    pub fn is_empty(&self) -> bool {
+        self.disabled.is_empty() && self.enabled.is_empty()
+    }
+
+    /// Validate the config: `disabled` and `enabled` must not both be set.
+    pub fn validate(&self) -> Result<()> {
+        if !self.disabled.is_empty() && !self.enabled.is_empty() {
+            return Err(Error::Config(
+                "builtin_tools: 'disabled' and 'enabled' are mutually exclusive, use only one"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Check whether a tool with the given name should be available.
+    pub fn is_tool_allowed(&self, name: &str) -> bool {
+        if !self.enabled.is_empty() {
+            return self.enabled.iter().any(|n| n == name);
+        }
+        if !self.disabled.is_empty() {
+            return !self.disabled.iter().any(|n| n == name);
+        }
+        true
+    }
+
+    /// Log warnings for tool names that are not in the known set.
+    pub fn warn_unknown_tools(&self, known: &[&str]) {
+        for name in self.disabled.iter().chain(self.enabled.iter()) {
+            if !known.iter().any(|k| k == name) {
+                tracing::warn!(
+                    "builtin_tools: unknown tool name '{}', it will have no effect",
+                    name
+                );
+            }
+        }
+    }
 }
 
 fn default_gitlab_url() -> String {
@@ -864,6 +925,7 @@ mod tests {
             contexts: BTreeMap::new(),
             active_context: None,
             proxy_mcp_servers: Vec::new(),
+            builtin_tools: BuiltinToolsConfig::default(),
         };
 
         let providers = config.configured_providers();
@@ -940,6 +1002,7 @@ mod tests {
             contexts: BTreeMap::new(),
             active_context: None,
             proxy_mcp_servers: Vec::new(),
+            builtin_tools: BuiltinToolsConfig::default(),
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -1205,5 +1268,148 @@ mod tests {
         let config = Config::default();
         let toml_str = toml::to_string_pretty(&config).unwrap();
         assert!(!toml_str.contains("proxy_mcp_servers"));
+    }
+
+    // =========================================================================
+    // BuiltinToolsConfig tests
+    // =========================================================================
+
+    #[test]
+    fn test_builtin_tools_config_default_is_empty() {
+        let config = BuiltinToolsConfig::default();
+        assert!(config.is_empty());
+        assert!(config.validate().is_ok());
+        assert!(config.is_tool_allowed("get_issues"));
+    }
+
+    #[test]
+    fn test_builtin_tools_disabled_mode() {
+        let config = BuiltinToolsConfig {
+            disabled: vec!["get_issues".to_string(), "create_issue".to_string()],
+            enabled: vec![],
+        };
+        assert!(!config.is_empty());
+        assert!(config.validate().is_ok());
+        assert!(!config.is_tool_allowed("get_issues"));
+        assert!(!config.is_tool_allowed("create_issue"));
+        assert!(config.is_tool_allowed("get_merge_requests"));
+        assert!(config.is_tool_allowed("list_contexts"));
+    }
+
+    #[test]
+    fn test_builtin_tools_enabled_mode() {
+        let config = BuiltinToolsConfig {
+            disabled: vec![],
+            enabled: vec![
+                "list_contexts".to_string(),
+                "use_context".to_string(),
+                "get_current_context".to_string(),
+            ],
+        };
+        assert!(!config.is_empty());
+        assert!(config.validate().is_ok());
+        assert!(config.is_tool_allowed("list_contexts"));
+        assert!(config.is_tool_allowed("use_context"));
+        assert!(!config.is_tool_allowed("get_issues"));
+        assert!(!config.is_tool_allowed("create_issue"));
+    }
+
+    #[test]
+    fn test_builtin_tools_mutually_exclusive_error() {
+        let config = BuiltinToolsConfig {
+            disabled: vec!["get_issues".to_string()],
+            enabled: vec!["list_contexts".to_string()],
+        };
+        assert!(config.validate().is_err());
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn test_builtin_tools_toml_parsing_disabled() {
+        let toml_str = r#"
+            [builtin_tools]
+            disabled = ["get_issues", "create_issue"]
+        "#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(!config.builtin_tools.is_empty());
+        assert_eq!(config.builtin_tools.disabled.len(), 2);
+        assert!(config.builtin_tools.enabled.is_empty());
+    }
+
+    #[test]
+    fn test_builtin_tools_toml_parsing_enabled() {
+        let toml_str = r#"
+            [builtin_tools]
+            enabled = ["list_contexts", "use_context", "get_current_context"]
+        "#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.builtin_tools.enabled.len(), 3);
+        assert!(config.builtin_tools.disabled.is_empty());
+    }
+
+    #[test]
+    fn test_builtin_tools_not_serialized_when_empty() {
+        let config = Config::default();
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        assert!(!toml_str.contains("builtin_tools"));
+    }
+
+    #[test]
+    fn test_builtin_tools_serialization_roundtrip() {
+        let config = Config {
+            builtin_tools: BuiltinToolsConfig {
+                disabled: vec!["get_issues".to_string(), "create_issue".to_string()],
+                enabled: vec![],
+            },
+            ..Default::default()
+        };
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        assert!(toml_str.contains("[builtin_tools]"));
+        assert!(toml_str.contains("get_issues"));
+
+        let parsed: Config = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.builtin_tools.disabled.len(), 2);
+    }
+
+    #[test]
+    fn test_builtin_tools_warn_unknown_with_unknown_names() {
+        let known = &["get_issues", "create_issue"];
+        let config = BuiltinToolsConfig {
+            disabled: vec!["get_issues".to_string(), "nonexistent_tool".to_string()],
+            enabled: vec![],
+        };
+        // Should not panic, logs a warning for nonexistent_tool
+        config.warn_unknown_tools(known);
+    }
+
+    #[test]
+    fn test_builtin_tools_warn_unknown_all_known() {
+        let known = &["get_issues", "create_issue"];
+        let config = BuiltinToolsConfig {
+            disabled: vec!["get_issues".to_string()],
+            enabled: vec![],
+        };
+        // All names are known — no warnings expected
+        config.warn_unknown_tools(known);
+    }
+
+    #[test]
+    fn test_builtin_tools_warn_unknown_in_enabled_list() {
+        let known = &["get_issues", "create_issue"];
+        let config = BuiltinToolsConfig {
+            disabled: vec![],
+            enabled: vec!["get_issues".to_string(), "unknown_tool".to_string()],
+        };
+        // Verify that the enabled list is also checked
+        config.warn_unknown_tools(known);
+    }
+
+    #[test]
+    fn test_builtin_tools_warn_unknown_empty_config() {
+        let known = &["get_issues"];
+        let config = BuiltinToolsConfig::default();
+        // Empty config — nothing to check
+        config.warn_unknown_tools(known);
     }
 }

--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -42,6 +42,6 @@ pub use types::{
 
 // Re-export config types
 pub use config::{
-    ClickUpConfig, Config, ContextConfig, GitHubConfig, GitLabConfig, JiraConfig,
-    ProxyMcpServerConfig,
+    BuiltinToolsConfig, ClickUpConfig, Config, ContextConfig, GitHubConfig, GitLabConfig,
+    JiraConfig, ProxyMcpServerConfig,
 };

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -20,6 +20,437 @@ use serde_json::Value;
 
 use crate::protocol::{ToolCallResult, ToolDefinition};
 
+/// Defines the complete tool registry in one place.
+///
+/// For each provider tool: name, description, JSON schema, and handler method.
+/// Context management tools only need name (handled by McpServer, not ToolHandler).
+///
+/// Generates:
+/// - `KNOWN_BUILTIN_TOOLS` — all tool names (provider + context)
+/// - `ToolHandler::available_tools()` — tool definitions with schemas
+/// - `ToolHandler::execute()` — match routing to handler methods
+macro_rules! define_tools {
+    (
+        $(
+            $name:literal => $handler:ident {
+                description: $desc:literal,
+                schema: $schema:tt
+            }
+        ),+ $(,)?
+        ;
+        context: $( $ctx_name:literal ),+ $(,)?
+    ) => {
+        /// All known built-in tool names (provider tools + context management tools).
+        pub const KNOWN_BUILTIN_TOOLS: &[&str] = &[
+            $( $name, )+
+            $( $ctx_name, )+
+        ];
+
+        impl ToolHandler {
+            /// Get available tool definitions.
+            pub fn available_tools(&self) -> Vec<ToolDefinition> {
+                vec![
+                    $(
+                        ToolDefinition {
+                            name: $name.to_string(),
+                            description: $desc.to_string(),
+                            input_schema: serde_json::json!($schema),
+                        },
+                    )+
+                ]
+            }
+
+            /// Execute a tool by name with arguments.
+            pub async fn execute(&self, name: &str, arguments: Option<Value>) -> ToolCallResult {
+                match name {
+                    $( $name => self.$handler(arguments).await, )+
+                    _ => ToolCallResult::error(format!("Unknown tool: {}", name)),
+                }
+            }
+        }
+    };
+}
+
+define_tools! {
+    // =====================================================================
+    // Issues
+    // =====================================================================
+
+    "get_issues" => handle_get_issues {
+        description: "Get issues from configured providers (GitLab, GitHub, ClickUp). Returns a list of issues with filters.",
+        schema: {
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string",
+                    "enum": ["open", "closed", "all"],
+                    "description": "Filter by issue state (default: open)"
+                },
+                "search": {
+                    "type": "string",
+                    "description": "Search query for title and description"
+                },
+                "labels": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Filter by label names"
+                },
+                "assignee": {
+                    "type": "string",
+                    "description": "Filter by assignee username"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results (default: 20)",
+                    "minimum": 1,
+                    "maximum": 100
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Number of results to skip for pagination (default: 0)",
+                    "minimum": 0
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["markdown", "compact", "json"],
+                    "description": "Output format (default: markdown)"
+                },
+                "provider": {
+                    "type": "string",
+                    "enum": ["github", "gitlab", "clickup", "jira"],
+                    "description": "Filter by provider. If not specified, returns issues from all configured providers."
+                },
+                "sort_by": {
+                    "type": "string",
+                    "enum": ["created_at", "updated_at"],
+                    "description": "Sort by field (default: updated_at)"
+                },
+                "sort_order": {
+                    "type": "string",
+                    "enum": ["asc", "desc"],
+                    "description": "Sort order (default: desc)"
+                }
+            }
+        }
+    },
+
+    "get_issue" => handle_get_issue {
+        description: "Get a single issue by key (e.g., 'gh#123', 'gitlab#456', 'CU-abc', 'DEV-42', 'jira#PROJ-123'). Returns full issue details.",
+        schema: {
+            "type": "object",
+            "required": ["key"],
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "Issue key (e.g., 'gh#123' for GitHub, 'gitlab#456' for GitLab, 'CU-abc' or custom ID like 'DEV-42' for ClickUp, 'jira#PROJ-123' for Jira)"
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["markdown", "compact", "json"],
+                    "description": "Output format (default: markdown)"
+                }
+            }
+        }
+    },
+
+    "get_issue_comments" => handle_get_issue_comments {
+        description: "Get comments for an issue. Returns all comments with author and timestamp.",
+        schema: {
+            "type": "object",
+            "required": ["key"],
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "Issue key (e.g., 'gh#123')"
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["markdown", "compact", "json"],
+                    "description": "Output format (default: markdown)"
+                }
+            }
+        }
+    },
+
+    "create_issue" => handle_create_issue {
+        description: "Create a new issue in the configured provider.",
+        schema: {
+            "type": "object",
+            "required": ["title"],
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Issue title"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Issue description/body"
+                },
+                "labels": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Labels to add"
+                },
+                "assignees": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Assignee usernames"
+                },
+                "provider": {
+                    "type": "string",
+                    "enum": ["github", "gitlab", "clickup", "jira"],
+                    "description": "Target provider to create the issue in. If not specified, uses the first configured provider."
+                }
+            }
+        }
+    },
+
+    "update_issue" => handle_update_issue {
+        description: "Update an existing issue. Only provided fields will be changed.",
+        schema: {
+            "type": "object",
+            "required": ["key"],
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "Issue key (e.g., 'gh#123')"
+                },
+                "title": {
+                    "type": "string",
+                    "description": "New title"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "New description"
+                },
+                "state": {
+                    "type": "string",
+                    "enum": ["open", "closed"],
+                    "description": "New state"
+                },
+                "labels": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "New labels (replaces existing)"
+                },
+                "assignees": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "New assignees (replaces existing)"
+                }
+            }
+        }
+    },
+
+    "add_issue_comment" => handle_add_issue_comment {
+        description: "Add a comment to an issue.",
+        schema: {
+            "type": "object",
+            "required": ["key", "body"],
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "Issue key (e.g., 'gh#123')"
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Comment text"
+                }
+            }
+        }
+    },
+
+    // =====================================================================
+    // Merge Requests
+    // =====================================================================
+
+    "get_merge_requests" => handle_get_merge_requests {
+        description: "Get merge requests / pull requests from configured providers.",
+        schema: {
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string",
+                    "enum": ["open", "closed", "merged", "all"],
+                    "description": "Filter by MR/PR state (default: open)"
+                },
+                "author": {
+                    "type": "string",
+                    "description": "Filter by author username"
+                },
+                "labels": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Filter by label names"
+                },
+                "source_branch": {
+                    "type": "string",
+                    "description": "Filter by source branch"
+                },
+                "target_branch": {
+                    "type": "string",
+                    "description": "Filter by target branch"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results (default: 20)",
+                    "minimum": 1,
+                    "maximum": 100
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["markdown", "compact", "json"],
+                    "description": "Output format (default: markdown)"
+                }
+            }
+        }
+    },
+
+    "get_merge_request" => handle_get_merge_request {
+        description: "Get a single merge request / pull request by key (e.g., 'pr#123', 'mr#456').",
+        schema: {
+            "type": "object",
+            "required": ["key"],
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "MR/PR key (e.g., 'pr#123' for GitHub, 'mr#456' for GitLab)"
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["markdown", "compact", "json"],
+                    "description": "Output format (default: markdown)"
+                }
+            }
+        }
+    },
+
+    "get_merge_request_discussions" => handle_get_merge_request_discussions {
+        description: "Get discussions/review comments for a merge request. Includes code review threads with positions.",
+        schema: {
+            "type": "object",
+            "required": ["key"],
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "MR/PR key (e.g., 'pr#123')"
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["markdown", "compact", "json"],
+                    "description": "Output format (default: markdown)"
+                }
+            }
+        }
+    },
+
+    "get_merge_request_diffs" => handle_get_merge_request_diffs {
+        description: "Get file diffs for a merge request. Shows changed files with additions/deletions.",
+        schema: {
+            "type": "object",
+            "required": ["key"],
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "MR/PR key (e.g., 'pr#123')"
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["markdown", "compact", "json"],
+                    "description": "Output format (default: markdown)"
+                }
+            }
+        }
+    },
+
+    "create_merge_request" => handle_create_merge_request {
+        description: "Create a new merge request (GitLab) or pull request (GitHub).",
+        schema: {
+            "type": "object",
+            "required": ["title", "source_branch", "target_branch"],
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "MR/PR title"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "MR/PR description/body"
+                },
+                "source_branch": {
+                    "type": "string",
+                    "description": "Source branch (head branch with changes)"
+                },
+                "target_branch": {
+                    "type": "string",
+                    "description": "Target branch (base branch to merge into)"
+                },
+                "draft": {
+                    "type": "boolean",
+                    "description": "Create as draft/WIP (default: false)"
+                },
+                "labels": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Labels to add"
+                },
+                "reviewers": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Reviewer usernames"
+                },
+                "provider": {
+                    "type": "string",
+                    "enum": ["github", "gitlab"],
+                    "description": "Target provider. If not specified, uses the first configured provider."
+                }
+            }
+        }
+    },
+
+    "create_merge_request_comment" => handle_create_merge_request_comment {
+        description: "Add a comment to a merge request. Can be a general comment or an inline code review comment.",
+        schema: {
+            "type": "object",
+            "required": ["key", "body"],
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "MR/PR key (e.g., 'pr#123')"
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Comment text"
+                },
+                "file_path": {
+                    "type": "string",
+                    "description": "File path for inline comment (optional)"
+                },
+                "line": {
+                    "type": "integer",
+                    "description": "Line number for inline comment (required if file_path is set)"
+                },
+                "line_type": {
+                    "type": "string",
+                    "enum": ["old", "new"],
+                    "description": "Line type: 'old' for deleted line, 'new' for added line (default: new)"
+                },
+                "commit_sha": {
+                    "type": "string",
+                    "description": "Commit SHA for inline comment (required for GitHub)"
+                },
+                "discussion_id": {
+                    "type": "string",
+                    "description": "Reply to existing discussion (optional)"
+                }
+            }
+        }
+    };
+
+    // Context management (handled by McpServer, not ToolHandler)
+    context: "list_contexts", "use_context", "get_current_context"
+}
+
 /// Helper to get provider name without ambiguity.
 fn get_provider_name(provider: &dyn Provider) -> &'static str {
     IssueProvider::provider_name(provider)
@@ -44,433 +475,6 @@ impl ToolHandler {
     pub fn with_pipeline_config(mut self, config: PipelineConfig) -> Self {
         self.pipeline_config = config;
         self
-    }
-
-    /// Get available tool definitions, grouped by category.
-    pub fn available_tools(&self) -> Vec<ToolDefinition> {
-        let mut tools = Vec::new();
-
-        // =================================================================
-        // ISSUES GROUP
-        // =================================================================
-
-        tools.push(ToolDefinition {
-            name: "get_issues".to_string(),
-            description: "Get issues from configured providers (GitLab, GitHub, ClickUp). Returns a list of issues with filters.".to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "state": {
-                        "type": "string",
-                        "enum": ["open", "closed", "all"],
-                        "description": "Filter by issue state (default: open)"
-                    },
-                    "search": {
-                        "type": "string",
-                        "description": "Search query for title and description"
-                    },
-                    "labels": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Filter by label names"
-                    },
-                    "assignee": {
-                        "type": "string",
-                        "description": "Filter by assignee username"
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "Maximum number of results (default: 20)",
-                        "minimum": 1,
-                        "maximum": 100
-                    },
-                    "offset": {
-                        "type": "integer",
-                        "description": "Number of results to skip for pagination (default: 0)",
-                        "minimum": 0
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["markdown", "compact", "json"],
-                        "description": "Output format (default: markdown)"
-                    },
-                    "provider": {
-                        "type": "string",
-                        "enum": ["github", "gitlab", "clickup", "jira"],
-                        "description": "Filter by provider. If not specified, returns issues from all configured providers."
-                    },
-                    "sort_by": {
-                        "type": "string",
-                        "enum": ["created_at", "updated_at"],
-                        "description": "Sort by field (default: updated_at)"
-                    },
-                    "sort_order": {
-                        "type": "string",
-                        "enum": ["asc", "desc"],
-                        "description": "Sort order (default: desc)"
-                    }
-                }
-            }),
-        });
-
-        tools.push(ToolDefinition {
-            name: "get_issue".to_string(),
-            description: "Get a single issue by key (e.g., 'gh#123', 'gitlab#456', 'CU-abc', 'DEV-42', 'jira#PROJ-123'). Returns full issue details.".to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "required": ["key"],
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "Issue key (e.g., 'gh#123' for GitHub, 'gitlab#456' for GitLab, 'CU-abc' or custom ID like 'DEV-42' for ClickUp, 'jira#PROJ-123' for Jira)"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["markdown", "compact", "json"],
-                        "description": "Output format (default: markdown)"
-                    }
-                }
-            }),
-        });
-
-        tools.push(ToolDefinition {
-            name: "get_issue_comments".to_string(),
-            description:
-                "Get comments for an issue. Returns all comments with author and timestamp."
-                    .to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "required": ["key"],
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "Issue key (e.g., 'gh#123')"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["markdown", "compact", "json"],
-                        "description": "Output format (default: markdown)"
-                    }
-                }
-            }),
-        });
-
-        tools.push(ToolDefinition {
-            name: "create_issue".to_string(),
-            description: "Create a new issue in the configured provider.".to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "required": ["title"],
-                "properties": {
-                    "title": {
-                        "type": "string",
-                        "description": "Issue title"
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "Issue description/body"
-                    },
-                    "labels": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Labels to add"
-                    },
-                    "assignees": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Assignee usernames"
-                    },
-                    "provider": {
-                        "type": "string",
-                        "enum": ["github", "gitlab", "clickup", "jira"],
-                        "description": "Target provider to create the issue in. If not specified, uses the first configured provider."
-                    }
-                }
-            }),
-        });
-
-        tools.push(ToolDefinition {
-            name: "update_issue".to_string(),
-            description: "Update an existing issue. Only provided fields will be changed."
-                .to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "required": ["key"],
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "Issue key (e.g., 'gh#123')"
-                    },
-                    "title": {
-                        "type": "string",
-                        "description": "New title"
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "New description"
-                    },
-                    "state": {
-                        "type": "string",
-                        "enum": ["open", "closed"],
-                        "description": "New state"
-                    },
-                    "labels": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "New labels (replaces existing)"
-                    },
-                    "assignees": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "New assignees (replaces existing)"
-                    }
-                }
-            }),
-        });
-
-        tools.push(ToolDefinition {
-            name: "add_issue_comment".to_string(),
-            description: "Add a comment to an issue.".to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "required": ["key", "body"],
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "Issue key (e.g., 'gh#123')"
-                    },
-                    "body": {
-                        "type": "string",
-                        "description": "Comment text"
-                    }
-                }
-            }),
-        });
-
-        // =================================================================
-        // MERGE REQUESTS GROUP
-        // =================================================================
-
-        tools.push(ToolDefinition {
-            name: "get_merge_requests".to_string(),
-            description: "Get merge requests / pull requests from configured providers."
-                .to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "state": {
-                        "type": "string",
-                        "enum": ["open", "closed", "merged", "all"],
-                        "description": "Filter by MR/PR state (default: open)"
-                    },
-                    "author": {
-                        "type": "string",
-                        "description": "Filter by author username"
-                    },
-                    "labels": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Filter by label names"
-                    },
-                    "source_branch": {
-                        "type": "string",
-                        "description": "Filter by source branch"
-                    },
-                    "target_branch": {
-                        "type": "string",
-                        "description": "Filter by target branch"
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "Maximum number of results (default: 20)",
-                        "minimum": 1,
-                        "maximum": 100
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["markdown", "compact", "json"],
-                        "description": "Output format (default: markdown)"
-                    }
-                }
-            }),
-        });
-
-        tools.push(ToolDefinition {
-            name: "get_merge_request".to_string(),
-            description:
-                "Get a single merge request / pull request by key (e.g., 'pr#123', 'mr#456')."
-                    .to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "required": ["key"],
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "MR/PR key (e.g., 'pr#123' for GitHub, 'mr#456' for GitLab)"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["markdown", "compact", "json"],
-                        "description": "Output format (default: markdown)"
-                    }
-                }
-            }),
-        });
-
-        tools.push(ToolDefinition {
-            name: "get_merge_request_discussions".to_string(),
-            description: "Get discussions/review comments for a merge request. Includes code review threads with positions.".to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "required": ["key"],
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "MR/PR key (e.g., 'pr#123')"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["markdown", "compact", "json"],
-                        "description": "Output format (default: markdown)"
-                    }
-                }
-            }),
-        });
-
-        tools.push(ToolDefinition {
-            name: "get_merge_request_diffs".to_string(),
-            description:
-                "Get file diffs for a merge request. Shows changed files with additions/deletions."
-                    .to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "required": ["key"],
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "MR/PR key (e.g., 'pr#123')"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["markdown", "compact", "json"],
-                        "description": "Output format (default: markdown)"
-                    }
-                }
-            }),
-        });
-
-        tools.push(ToolDefinition {
-            name: "create_merge_request".to_string(),
-            description: "Create a new merge request (GitLab) or pull request (GitHub).".to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "required": ["title", "source_branch", "target_branch"],
-                "properties": {
-                    "title": {
-                        "type": "string",
-                        "description": "MR/PR title"
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "MR/PR description/body"
-                    },
-                    "source_branch": {
-                        "type": "string",
-                        "description": "Source branch (head branch with changes)"
-                    },
-                    "target_branch": {
-                        "type": "string",
-                        "description": "Target branch (base branch to merge into)"
-                    },
-                    "draft": {
-                        "type": "boolean",
-                        "description": "Create as draft/WIP (default: false)"
-                    },
-                    "labels": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Labels to add"
-                    },
-                    "reviewers": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Reviewer usernames"
-                    },
-                    "provider": {
-                        "type": "string",
-                        "enum": ["github", "gitlab"],
-                        "description": "Target provider. If not specified, uses the first configured provider."
-                    }
-                }
-            }),
-        });
-
-        tools.push(ToolDefinition {
-            name: "create_merge_request_comment".to_string(),
-            description: "Add a comment to a merge request. Can be a general comment or an inline code review comment.".to_string(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "required": ["key", "body"],
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "MR/PR key (e.g., 'pr#123')"
-                    },
-                    "body": {
-                        "type": "string",
-                        "description": "Comment text"
-                    },
-                    "file_path": {
-                        "type": "string",
-                        "description": "File path for inline comment (optional)"
-                    },
-                    "line": {
-                        "type": "integer",
-                        "description": "Line number for inline comment (required if file_path is set)"
-                    },
-                    "line_type": {
-                        "type": "string",
-                        "enum": ["old", "new"],
-                        "description": "Line type: 'old' for deleted line, 'new' for added line (default: new)"
-                    },
-                    "commit_sha": {
-                        "type": "string",
-                        "description": "Commit SHA for inline comment (required for GitHub)"
-                    },
-                    "discussion_id": {
-                        "type": "string",
-                        "description": "Reply to existing discussion (optional)"
-                    }
-                }
-            }),
-        });
-
-        tools
-    }
-
-    /// Execute a tool by name with arguments.
-    pub async fn execute(&self, name: &str, arguments: Option<Value>) -> ToolCallResult {
-        match name {
-            // Issues
-            "get_issues" => self.handle_get_issues(arguments).await,
-            "get_issue" => self.handle_get_issue(arguments).await,
-            "get_issue_comments" => self.handle_get_issue_comments(arguments).await,
-            "create_issue" => self.handle_create_issue(arguments).await,
-            "update_issue" => self.handle_update_issue(arguments).await,
-            "add_issue_comment" => self.handle_add_issue_comment(arguments).await,
-            // Merge Requests
-            "get_merge_requests" => self.handle_get_merge_requests(arguments).await,
-            "get_merge_request" => self.handle_get_merge_request(arguments).await,
-            "get_merge_request_discussions" => {
-                self.handle_get_merge_request_discussions(arguments).await
-            }
-            "get_merge_request_diffs" => self.handle_get_merge_request_diffs(arguments).await,
-            "create_merge_request" => self.handle_create_merge_request(arguments).await,
-            "create_merge_request_comment" => {
-                self.handle_create_merge_request_comment(arguments).await
-            }
-            _ => ToolCallResult::error(format!("Unknown tool: {}", name)),
-        }
     }
 
     // =========================================================================

--- a/crates/devboy-mcp/src/lib.rs
+++ b/crates/devboy-mcp/src/lib.rs
@@ -28,6 +28,7 @@ pub mod server;
 pub mod tools;
 pub mod transport;
 
-pub use handlers::ToolHandler;
+pub use handlers::{ToolHandler, KNOWN_BUILTIN_TOOLS};
+pub use protocol::{JsonRpcRequest, RequestId, JSONRPC_VERSION};
 pub use proxy::{McpProxyClient, ProxyManager, ProxyTransport};
 pub use server::McpServer;

--- a/crates/devboy-mcp/src/proxy.rs
+++ b/crates/devboy-mcp/src/proxy.rs
@@ -488,6 +488,13 @@ impl ProxyManager {
             .collect()
     }
 
+    /// Check whether a tool name belongs to a proxied upstream.
+    pub fn has_tool(&self, tool_name: &str) -> bool {
+        self.clients
+            .iter()
+            .any(|c| tool_name.starts_with(&format!("{}__", c.prefix())))
+    }
+
     /// Try to route a tool call to the matching upstream.
     /// Returns None if no upstream matches the tool name prefix.
     pub async fn try_call(

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use devboy_core::Provider;
+use devboy_core::{BuiltinToolsConfig, Provider};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -26,6 +26,7 @@ pub struct McpServer {
     active_context: RwLock<String>,
     initialized: bool,
     proxy_manager: ProxyManager,
+    builtin_tools_config: BuiltinToolsConfig,
 }
 
 impl McpServer {
@@ -38,7 +39,20 @@ impl McpServer {
             active_context: RwLock::new("default".to_string()),
             initialized: false,
             proxy_manager: ProxyManager::new(),
+            builtin_tools_config: BuiltinToolsConfig::default(),
         }
+    }
+
+    /// Set the built-in tools filtering configuration.
+    ///
+    /// Returns an error if both `disabled` and `enabled` are set (mutually exclusive).
+    pub fn set_builtin_tools_config(
+        &mut self,
+        config: BuiltinToolsConfig,
+    ) -> devboy_core::Result<()> {
+        config.validate()?;
+        self.builtin_tools_config = config;
+        Ok(())
     }
 
     /// Set the proxy manager for upstream MCP server connections.
@@ -166,7 +180,7 @@ impl McpServer {
     }
 
     /// Handle a JSON-RPC request.
-    async fn handle_request(&mut self, req: JsonRpcRequest) -> JsonRpcResponse {
+    pub async fn handle_request(&mut self, req: JsonRpcRequest) -> JsonRpcResponse {
         tracing::debug!("Handling request: {} (id: {:?})", req.method, req.id);
 
         match req.method.as_str() {
@@ -245,8 +259,7 @@ impl McpServer {
     /// Handle tools/list request.
     fn handle_tools_list(&self, id: RequestId) -> JsonRpcResponse {
         let handler = ToolHandler::new(self.active_providers());
-        let tools = handler.available_tools();
-        let mut tools = tools;
+        let mut tools = handler.available_tools();
         tools.push(crate::protocol::ToolDefinition {
             name: "list_contexts".to_string(),
             description: "List configured contexts and indicate the active context.".to_string(),
@@ -275,7 +288,12 @@ impl McpServer {
             }),
         });
 
-        // Append proxied tools from upstream MCP servers
+        // Filter built-in tools based on config
+        if !self.builtin_tools_config.is_empty() {
+            tools.retain(|t| self.builtin_tools_config.is_tool_allowed(&t.name));
+        }
+
+        // Append proxied tools from upstream MCP servers (not affected by builtin_tools filter)
         tools.extend(self.proxy_manager.all_tools());
 
         let result = ToolsListResult { tools };
@@ -300,6 +318,20 @@ impl McpServer {
         };
 
         tracing::info!("Calling tool: {}", params.name);
+
+        // Block disabled built-in tools (proxy tools are not affected)
+        if !self.builtin_tools_config.is_empty()
+            && !self.builtin_tools_config.is_tool_allowed(&params.name)
+            && !self.proxy_manager.has_tool(&params.name)
+        {
+            return JsonRpcResponse::error(
+                id,
+                JsonRpcError::method_not_found(&format!(
+                    "Tool '{}' is disabled by builtin_tools configuration",
+                    params.name
+                )),
+            );
+        }
 
         let result = match params.name.as_str() {
             "list_contexts" => {
@@ -860,5 +892,101 @@ mod tests {
         let resp = server.handle_tools_list(RequestId::Number(1));
         let result: ToolsListResult = serde_json::from_value(resp.result.unwrap()).unwrap();
         assert!(!result.tools.iter().any(|t| t.name.contains("__")));
+    }
+
+    #[test]
+    fn test_builtin_tools_disabled_filters_tools_list() {
+        let mut server = McpServer::new();
+        server
+            .set_builtin_tools_config(BuiltinToolsConfig {
+                disabled: vec!["get_issues".to_string(), "create_issue".to_string()],
+                enabled: vec![],
+            })
+            .unwrap();
+
+        let resp = server.handle_tools_list(RequestId::Number(1));
+        let result: ToolsListResult = serde_json::from_value(resp.result.unwrap()).unwrap();
+
+        assert!(!result.tools.iter().any(|t| t.name == "get_issues"));
+        assert!(!result.tools.iter().any(|t| t.name == "create_issue"));
+        // Non-disabled tools should still be present
+        assert!(result.tools.iter().any(|t| t.name == "get_merge_requests"));
+        assert!(result.tools.iter().any(|t| t.name == "list_contexts"));
+    }
+
+    #[test]
+    fn test_builtin_tools_enabled_whitelist_filters_tools_list() {
+        let mut server = McpServer::new();
+        server
+            .set_builtin_tools_config(BuiltinToolsConfig {
+                disabled: vec![],
+                enabled: vec![
+                    "list_contexts".to_string(),
+                    "use_context".to_string(),
+                    "get_current_context".to_string(),
+                ],
+            })
+            .unwrap();
+
+        let resp = server.handle_tools_list(RequestId::Number(1));
+        let result: ToolsListResult = serde_json::from_value(resp.result.unwrap()).unwrap();
+
+        assert_eq!(result.tools.len(), 3);
+        assert!(result.tools.iter().any(|t| t.name == "list_contexts"));
+        assert!(result.tools.iter().any(|t| t.name == "use_context"));
+        assert!(result.tools.iter().any(|t| t.name == "get_current_context"));
+        assert!(!result.tools.iter().any(|t| t.name == "get_issues"));
+    }
+
+    #[tokio::test]
+    async fn test_disabled_tool_call_returns_error() {
+        let mut server = McpServer::new();
+        server
+            .set_builtin_tools_config(BuiltinToolsConfig {
+                disabled: vec!["get_issues".to_string()],
+                enabled: vec![],
+            })
+            .unwrap();
+
+        let req = JsonRpcRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: RequestId::Number(1),
+            method: "tools/call".to_string(),
+            params: Some(serde_json::json!({
+                "name": "get_issues",
+                "arguments": {}
+            })),
+        };
+
+        let resp = server.handle_request(req).await;
+        assert!(resp.error.is_some());
+        let err = resp.error.unwrap();
+        assert_eq!(err.code, JsonRpcError::METHOD_NOT_FOUND);
+        assert!(err.message.contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn test_disabled_tool_allows_non_disabled() {
+        let mut server = McpServer::new();
+        server
+            .set_builtin_tools_config(BuiltinToolsConfig {
+                disabled: vec!["get_issues".to_string()],
+                enabled: vec![],
+            })
+            .unwrap();
+
+        let req = JsonRpcRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: RequestId::Number(1),
+            method: "tools/call".to_string(),
+            params: Some(serde_json::json!({
+                "name": "get_current_context",
+                "arguments": {}
+            })),
+        };
+
+        let resp = server.handle_request(req).await;
+        assert!(resp.error.is_none());
+        assert!(resp.result.is_some());
     }
 }

--- a/docs/guide/configuration/index.md
+++ b/docs/guide/configuration/index.md
@@ -46,6 +46,66 @@ devboy config set-secret github.token <token>
 devboy config set-secret gitlab.token <token>
 ```
 
+## Built-in tools
+
+By default all built-in tools are enabled. You can disable specific tools to reduce LLM context size — disabled tools won't appear in `tools/list` and won't consume tokens.
+
+DevBoy uses a **blacklist** approach: all tools are enabled by default, and you explicitly disable the ones you don't need. This means any new tools added in future versions will be available automatically.
+
+### Configuration
+
+```toml
+[builtin_tools]
+disabled = ["create_issue", "update_issue", "add_issue_comment"]
+```
+
+### CLI commands
+
+```bash
+# Interactive mode — toggle tools with checkboxes
+devboy tools
+
+# List all tools with their status
+devboy tools list
+
+# Disable specific tools
+devboy tools disable create_issue update_issue
+
+# Re-enable specific tools
+devboy tools enable create_issue
+
+# Reset all filtering (re-enable everything)
+devboy tools reset
+
+# Call a built-in tool directly
+devboy tools call list_contexts
+devboy tools call get_issues '{"state":"open","limit":5}'
+```
+
+### Available built-in tools
+
+| Tool | Description |
+|------|-------------|
+| `get_issues` | List issues |
+| `get_issue` | Get issue details |
+| `get_issue_comments` | Get issue comments |
+| `create_issue` | Create a new issue |
+| `update_issue` | Update an issue |
+| `add_issue_comment` | Add comment to issue |
+| `get_merge_requests` | List merge requests |
+| `get_merge_request` | Get MR details |
+| `get_merge_request_discussions` | Get MR discussions |
+| `get_merge_request_diffs` | Get MR diffs |
+| `create_merge_request` | Create a new MR |
+| `create_merge_request_comment` | Add comment to MR |
+| `list_contexts` | List available contexts |
+| `use_context` | Switch active context |
+| `get_current_context` | Get current context |
+
+:::tip
+Proxy tools from upstream MCP servers are **not** affected by builtin_tools filtering.
+:::
+
 ## MCP proxy
 
 You can proxy tools from upstream MCP servers through DevBoy. See [MCP proxy](./proxy) for details.
@@ -82,4 +142,18 @@ devboy proxy tools
 
 # Call a proxied tool
 devboy proxy call <tool_name> [args_json]
+
+# Manage built-in tools (interactive mode)
+devboy tools
+
+# List tools with status
+devboy tools list
+
+# Disable/enable/reset tools
+devboy tools disable <names...>
+devboy tools enable <names...>
+devboy tools reset
+
+# Call a built-in tool directly
+devboy tools call <name> [args_json]
 ```


### PR DESCRIPTION
## Summary

Closes #45

- Add `BuiltinToolsConfig` with blacklist (`disabled`) and whitelist (`enabled`) modes to control which built-in MCP tools are exposed to AI assistants
- Disabled tools are filtered from `tools/list` response and blocked on `tools/call` with `METHOD_NOT_FOUND` error — they don't appear in LLM context and don't consume tokens
- Proxy tools are **not** affected by builtin_tools filtering
- CLI commands for managing tool configuration:
  - `devboy tools` — interactive TUI mode with checkboxes (dialoguer MultiSelect)
  - `devboy tools list` — show all tools with enabled/disabled status
  - `devboy tools disable <names...>` — disable specific tools
  - `devboy tools enable <names...>` — re-enable specific tools
  - `devboy tools reset` — clear all filtering
  - `devboy tools call <name> [args]` — call a built-in tool directly from CLI
- 23 new tests (8 in config.rs, 4 in server.rs, 11 in main.rs)

## Config example

```toml
[builtin_tools]
disabled = ["get_issues", "create_issue"]
```

## Test plan

- [ ] `cargo test` — all tests pass
- [ ] `devboy tools list` — shows all tools with status
- [ ] `devboy tools disable get_issues` → `devboy tools list` — get_issues is disabled
- [ ] `devboy tools enable get_issues` → `devboy tools list` — get_issues is enabled again
- [ ] `devboy tools reset` — all tools enabled
- [ ] `devboy tools` — interactive TUI with checkboxes
- [ ] `devboy tools call list_contexts` — calls tool directly
- [ ] MCP: disabled tools not in `tools/list`, `tools/call` returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)