### PR TITLE
feat: auto-generate tool documentation from code

### DIFF
--- a/crates/devboy-cli/Cargo.toml
+++ b/crates/devboy-cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 devboy-core = { path = "../devboy-core" }
 devboy-mcp = { path = "../devboy-mcp" }
+devboy-executor = { path = "../devboy-executor" }
 devboy-storage = { path = "../devboy-storage" }
 devboy-github = { path = "../plugins/api/github" }
 devboy-gitlab = { path = "../plugins/api/gitlab" }

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -344,6 +344,12 @@ enum ToolsCommands {
         #[arg(default_value = "{}")]
         args: String,
     },
+    /// Generate tool documentation (markdown)
+    Docs {
+        /// Output file (default: stdout)
+        #[arg(short, long)]
+        output: Option<String>,
+    },
 }
 
 /// Environment variable to skip keychain operations (for CI testing).
@@ -2582,6 +2588,7 @@ async fn handle_tools_command(command: Option<ToolsCommands>) -> Result<()> {
         Some(ToolsCommands::Enable { names }) => handle_tools_enable(names)?,
         Some(ToolsCommands::Reset) => handle_tools_reset()?,
         Some(ToolsCommands::Call { name, args }) => handle_tools_call(&name, &args).await?,
+        Some(ToolsCommands::Docs { output }) => handle_tools_docs(output.as_deref())?,
     }
     Ok(())
 }
@@ -2803,6 +2810,124 @@ async fn handle_tools_call(name: &str, args: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+// =============================================================================
+// Tools Docs
+// =============================================================================
+
+fn handle_tools_docs(output: Option<&str>) -> Result<()> {
+    use devboy_executor::tools::{base_tool_definitions, known_providers};
+
+    let tools = base_tool_definitions();
+    let providers = known_providers();
+
+    let mut md = String::new();
+    md.push_str("# DevBoy Tools Reference\n\n");
+    md.push_str("Auto-generated from code. Run `devboy tools docs` to regenerate.\n\n");
+
+    // Collect unique categories from actual tool definitions
+    let all_categories: Vec<devboy_core::ToolCategory> = {
+        let mut cats: Vec<_> = tools.iter().map(|t| t.category).collect();
+        cats.sort();
+        cats.dedup();
+        cats
+    };
+
+    // Provider matrix — derived from known_providers()
+    md.push_str("## Provider Support Matrix\n\n");
+    md.push_str("| Provider |");
+    for cat in &all_categories {
+        md.push_str(&format!(" {cat} |"));
+    }
+    md.push('\n');
+    md.push_str("|----------|");
+    for _ in &all_categories {
+        md.push_str(":---:|");
+    }
+    md.push('\n');
+    for provider in &providers {
+        md.push_str(&format!("| **{}** |", provider.name));
+        for cat in &all_categories {
+            if provider.categories.contains(cat) {
+                md.push_str(" ✅ |");
+            } else {
+                md.push_str(" — |");
+            }
+        }
+        md.push('\n');
+    }
+    md.push('\n');
+
+    // Tools grouped by category — providers derived from known_providers()
+    for cat in &all_categories {
+        let cat_tools: Vec<_> = tools.iter().filter(|t| t.category == *cat).collect();
+        if cat_tools.is_empty() {
+            continue;
+        }
+
+        let cat_providers: Vec<&str> = providers
+            .iter()
+            .filter(|p| p.categories.contains(cat))
+            .map(|p| p.name.as_str())
+            .collect();
+
+        md.push_str(&format!("## {cat} Tools\n\n"));
+        md.push_str(&format!("Providers: {}\n\n", cat_providers.join(", ")));
+
+        for tool in &cat_tools {
+            md.push_str(&format!("### `{}`\n\n", tool.name));
+            md.push_str(&format!("{}\n\n", tool.description));
+
+            if !tool.input_schema.properties.is_empty() {
+                md.push_str("| Parameter | Type | Required | Description |\n");
+                md.push_str("|-----------|------|:---:|-------------|\n");
+
+                let mut params: Vec<_> = tool.input_schema.properties.iter().collect();
+                params.sort_by_key(|(name, _)| !tool.input_schema.required.contains(*name));
+
+                for (name, prop) in &params {
+                    let type_str = format_prop_type(prop);
+                    let required = if tool.input_schema.required.contains(*name) {
+                        "✅"
+                    } else {
+                        "—"
+                    };
+                    let desc = prop.description.as_deref().unwrap_or("");
+                    md.push_str(&format!(
+                        "| `{name}` | {type_str} | {required} | {desc} |\n"
+                    ));
+                }
+                md.push('\n');
+            } else {
+                md.push_str("No parameters.\n\n");
+            }
+        }
+    }
+
+    if let Some(path) = output {
+        std::fs::write(path, &md).context(format!("Failed to write to {path}"))?;
+        println!("Documentation written to {path}");
+    } else {
+        print!("{md}");
+    }
+
+    Ok(())
+}
+
+fn format_prop_type(prop: &devboy_core::PropertySchema) -> &'static str {
+    if prop.enum_values.is_some() {
+        "enum"
+    } else if prop.items.is_some() {
+        "array"
+    } else {
+        match prop.schema_type.as_str() {
+            "string" => "string",
+            "integer" | "number" => "number",
+            "boolean" => "boolean",
+            _ => "any",
+        }
+    }
 }
 
 // =============================================================================

--- a/crates/devboy-core/src/tool_category.rs
+++ b/crates/devboy-core/src/tool_category.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// Category of MCP tools — determines which tools are available
 /// based on provider capabilities.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolCategory {
     /// Git repository tools: MR/PR, pipeline, diffs, discussions.
@@ -26,4 +26,15 @@ pub enum ToolCategory {
     /// Release tools: tags, releases, assets.
     /// Providers: GitLab, GitHub
     Releases,
+}
+
+impl std::fmt::Display for ToolCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GitRepository => write!(f, "Git Repository"),
+            Self::IssueTracker => write!(f, "Issue Tracker"),
+            Self::Epics => write!(f, "Epics"),
+            Self::Releases => write!(f, "Releases"),
+        }
+    }
 }

--- a/crates/devboy-executor/src/lib.rs
+++ b/crates/devboy-executor/src/lib.rs
@@ -59,4 +59,4 @@ pub use executor::{Executor, SUPPORTED_TOOLS};
 pub use factory::create_enricher;
 pub use format::{execute_and_format, format_output};
 pub use output::ToolOutput;
-pub use tools::ToolDefinition;
+pub use tools::{ProviderInfo, ToolDefinition};

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -296,6 +296,46 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
     ]
 }
 
+/// Provider info for documentation generation.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProviderInfo {
+    pub name: String,
+    pub categories: Vec<ToolCategory>,
+}
+
+/// Get all known providers with their supported categories.
+///
+/// Derived from actual enricher `supported_categories()` implementations.
+pub fn known_providers() -> Vec<ProviderInfo> {
+    let providers: Vec<(&str, Box<dyn devboy_core::ToolEnricher>)> = vec![
+        ("GitHub", Box::new(devboy_github::GitHubSchemaEnricher)),
+        ("GitLab", Box::new(devboy_gitlab::GitLabSchemaEnricher)),
+        // ClickUp and Jira enrichers require metadata, use their known categories
+    ];
+
+    let mut result: Vec<ProviderInfo> = providers
+        .iter()
+        .map(|(name, enricher)| ProviderInfo {
+            name: name.to_string(),
+            categories: enricher.supported_categories().to_vec(),
+        })
+        .collect();
+
+    // ClickUp — supports IssueTracker + Epics (from ClickUpSchemaEnricher)
+    result.push(ProviderInfo {
+        name: "ClickUp".into(),
+        categories: vec![ToolCategory::IssueTracker, ToolCategory::Epics],
+    });
+
+    // Jira — supports IssueTracker (from JiraSchemaEnricher)
+    result.push(ProviderInfo {
+        name: "Jira".into(),
+        categories: vec![ToolCategory::IssueTracker],
+    });
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/docs/guide/tools-reference.md
+++ b/docs/guide/tools-reference.md
@@ -1,0 +1,236 @@
+# DevBoy Tools Reference
+
+Auto-generated from code. Run `devboy tools docs` to regenerate.
+
+## Provider Support Matrix
+
+| Provider | Git Repository | Issue Tracker | Epics |
+|----------|:---:|:---:|:---:|
+| **GitHub** | ✅ | ✅ | — |
+| **GitLab** | ✅ | ✅ | — |
+| **ClickUp** | — | ✅ | ✅ |
+| **Jira** | — | ✅ | — |
+
+## Git Repository Tools
+
+Providers: GitHub, GitLab
+
+### `get_merge_requests`
+
+Get merge requests / pull requests from configured provider.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `labels` | array | — | Filter by label names |
+| `target_branch` | string | — | Filter by target branch |
+| `state` | enum | — | Filter by state (default: open) |
+| `limit` | number | — | Maximum results (default: 20) |
+| `author` | string | — | Filter by author username |
+| `source_branch` | string | — | Filter by source branch |
+
+### `get_merge_request`
+
+Get a single merge request by key (e.g., 'pr#123', 'mr#456').
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `key` | string | ✅ | MR/PR key |
+
+### `get_merge_request_discussions`
+
+Get discussions/review comments for a merge request with code positions.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `key` | string | ✅ | MR/PR key |
+| `offset` | number | — | Skip N discussions (default: 0) |
+| `limit` | number | — | Max discussions (default: 20) |
+
+### `get_merge_request_diffs`
+
+Get file diffs for a merge request.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `key` | string | ✅ | MR/PR key |
+
+### `create_merge_request`
+
+Create a new merge request (GitLab) or pull request (GitHub).
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `title` | string | ✅ | MR/PR title |
+| `target_branch` | string | ✅ | Target branch |
+| `source_branch` | string | ✅ | Source branch |
+| `draft` | boolean | — | Create as draft (default: false) |
+| `labels` | array | — | Labels |
+| `reviewers` | array | — | Reviewers |
+| `description` | string | — | MR/PR description |
+
+### `create_merge_request_comment`
+
+Add a comment to a merge request. Can be general or inline code review.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `key` | string | ✅ | MR/PR key |
+| `body` | string | ✅ | Comment text |
+| `discussion_id` | string | — | Reply to existing discussion |
+| `line` | number | — | Line number for inline comment |
+| `file_path` | string | — | File path for inline comment |
+| `line_type` | enum | — | Line type (default: new) |
+| `commit_sha` | string | — | Commit SHA for inline comment |
+
+### `get_pipeline`
+
+Get CI/CD pipeline status for branch or MR/PR with job details.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `mrKey` | string | — | MR/PR key (priority over branch) |
+| `branch` | string | — | Branch name (default: main) |
+| `includeFailedLogs` | boolean | — | Include error extraction for failed jobs (default: true) |
+
+### `get_job_logs`
+
+Get CI/CD job logs. Modes: smart (auto errors), search (pattern), paginated, full.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `jobId` | string | ✅ | Job ID from get_pipeline |
+| `offset` | number | — | Start line for paginated mode |
+| `limit` | number | — | Lines to return (default: 200, max: 1000) |
+| `full` | boolean | — | Return entire log |
+| `pattern` | string | — | Regex/keyword search pattern |
+| `context` | number | — | Context lines around match (default: 5) |
+| `maxMatches` | number | — | Max search results (default: 20) |
+
+## Issue Tracker Tools
+
+Providers: GitHub, GitLab, ClickUp, Jira
+
+### `get_issues`
+
+Get issues from configured provider. Returns a list with filters.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `limit` | number | — | Maximum number of results (default: 20) |
+| `sort_by` | enum | — | Sort by field (default: updated_at) |
+| `search` | string | — | Search query for title and description |
+| `state` | enum | — | Filter by issue state (default: open) |
+| `assignee` | string | — | Filter by assignee username |
+| `offset` | number | — | Number of results to skip (default: 0) |
+| `sort_order` | enum | — | Sort order (default: desc) |
+| `labels` | array | — | Filter by label names |
+
+### `get_issue`
+
+Get a single issue by key (e.g., 'gh#123', 'gitlab#456', 'CU-abc', 'jira#PROJ-123').
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `key` | string | ✅ | Issue key |
+
+### `get_issue_comments`
+
+Get comments for an issue.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `key` | string | ✅ | Issue key |
+
+### `create_issue`
+
+Create a new issue in the configured provider.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `title` | string | ✅ | Issue title |
+| `labels` | array | — | Labels to add |
+| `description` | string | — | Issue description/body |
+| `assignees` | array | — | Assignee usernames |
+
+### `update_issue`
+
+Update an existing issue. Only provided fields will be changed.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `key` | string | ✅ | Issue key |
+| `state` | enum | — | New state |
+| `labels` | array | — | New labels (replaces existing) |
+| `assignees` | array | — | New assignees |
+| `description` | string | — | New description |
+| `title` | string | — | New title |
+
+### `add_issue_comment`
+
+Add a comment to an issue.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `key` | string | ✅ | Issue key |
+| `body` | string | ✅ | Comment text |
+
+### `get_available_statuses`
+
+Get available statuses for the issue tracker.
+
+No parameters.
+
+### `get_users`
+
+Get users from the issue tracker (Jira). Search by name, project, or ID.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `maxResults` | number | — | Max results (default: 50) |
+| `userId` | string | — | Get specific user by ID |
+| `search` | string | — | Search by name or email |
+| `projectKey` | string | — | Get assignable users for project |
+
+### `link_issues`
+
+Link two issues together (blocks, relates_to, etc.).
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `targetIssueKey` | string | ✅ | Target issue key |
+| `sourceIssueKey` | string | ✅ | Source issue key |
+| `linkType` | string | ✅ | Link type (e.g., blocks, relates_to) |
+
+## Epics Tools
+
+Providers: ClickUp
+
+### `get_epics`
+
+Get epics (high-level tasks) from the issue tracker.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `search` | string | — | Search in epic title |
+| `limit` | number | — | Max results (default: 50) |
+| `offset` | number | — | Skip N results (default: 0) |
+
+### `create_epic`
+
+Create a new epic.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `title` | string | ✅ | Epic title |
+| `description` | string | — | Epic description |
+
+### `update_epic`
+
+Update an existing epic.
+
+| Parameter | Type | Required | Description |
+|-----------|------|:---:|-------------|
+| `key` | string | ✅ | Epic key |
+| `title` | string | — | New title |
+| `description` | string | — | New description |
+


### PR DESCRIPTION
## Summary

- Add `devboy tools docs` CLI command that generates markdown reference from `base_tool_definitions()`
- Includes provider support matrix (GitHub, GitLab, ClickUp, Jira)
- Tools grouped by category: Issue Tracker, Git Repository, Epics
- Parameter tables with type, required flag, and description
- Optional `--output` flag to write to file
- Pre-generated `docs/guide/tools-reference.md` included

## Usage

```bash
# Print to stdout
devboy tools docs

# Write to file
devboy tools docs --output docs/guide/tools-reference.md
```

## Test plan

- [x] `cargo fmt --check` — OK
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] `cargo test --workspace` — 1020 passed, 0 failed
- [x] Manual: `devboy tools docs` outputs complete markdown with all 20 tools
- [x] Manual: `devboy tools docs --output file.md` writes to file
- [x] All tools present: 9 Issue Tracker + 8 Git Repository + 3 Epics = 20 total

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)