### PR TITLE
feat: add Fireflies.ai meeting notes provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/plugins/api/github",
     "crates/plugins/api/clickup",
     "crates/plugins/api/jira",
+    "crates/plugins/api/fireflies",
     # Pipeline plugins
     "crates/plugins/format-pipeline",
 ]

--- a/crates/devboy-cli/Cargo.toml
+++ b/crates/devboy-cli/Cargo.toml
@@ -19,6 +19,7 @@ devboy-github = { path = "../plugins/api/github" }
 devboy-gitlab = { path = "../plugins/api/gitlab" }
 devboy-clickup = { path = "../plugins/api/clickup" }
 devboy-jira = { path = "../plugins/api/jira" }
+devboy-fireflies = { path = "../plugins/api/fireflies" }
 devboy-format-pipeline = { path = "../plugins/format-pipeline" }
 tokio.workspace = true
 serde.workspace = true

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -1106,6 +1106,7 @@ fn build_config(options: &InitOptions) -> Config {
             gitlab: options.gitlab.clone(),
             clickup: options.clickup.clone(),
             jira: options.jira.clone(),
+            fireflies: None,
         };
         config.contexts.insert(context_name, context);
     }
@@ -2280,6 +2281,7 @@ impl EnvContextBuilder {
             gitlab,
             clickup,
             jira,
+            fireflies: None,
         };
 
         if context.has_any_provider() {
@@ -2375,6 +2377,20 @@ fn add_context_providers_from_env(
         } else {
             tracing::warn!(
                 "Jira configured via env for context '{}' but no token found",
+                context_name
+            );
+        }
+    }
+
+    if context.fireflies.is_some() {
+        if let Some(token) = get_token_for_context(store, context_name, "fireflies") {
+            let client = devboy_fireflies::FirefliesClient::new(&token);
+            server.add_meeting_provider(Arc::new(client));
+            tracing::info!("Added Fireflies provider to context '{}'", context_name);
+            added = true;
+        } else {
+            tracing::warn!(
+                "Fireflies configured for context '{}' but no API key found",
                 context_name
             );
         }
@@ -2562,6 +2578,20 @@ fn add_context_providers(
             tracing::warn!(
                 "Jira configured in context '{}' but no token found (tried contexts.{}.jira.token then jira.token)",
                 context_name,
+                context_name
+            );
+        }
+    }
+
+    if context.fireflies.is_some() {
+        if let Some(token) = get_token_for_context(store, context_name, "fireflies") {
+            let client = devboy_fireflies::FirefliesClient::new(&token);
+            server.add_meeting_provider(Arc::new(client));
+            tracing::info!("Added Fireflies provider to context '{}'", context_name);
+            added = true;
+        } else {
+            tracing::warn!(
+                "Fireflies configured for context '{}' but no API key found",
                 context_name
             );
         }

--- a/crates/devboy-core/src/config.rs
+++ b/crates/devboy-core/src/config.rs
@@ -184,7 +184,7 @@ pub struct JiraConfig {
 /// Fireflies.ai provider configuration (meeting notes).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FirefliesConfig {
-    // API key is stored in OS keychain (key: "fireflies.api_key")
+    // API key is stored in OS keychain (key: "fireflies.token")
     // No fields needed — config just enables the provider
 }
 

--- a/crates/devboy-core/src/config.rs
+++ b/crates/devboy-core/src/config.rs
@@ -60,6 +60,10 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub jira: Option<JiraConfig>,
 
+    /// Fireflies.ai configuration (meeting notes)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fireflies: Option<FirefliesConfig>,
+
     /// Named contexts (profiles) configuration.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub contexts: BTreeMap<String, ContextConfig>,
@@ -128,6 +132,10 @@ pub struct ContextConfig {
     /// Jira configuration
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub jira: Option<JiraConfig>,
+
+    /// Fireflies.ai configuration (meeting notes)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fireflies: Option<FirefliesConfig>,
 }
 
 /// GitHub provider configuration.
@@ -171,6 +179,13 @@ pub struct JiraConfig {
     pub project_key: String,
     /// User email (required for Jira auth)
     pub email: String,
+}
+
+/// Fireflies.ai provider configuration (meeting notes).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirefliesConfig {
+    // API key is stored in OS keychain (key: "fireflies.api_key")
+    // No fields needed — config just enables the provider
 }
 
 /// Configuration for controlling which built-in tools are available.
@@ -422,6 +437,7 @@ impl Config {
             || self.gitlab.is_some()
             || self.clickup.is_some()
             || self.jira.is_some()
+            || self.fireflies.is_some()
             || self.contexts.values().any(ContextConfig::has_any_provider)
     }
 
@@ -499,6 +515,7 @@ impl Config {
             gitlab: self.gitlab.clone(),
             clickup: self.clickup.clone(),
             jira: self.jira.clone(),
+            fireflies: self.fireflies.clone(),
         };
 
         if ctx.has_any_provider() {
@@ -680,6 +697,7 @@ impl ContextConfig {
             || self.gitlab.is_some()
             || self.clickup.is_some()
             || self.jira.is_some()
+            || self.fireflies.is_some()
     }
 
     /// Return configured provider names for this context.
@@ -1033,6 +1051,7 @@ mod tests {
                 project_key: "k".to_string(),
                 email: "e".to_string(),
             }),
+            fireflies: None,
             contexts: BTreeMap::new(),
             active_context: None,
             proxy_mcp_servers: Vec::new(),
@@ -1111,6 +1130,7 @@ mod tests {
             }),
             clickup: None,
             jira: None,
+            fireflies: None,
             contexts: BTreeMap::new(),
             active_context: None,
             proxy_mcp_servers: Vec::new(),

--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -53,6 +53,7 @@ pub use tool_category::ToolCategory;
 
 // Re-export config types
 pub use config::{
-    BuiltinToolsConfig, ClickUpConfig, Config, ContextConfig, FormatPipelineConfig, GitHubConfig,
-    GitLabConfig, JiraConfig, ProxyMatchingConfig, ProxyMcpServerConfig,
+    BuiltinToolsConfig, ClickUpConfig, Config, ContextConfig, FirefliesConfig,
+    FormatPipelineConfig, GitHubConfig, GitLabConfig, JiraConfig, ProxyMatchingConfig,
+    ProxyMcpServerConfig,
 };

--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -33,15 +33,18 @@ pub mod types;
 pub use error::{Error, Result};
 
 // Re-export provider traits
-pub use provider::{IssueProvider, MergeRequestProvider, PipelineProvider, Provider};
+pub use provider::{
+    IssueProvider, MeetingNotesProvider, MergeRequestProvider, PipelineProvider, Provider,
+};
 
 // Re-export all types
 pub use types::{
     CodePosition, Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput,
     Discussion, FailedJob, FileDiff, GetPipelineInput, GetUsersOptions, Issue, IssueFilter,
-    IssueStatus, JobLogMode, JobLogOptions, JobLogOutput, MergeRequest, MrFilter, Pagination,
-    PipelineInfo, PipelineJob, PipelineStage, PipelineStatus, PipelineSummary, Release,
-    ReleaseAsset, UpdateIssueInput, User,
+    IssueStatus, JobLogMode, JobLogOptions, JobLogOutput, MeetingFilter, MeetingNote,
+    MeetingSpeaker, MeetingTranscript, MergeRequest, MrFilter, Pagination, PipelineInfo,
+    PipelineJob, PipelineStage, PipelineStatus, PipelineSummary, Release, ReleaseAsset,
+    TranscriptSentence, UpdateIssueInput, User,
 };
 
 // Re-export enricher traits and utilities

--- a/crates/devboy-core/src/provider.rs
+++ b/crates/devboy-core/src/provider.rs
@@ -187,9 +187,6 @@ pub trait MeetingNotesProvider: Send + Sync {
     async fn get_transcript(&self, meeting_id: &str) -> Result<MeetingTranscript>;
 
     /// Search meetings by keyword across titles, action items, keywords, and topics.
-    async fn search_meetings(
-        &self,
-        query: &str,
-        filter: MeetingFilter,
-    ) -> Result<Vec<MeetingNote>>;
+    async fn search_meetings(&self, query: &str, filter: MeetingFilter)
+    -> Result<Vec<MeetingNote>>;
 }

--- a/crates/devboy-core/src/provider.rs
+++ b/crates/devboy-core/src/provider.rs
@@ -9,7 +9,8 @@ use crate::error::{Error, Result};
 use crate::types::{
     Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, Discussion, FileDiff,
     GetPipelineInput, GetUsersOptions, Issue, IssueFilter, IssueStatus, JobLogOptions,
-    JobLogOutput, MergeRequest, MrFilter, PipelineInfo, Release, UpdateIssueInput, User,
+    JobLogOutput, MeetingFilter, MeetingNote, MeetingTranscript, MergeRequest, MrFilter,
+    PipelineInfo, Release, UpdateIssueInput, User,
 };
 
 /// Provider for working with issues.
@@ -169,4 +170,26 @@ pub trait PipelineProvider: Send + Sync {
 pub trait Provider: IssueProvider + MergeRequestProvider + PipelineProvider {
     /// Get the current authenticated user.
     async fn get_current_user(&self) -> Result<User>;
+}
+
+/// Provider for meeting notes and transcripts.
+///
+/// Implementations include Fireflies.ai.
+#[async_trait]
+pub trait MeetingNotesProvider: Send + Sync {
+    /// Get the provider name for logging (e.g., "fireflies").
+    fn provider_name(&self) -> &'static str;
+
+    /// Get a list of meeting notes with optional filters.
+    async fn get_meetings(&self, filter: MeetingFilter) -> Result<Vec<MeetingNote>>;
+
+    /// Get the full transcript for a meeting.
+    async fn get_transcript(&self, meeting_id: &str) -> Result<MeetingTranscript>;
+
+    /// Search meetings by keyword across titles, action items, keywords, and topics.
+    async fn search_meetings(
+        &self,
+        query: &str,
+        filter: MeetingFilter,
+    ) -> Result<Vec<MeetingNote>>;
 }

--- a/crates/devboy-core/src/tool_category.rs
+++ b/crates/devboy-core/src/tool_category.rs
@@ -26,4 +26,8 @@ pub enum ToolCategory {
     /// Release tools: tags, releases, assets.
     /// Providers: GitLab, GitHub
     Releases,
+
+    /// Meeting notes tools: transcripts, summaries, search.
+    /// Providers: Fireflies
+    MeetingNotes,
 }

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -524,3 +524,98 @@ pub struct JobLogOutput {
     pub mode: String,
     pub total_lines: Option<usize>,
 }
+
+// =============================================================================
+// Meeting Notes
+// =============================================================================
+
+/// Represents a meeting note / transcript summary.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MeetingNote {
+    /// Unique identifier from the provider
+    pub id: String,
+    /// Meeting title
+    pub title: String,
+    /// Meeting date (ISO 8601)
+    pub meeting_date: Option<String>,
+    /// Duration in seconds
+    pub duration_seconds: Option<u64>,
+    /// Host email
+    pub host_email: Option<String>,
+    /// Organizer email
+    pub organizer_email: Option<String>,
+    /// Participant emails
+    pub participants: Vec<String>,
+    /// Speaker names
+    pub speakers: Vec<MeetingSpeaker>,
+    /// AI-extracted action items
+    pub action_items: Vec<String>,
+    /// Keywords / topics
+    pub keywords: Vec<String>,
+    /// Topics discussed
+    pub topics_discussed: Vec<String>,
+    /// Meeting type (e.g., "standup", "planning")
+    pub meeting_type: Option<String>,
+    /// AI summary overview
+    pub summary: Option<String>,
+    /// Transcript URL
+    pub transcript_url: Option<String>,
+    /// Audio recording URL
+    pub audio_url: Option<String>,
+    /// Video recording URL
+    pub video_url: Option<String>,
+    /// Meeting link (e.g., Zoom/Google Meet URL)
+    pub meeting_link: Option<String>,
+}
+
+/// A speaker in a meeting.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MeetingSpeaker {
+    pub id: String,
+    pub name: String,
+}
+
+/// Full meeting transcript with speaker-attributed sentences.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MeetingTranscript {
+    /// Meeting ID this transcript belongs to
+    pub meeting_id: String,
+    /// Meeting title
+    pub title: Option<String>,
+    /// Speaker-attributed sentences
+    pub sentences: Vec<TranscriptSentence>,
+}
+
+/// A single sentence in a meeting transcript.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct TranscriptSentence {
+    /// Speaker ID (maps to MeetingSpeaker.id)
+    pub speaker_id: String,
+    /// Speaker name (resolved from speakers list)
+    pub speaker_name: Option<String>,
+    /// Sentence text
+    pub text: String,
+    /// Start time in seconds
+    pub start_time: f64,
+    /// End time in seconds
+    pub end_time: f64,
+}
+
+/// Filter for listing meeting notes.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MeetingFilter {
+    /// Search keyword
+    pub keyword: Option<String>,
+    /// Filter from date (ISO 8601)
+    pub from_date: Option<String>,
+    /// Filter to date (ISO 8601)
+    pub to_date: Option<String>,
+    /// Filter by participant emails
+    pub participants: Option<Vec<String>>,
+    /// Filter by host email
+    pub host_email: Option<String>,
+    /// Max results
+    pub limit: Option<u32>,
+    /// Skip N results
+    pub skip: Option<u32>,
+}

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -544,7 +544,7 @@ pub struct MeetingNote {
     pub host_email: Option<String>,
     /// Organizer email
     pub organizer_email: Option<String>,
-    /// Participant emails
+    /// Participant identifiers (emails, names, or display names depending on provider)
     pub participants: Vec<String>,
     /// Speaker names
     pub speakers: Vec<MeetingSpeaker>,

--- a/crates/devboy-executor/Cargo.toml
+++ b/crates/devboy-executor/Cargo.toml
@@ -13,6 +13,7 @@ devboy-gitlab = { path = "../plugins/api/gitlab" }
 devboy-github = { path = "../plugins/api/github" }
 devboy-clickup = { path = "../plugins/api/clickup" }
 devboy-jira = { path = "../plugins/api/jira" }
+devboy-fireflies = { path = "../plugins/api/fireflies" }
 devboy-format-pipeline = { path = "../plugins/format-pipeline" }
 
 tokio.workspace = true

--- a/crates/devboy-executor/src/context.rs
+++ b/crates/devboy-executor/src/context.rs
@@ -77,6 +77,12 @@ pub enum ProviderConfig {
         #[serde(default)]
         extra: HashMap<String, serde_json::Value>,
     },
+    /// Fireflies.ai meeting notes provider.
+    Fireflies {
+        api_key: String,
+        #[serde(default)]
+        extra: HashMap<String, serde_json::Value>,
+    },
     /// Fully dynamic variant for community/custom provider plugins.
     Custom {
         name: String,
@@ -92,6 +98,7 @@ impl ProviderConfig {
             Self::GitHub { .. } => "github",
             Self::ClickUp { .. } => "clickup",
             Self::Jira { .. } => "jira",
+            Self::Fireflies { .. } => "fireflies",
             Self::Custom { name, .. } => name,
         }
     }

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -764,6 +764,9 @@ pub const SUPPORTED_TOOLS: &[&str] = &[
     "get_epics",
     "create_epic",
     "update_epic",
+    "get_meeting_notes",
+    "get_meeting_transcript",
+    "search_meeting_notes",
 ];
 
 #[cfg(test)]
@@ -950,7 +953,10 @@ mod tests {
         assert!(SUPPORTED_TOOLS.contains(&"get_issues"));
         assert!(SUPPORTED_TOOLS.contains(&"get_merge_requests"));
         assert!(SUPPORTED_TOOLS.contains(&"create_merge_request_comment"));
-        assert_eq!(SUPPORTED_TOOLS.len(), 20);
+        assert!(SUPPORTED_TOOLS.contains(&"get_meeting_notes"));
+        assert!(SUPPORTED_TOOLS.contains(&"get_meeting_transcript"));
+        assert!(SUPPORTED_TOOLS.contains(&"search_meeting_notes"));
+        assert_eq!(SUPPORTED_TOOLS.len(), 23);
     }
 
     // --- Issue tool dispatch tests ---
@@ -1282,6 +1288,113 @@ mod tests {
         let provider = MockProvider;
         let args = serde_json::json!({"source_key": "gh#1"});
         let result = dispatch_tool("link_issues", &args, &provider).await;
+        assert!(result.is_err());
+    }
+
+    // --- Mock MeetingNotesProvider tests ---
+
+    struct MockMeetingProvider;
+
+    #[async_trait]
+    impl MeetingNotesProvider for MockMeetingProvider {
+        fn provider_name(&self) -> &'static str {
+            "mock_meetings"
+        }
+
+        async fn get_meetings(
+            &self,
+            _filter: MeetingFilter,
+        ) -> devboy_core::Result<Vec<devboy_core::MeetingNote>> {
+            Ok(vec![devboy_core::MeetingNote {
+                id: "m1".into(),
+                title: "Test Meeting".into(),
+                ..Default::default()
+            }])
+        }
+
+        async fn get_transcript(
+            &self,
+            meeting_id: &str,
+        ) -> devboy_core::Result<devboy_core::MeetingTranscript> {
+            Ok(devboy_core::MeetingTranscript {
+                meeting_id: meeting_id.to_string(),
+                title: Some("Test Transcript".into()),
+                sentences: vec![devboy_core::TranscriptSentence {
+                    speaker_id: "s1".into(),
+                    speaker_name: Some("Alice".into()),
+                    text: "Hello".into(),
+                    start_time: 0.0,
+                    end_time: 1.0,
+                }],
+            })
+        }
+
+        async fn search_meetings(
+            &self,
+            _query: &str,
+            _filter: MeetingFilter,
+        ) -> devboy_core::Result<Vec<devboy_core::MeetingNote>> {
+            Ok(vec![devboy_core::MeetingNote {
+                id: "m2".into(),
+                title: "Search Result Meeting".into(),
+                ..Default::default()
+            }])
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_get_meeting_notes() {
+        let provider = MockMeetingProvider;
+        let args = serde_json::json!({"from_date": "2025-01-01", "limit": 10});
+        let result = dispatch_meeting_tool("get_meeting_notes", &args, &provider)
+            .await
+            .unwrap();
+        match result {
+            ToolOutput::MeetingNotes(meetings) => {
+                assert_eq!(meetings.len(), 1);
+                assert_eq!(meetings[0].title, "Test Meeting");
+            }
+            other => panic!("Expected MeetingNotes, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_get_meeting_transcript() {
+        let provider = MockMeetingProvider;
+        let args = serde_json::json!({"meeting_id": "m1"});
+        let result = dispatch_meeting_tool("get_meeting_transcript", &args, &provider)
+            .await
+            .unwrap();
+        match result {
+            ToolOutput::MeetingTranscript(transcript) => {
+                assert_eq!(transcript.meeting_id, "m1");
+                assert_eq!(transcript.sentences.len(), 1);
+                assert_eq!(transcript.sentences[0].speaker_name, Some("Alice".into()));
+            }
+            other => panic!("Expected MeetingTranscript, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_search_meeting_notes() {
+        let provider = MockMeetingProvider;
+        let args = serde_json::json!({"query": "sprint", "limit": 5});
+        let result = dispatch_meeting_tool("search_meeting_notes", &args, &provider)
+            .await
+            .unwrap();
+        match result {
+            ToolOutput::MeetingNotes(meetings) => {
+                assert_eq!(meetings.len(), 1);
+                assert_eq!(meetings[0].title, "Search Result Meeting");
+            }
+            other => panic!("Expected MeetingNotes, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_unknown_meeting_tool() {
+        let provider = MockMeetingProvider;
+        let result = dispatch_meeting_tool("nonexistent_tool", &Value::Null, &provider).await;
         assert!(result.is_err());
     }
 }

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -1,7 +1,8 @@
 use devboy_core::{
     CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, Error, GetPipelineInput,
-    GetUsersOptions, IssueFilter, IssueProvider, JobLogMode, JobLogOptions, MergeRequestProvider,
-    MrFilter, PipelineProvider, Result, UpdateIssueInput,
+    GetUsersOptions, IssueFilter, IssueProvider, JobLogMode, JobLogOptions, MeetingFilter,
+    MeetingNotesProvider, MergeRequestProvider, MrFilter, PipelineProvider, Result,
+    ToolCategory, UpdateIssueInput,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -100,11 +101,14 @@ impl Executor {
             "executing tool"
         );
 
-        // Create provider from context
-        let provider = factory::create_provider(&ctx.provider, ctx.proxy.as_ref())?;
-
-        // Dispatch to tool handler
-        let output = dispatch_tool(tool, &args, provider.as_ref()).await?;
+        // Dispatch based on tool category
+        let output = if tool_category == Some(ToolCategory::MeetingNotes) {
+            let provider = factory::create_meeting_notes_provider(&ctx.provider)?;
+            dispatch_meeting_tool(tool, &args, provider.as_ref()).await?
+        } else {
+            let provider = factory::create_provider(&ctx.provider, ctx.proxy.as_ref())?;
+            dispatch_tool(tool, &args, provider.as_ref()).await?
+        };
 
         Ok(output)
     }
@@ -161,6 +165,90 @@ async fn dispatch_tool(
 
         _ => Err(Error::NotFound(format!("unknown tool: {tool}"))),
     }
+}
+
+/// Dispatch a meeting notes tool call.
+async fn dispatch_meeting_tool(
+    tool: &str,
+    args: &Value,
+    provider: &dyn MeetingNotesProvider,
+) -> Result<ToolOutput> {
+    match tool {
+        "get_meeting_notes" => execute_get_meeting_notes(provider, args).await,
+        "get_meeting_transcript" => execute_get_meeting_transcript(provider, args).await,
+        "search_meeting_notes" => execute_search_meeting_notes(provider, args).await,
+        _ => Err(Error::NotFound(format!("unknown meeting tool: {tool}"))),
+    }
+}
+
+// --- Meeting notes tool handlers ---
+
+#[derive(Deserialize, Default)]
+struct GetMeetingNotesParams {
+    from_date: Option<String>,
+    to_date: Option<String>,
+    participants: Option<Vec<String>>,
+    host_email: Option<String>,
+    limit: Option<u32>,
+    offset: Option<u32>,
+}
+
+async fn execute_get_meeting_notes(
+    provider: &dyn MeetingNotesProvider,
+    args: &Value,
+) -> Result<ToolOutput> {
+    let params: GetMeetingNotesParams = serde_json::from_value(args.clone()).unwrap_or_default();
+    let filter = MeetingFilter {
+        keyword: None,
+        from_date: params.from_date,
+        to_date: params.to_date,
+        participants: params.participants,
+        host_email: params.host_email,
+        limit: params.limit,
+        skip: params.offset,
+    };
+    let meetings = provider.get_meetings(filter).await?;
+    Ok(ToolOutput::MeetingNotes(meetings))
+}
+
+#[derive(Deserialize)]
+struct GetMeetingTranscriptParams {
+    meeting_id: String,
+}
+
+async fn execute_get_meeting_transcript(
+    provider: &dyn MeetingNotesProvider,
+    args: &Value,
+) -> Result<ToolOutput> {
+    let params: GetMeetingTranscriptParams = serde_json::from_value(args.clone())
+        .map_err(|e| Error::InvalidData(format!("invalid params: {e}")))?;
+    let transcript = provider.get_transcript(&params.meeting_id).await?;
+    Ok(ToolOutput::MeetingTranscript(Box::new(transcript)))
+}
+
+#[derive(Deserialize)]
+struct SearchMeetingNotesParams {
+    query: String,
+    from_date: Option<String>,
+    to_date: Option<String>,
+    limit: Option<u32>,
+}
+
+async fn execute_search_meeting_notes(
+    provider: &dyn MeetingNotesProvider,
+    args: &Value,
+) -> Result<ToolOutput> {
+    let params: SearchMeetingNotesParams = serde_json::from_value(args.clone())
+        .map_err(|e| Error::InvalidData(format!("invalid params: {e}")))?;
+    let filter = MeetingFilter {
+        keyword: None,
+        from_date: params.from_date,
+        to_date: params.to_date,
+        limit: params.limit,
+        ..Default::default()
+    };
+    let meetings = provider.search_meetings(&params.query, filter).await?;
+    Ok(ToolOutput::MeetingNotes(meetings))
 }
 
 // --- Issue tool handlers ---

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -231,7 +231,10 @@ struct SearchMeetingNotesParams {
     query: String,
     from_date: Option<String>,
     to_date: Option<String>,
+    participants: Option<Vec<String>>,
+    host_email: Option<String>,
     limit: Option<u32>,
+    offset: Option<u32>,
 }
 
 async fn execute_search_meeting_notes(
@@ -244,8 +247,10 @@ async fn execute_search_meeting_notes(
         keyword: None,
         from_date: params.from_date,
         to_date: params.to_date,
+        participants: params.participants,
+        host_email: params.host_email,
         limit: params.limit,
-        ..Default::default()
+        skip: params.offset,
     };
     let meetings = provider.search_meetings(&params.query, filter).await?;
     Ok(ToolOutput::MeetingNotes(meetings))

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -1,8 +1,8 @@
 use devboy_core::{
     CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, Error, GetPipelineInput,
     GetUsersOptions, IssueFilter, IssueProvider, JobLogMode, JobLogOptions, MeetingFilter,
-    MeetingNotesProvider, MergeRequestProvider, MrFilter, PipelineProvider, Result,
-    ToolCategory, UpdateIssueInput,
+    MeetingNotesProvider, MergeRequestProvider, MrFilter, PipelineProvider, Result, ToolCategory,
+    UpdateIssueInput,
 };
 use serde::Deserialize;
 use serde_json::Value;

--- a/crates/devboy-executor/src/factory.rs
+++ b/crates/devboy-executor/src/factory.rs
@@ -1,4 +1,4 @@
-use devboy_core::{Error, Provider, Result, ToolEnricher};
+use devboy_core::{Error, MeetingNotesProvider, Provider, Result, ToolEnricher};
 
 use crate::context::{
     ClickUpScope, GitHubScope, GitLabScope, JiraScope, ProviderConfig, ProviderMetadata,
@@ -107,9 +107,32 @@ pub fn create_provider(
             }),
         },
 
+        ProviderConfig::Fireflies { .. } => Err(Error::ProviderUnsupported {
+            provider: "fireflies".into(),
+            operation: "Fireflies is a MeetingNotesProvider, not a Provider. Use create_meeting_notes_provider() instead.".into(),
+        }),
+
         ProviderConfig::Custom { name, .. } => Err(Error::ProviderNotFound(format!(
             "custom provider '{name}' not yet supported"
         ))),
+    }
+}
+
+/// Create a meeting notes provider from config.
+///
+/// Separate from `create_provider()` because meeting notes providers
+/// implement `MeetingNotesProvider`, not `Provider`.
+pub fn create_meeting_notes_provider(
+    config: &ProviderConfig,
+) -> Result<Box<dyn MeetingNotesProvider>> {
+    match config {
+        ProviderConfig::Fireflies { api_key, .. } => {
+            Ok(Box::new(devboy_fireflies::FirefliesClient::new(api_key)))
+        }
+        other => Err(Error::ProviderUnsupported {
+            provider: other.provider_name().into(),
+            operation: "not a meeting notes provider".into(),
+        }),
     }
 }
 
@@ -139,6 +162,9 @@ pub fn create_enricher(
             let jira_meta: devboy_jira::JiraMetadata =
                 serde_json::from_value(meta.data.clone()).ok()?;
             Some(Box::new(devboy_jira::JiraSchemaEnricher::new(jira_meta)))
+        }
+        ProviderConfig::Fireflies { .. } => {
+            Some(Box::new(devboy_fireflies::FirefliesSchemaEnricher))
         }
         ProviderConfig::Custom { .. } => None,
     }

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -260,7 +260,11 @@ fn format_meeting_transcript(transcript: &devboy_core::MeetingTranscript) -> Str
     ));
 
     for s in &transcript.sentences {
-        let fallback = format!("Speaker {}", s.speaker_id);
+        let fallback = if s.speaker_id.is_empty() {
+            "Unknown speaker".to_string()
+        } else {
+            format!("Speaker {}", s.speaker_id)
+        };
         let speaker = s.speaker_name.as_deref().unwrap_or(&fallback);
         let time = format_time(s.start_time);
         output.push_str(&format!("[{time}] {speaker}: {}\n", s.text));

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -227,7 +227,10 @@ fn format_meeting_notes(meetings: &[devboy_core::MeetingNote]) -> String {
             output.push_str(&format!("**Host:** {host}\n"));
         }
         if !m.participants.is_empty() {
-            output.push_str(&format!("**Participants:** {}\n", m.participants.join(", ")));
+            output.push_str(&format!(
+                "**Participants:** {}\n",
+                m.participants.join(", ")
+            ));
         }
         if let Some(ref summary) = m.summary {
             output.push_str(&format!("\n{summary}\n"));

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -925,4 +925,117 @@ mod tests {
             .content;
         assert_eq!(result, "raw text");
     }
+
+    // --- Meeting notes formatting ---
+
+    #[test]
+    fn test_format_meeting_notes() {
+        let meetings = vec![devboy_core::MeetingNote {
+            id: "m1".into(),
+            title: "Sprint Planning".into(),
+            meeting_date: Some("2025-01-15T10:00:00Z".into()),
+            duration_seconds: Some(2700), // 45 min
+            host_email: Some("host@example.com".into()),
+            participants: vec!["alice@example.com".into(), "bob@example.com".into()],
+            action_items: vec!["Review PR #42".into(), "Update docs".into()],
+            keywords: vec!["sprint".into(), "planning".into()],
+            summary: Some("Discussed sprint goals.".into()),
+            ..Default::default()
+        }];
+        let output = ToolOutput::MeetingNotes(meetings);
+        let result = format_output(output, None, None, None).unwrap().content;
+        assert!(result.contains("Sprint Planning"));
+        assert!(result.contains("2025-01-15T10:00:00Z"));
+        assert!(result.contains("45 min"));
+        assert!(result.contains("host@example.com"));
+        assert!(result.contains("alice@example.com"));
+        assert!(result.contains("Review PR #42"));
+        assert!(result.contains("Update docs"));
+        assert!(result.contains("sprint"));
+        assert!(result.contains("Discussed sprint goals."));
+    }
+
+    #[test]
+    fn test_format_meeting_notes_empty() {
+        let output = ToolOutput::MeetingNotes(vec![]);
+        let result = format_output(output, None, None, None).unwrap().content;
+        assert_eq!(result, "No meeting notes found.");
+    }
+
+    #[test]
+    fn test_format_meeting_transcript() {
+        let transcript = devboy_core::MeetingTranscript {
+            meeting_id: "m1".into(),
+            title: Some("Sprint Planning".into()),
+            sentences: vec![
+                devboy_core::TranscriptSentence {
+                    speaker_id: "s1".into(),
+                    speaker_name: Some("Alice".into()),
+                    text: "Let's start the meeting.".into(),
+                    start_time: 0.0,
+                    end_time: 3.0,
+                },
+                devboy_core::TranscriptSentence {
+                    speaker_id: "s2".into(),
+                    speaker_name: Some("Bob".into()),
+                    text: "Sounds good.".into(),
+                    start_time: 5.0,
+                    end_time: 7.0,
+                },
+            ],
+        };
+        let output = ToolOutput::MeetingTranscript(Box::new(transcript));
+        let result = format_output(output, None, None, None).unwrap().content;
+        assert!(result.contains("Sprint Planning"));
+        assert!(result.contains("2 sentences"));
+        assert!(result.contains("[00:00] Alice: Let's start the meeting."));
+        assert!(result.contains("[00:05] Bob: Sounds good."));
+    }
+
+    #[test]
+    fn test_format_meeting_transcript_unknown_speaker() {
+        let transcript = devboy_core::MeetingTranscript {
+            meeting_id: "m1".into(),
+            title: None,
+            sentences: vec![devboy_core::TranscriptSentence {
+                speaker_id: "".into(),
+                speaker_name: None,
+                text: "Hello".into(),
+                start_time: 0.0,
+                end_time: 1.0,
+            }],
+        };
+        let output = ToolOutput::MeetingTranscript(Box::new(transcript));
+        let result = format_output(output, None, None, None).unwrap().content;
+        assert!(result.contains("Meeting Transcript"));
+        assert!(result.contains("Unknown speaker"));
+    }
+
+    // --- format_time edge cases ---
+
+    #[test]
+    fn test_format_time_zero() {
+        assert_eq!(format_time(0.0), "00:00");
+    }
+
+    #[test]
+    fn test_format_time_seconds_only() {
+        assert_eq!(format_time(45.0), "00:45");
+    }
+
+    #[test]
+    fn test_format_time_minutes_and_seconds() {
+        assert_eq!(format_time(125.0), "02:05");
+    }
+
+    #[test]
+    fn test_format_time_hours() {
+        assert_eq!(format_time(3661.0), "01:01:01");
+    }
+
+    #[test]
+    fn test_format_time_fractional_seconds() {
+        // Fractional seconds are truncated
+        assert_eq!(format_time(59.9), "00:59");
+    }
 }

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -151,6 +151,10 @@ pub fn format_output(
         ToolOutput::JobLog(log) => Ok(text_result(format_job_log(&log))),
         ToolOutput::Statuses(statuses) => Ok(text_result(format_statuses(&statuses))),
         ToolOutput::Users(users) => Ok(text_result(format_users(&users))),
+        ToolOutput::MeetingNotes(meetings) => Ok(text_result(format_meeting_notes(&meetings))),
+        ToolOutput::MeetingTranscript(transcript) => {
+            Ok(text_result(format_meeting_transcript(&transcript)))
+        }
         ToolOutput::Text(text) => Ok(text_result(text)),
     }
 }
@@ -200,6 +204,79 @@ fn format_users(users: &[devboy_core::User]) -> String {
     }
 
     output
+}
+
+/// Format meeting notes as markdown.
+fn format_meeting_notes(meetings: &[devboy_core::MeetingNote]) -> String {
+    if meetings.is_empty() {
+        return "No meeting notes found.".to_string();
+    }
+
+    let mut output = format!("# Meeting Notes ({} results)\n\n", meetings.len());
+
+    for m in meetings {
+        output.push_str(&format!("## {}\n", m.title));
+        if let Some(ref date) = m.meeting_date {
+            output.push_str(&format!("**Date:** {date}\n"));
+        }
+        if let Some(secs) = m.duration_seconds {
+            let mins = secs / 60;
+            output.push_str(&format!("**Duration:** {mins} min\n"));
+        }
+        if let Some(ref host) = m.host_email {
+            output.push_str(&format!("**Host:** {host}\n"));
+        }
+        if !m.participants.is_empty() {
+            output.push_str(&format!("**Participants:** {}\n", m.participants.join(", ")));
+        }
+        if let Some(ref summary) = m.summary {
+            output.push_str(&format!("\n{summary}\n"));
+        }
+        if !m.action_items.is_empty() {
+            output.push_str("\n**Action Items:**\n");
+            for item in &m.action_items {
+                output.push_str(&format!("- {item}\n"));
+            }
+        }
+        if !m.keywords.is_empty() {
+            output.push_str(&format!("**Keywords:** {}\n", m.keywords.join(", ")));
+        }
+        output.push('\n');
+    }
+
+    output
+}
+
+/// Format a meeting transcript as compact text.
+fn format_meeting_transcript(transcript: &devboy_core::MeetingTranscript) -> String {
+    let title = transcript.title.as_deref().unwrap_or("Meeting Transcript");
+    let mut output = format!("# {title}\n\n");
+    output.push_str(&format!(
+        "Showing {} sentences\n\n",
+        transcript.sentences.len()
+    ));
+
+    for s in &transcript.sentences {
+        let fallback = format!("Speaker {}", s.speaker_id);
+        let speaker = s.speaker_name.as_deref().unwrap_or(&fallback);
+        let time = format_time(s.start_time);
+        output.push_str(&format!("[{time}] {speaker}: {}\n", s.text));
+    }
+
+    output
+}
+
+/// Format seconds as [MM:SS] or [HH:MM:SS].
+fn format_time(seconds: f64) -> String {
+    let total_secs = seconds as u64;
+    let hours = total_secs / 3600;
+    let minutes = (total_secs % 3600) / 60;
+    let secs = total_secs % 60;
+    if hours > 0 {
+        format!("{hours:02}:{minutes:02}:{secs:02}")
+    } else {
+        format!("{minutes:02}:{secs:02}")
+    }
 }
 
 /// Format pipeline status as markdown.

--- a/crates/devboy-executor/src/output.rs
+++ b/crates/devboy-executor/src/output.rs
@@ -1,6 +1,6 @@
 use devboy_core::{
-    Comment, Discussion, FileDiff, Issue, IssueStatus, JobLogOutput, MergeRequest, PipelineInfo,
-    User,
+    Comment, Discussion, FileDiff, Issue, IssueStatus, JobLogOutput, MeetingNote,
+    MeetingTranscript, MergeRequest, PipelineInfo, User,
 };
 
 /// Typed result of tool execution.
@@ -32,6 +32,10 @@ pub enum ToolOutput {
     Statuses(Vec<IssueStatus>),
     /// List of users
     Users(Vec<User>),
+    /// List of meeting notes
+    MeetingNotes(Vec<MeetingNote>),
+    /// Single meeting transcript with sentences
+    MeetingTranscript(Box<MeetingTranscript>),
     /// Plain text result (e.g., "Comment created successfully")
     Text(String),
 }
@@ -47,10 +51,12 @@ impl ToolOutput {
             Self::Comments(v) => v.len(),
             Self::Statuses(v) => v.len(),
             Self::Users(v) => v.len(),
+            Self::MeetingNotes(v) => v.len(),
             Self::SingleMergeRequest(_)
             | Self::SingleIssue(_)
             | Self::Pipeline(_)
             | Self::JobLog(_)
+            | Self::MeetingTranscript(_)
             | Self::Text(_) => 1,
         }
     }
@@ -69,6 +75,8 @@ impl ToolOutput {
             Self::JobLog(_) => "job_log",
             Self::Statuses(_) => "statuses",
             Self::Users(_) => "users",
+            Self::MeetingNotes(_) => "meeting_notes",
+            Self::MeetingTranscript(_) => "meeting_transcript",
             Self::Text(_) => "text",
         }
     }

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -293,6 +293,47 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s
             },
         },
+        // Meeting notes tools
+        ToolDefinition {
+            name: "get_meeting_notes".into(),
+            description: "Get meeting notes and transcripts with optional filters (date range, participants, host).".into(),
+            category: ToolCategory::MeetingNotes,
+            input_schema: {
+                let mut s = ToolSchema::new();
+                s.add_property("from_date", PropertySchema::string("Filter from date (ISO 8601, e.g., '2025-01-01T00:00:00Z')"));
+                s.add_property("to_date", PropertySchema::string("Filter to date (ISO 8601)"));
+                s.add_property("participants", PropertySchema::array(PropertySchema::string("email"), "Filter by participant email addresses"));
+                s.add_property("host_email", PropertySchema::string("Filter by host email"));
+                s.add_property("limit", PropertySchema::integer("Maximum number of results (default: 50)", Some(1.0), Some(50.0)));
+                s.add_property("offset", PropertySchema::integer("Number of results to skip (default: 0)", Some(0.0), None));
+                s
+            },
+        },
+        ToolDefinition {
+            name: "get_meeting_transcript".into(),
+            description: "Get the full transcript for a meeting. Returns speaker-attributed sentences with timestamps.".into(),
+            category: ToolCategory::MeetingNotes,
+            input_schema: {
+                let mut s = ToolSchema::new();
+                s.add_property("meeting_id", PropertySchema::string("Meeting ID from get_meeting_notes"));
+                s.set_required("meeting_id", true);
+                s
+            },
+        },
+        ToolDefinition {
+            name: "search_meeting_notes".into(),
+            description: "Search across meetings by keywords, topics, or action items.".into(),
+            category: ToolCategory::MeetingNotes,
+            input_schema: {
+                let mut s = ToolSchema::new();
+                s.add_property("query", PropertySchema::string("Search query"));
+                s.add_property("from_date", PropertySchema::string("Filter from date (ISO 8601)"));
+                s.add_property("to_date", PropertySchema::string("Filter to date (ISO 8601)"));
+                s.add_property("limit", PropertySchema::integer("Maximum number of results (default: 50)", Some(1.0), Some(50.0)));
+                s.set_required("query", true);
+                s
+            },
+        },
     ]
 }
 
@@ -303,7 +344,7 @@ mod tests {
     #[test]
     fn test_base_definitions_count() {
         let tools = base_tool_definitions();
-        assert_eq!(tools.len(), 20);
+        assert_eq!(tools.len(), 23);
     }
 
     #[test]
@@ -340,6 +381,11 @@ mod tests {
             "get_job_logs",
         ];
         let epics_tools = ["get_epics", "create_epic", "update_epic"];
+        let meeting_notes_tools = [
+            "get_meeting_notes",
+            "get_meeting_transcript",
+            "search_meeting_notes",
+        ];
 
         for tool in &tools {
             if issue_tracker_tools.contains(&tool.name.as_str()) {
@@ -361,6 +407,13 @@ mod tests {
                     tool.category,
                     ToolCategory::Epics,
                     "tool {} should be Epics",
+                    tool.name
+                );
+            } else if meeting_notes_tools.contains(&tool.name.as_str()) {
+                assert_eq!(
+                    tool.category,
+                    ToolCategory::MeetingNotes,
+                    "tool {} should be MeetingNotes",
                     tool.name
                 );
             } else {

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -322,14 +322,17 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "search_meeting_notes".into(),
-            description: "Search across meetings by keywords, topics, or action items.".into(),
+            description: "Search across meetings by keywords, topics, or action items, with optional filters (date range, participants, host).".into(),
             category: ToolCategory::MeetingNotes,
             input_schema: {
                 let mut s = ToolSchema::new();
                 s.add_property("query", PropertySchema::string("Search query"));
                 s.add_property("from_date", PropertySchema::string("Filter from date (ISO 8601)"));
                 s.add_property("to_date", PropertySchema::string("Filter to date (ISO 8601)"));
+                s.add_property("participants", PropertySchema::array(PropertySchema::string("email"), "Filter by participant email addresses"));
+                s.add_property("host_email", PropertySchema::string("Filter by host email"));
                 s.add_property("limit", PropertySchema::integer("Maximum number of results (default: 50)", Some(1.0), Some(50.0)));
+                s.add_property("offset", PropertySchema::integer("Number of results to skip (default: 0)", Some(0.0), None));
                 s.set_required("query", true);
                 s
             },

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -1517,7 +1517,10 @@ impl ToolHandler {
         let filter = devboy_core::MeetingFilter {
             from_date: params.from_date,
             to_date: params.to_date,
+            participants: params.participants,
+            host_email: params.host_email,
             limit: params.limit,
+            skip: params.offset,
             ..Default::default()
         };
 
@@ -1736,7 +1739,10 @@ struct SearchMeetingNotesParams {
     query: String,
     from_date: Option<String>,
     to_date: Option<String>,
+    participants: Option<Vec<String>>,
+    host_email: Option<String>,
     limit: Option<u32>,
+    offset: Option<u32>,
 }
 
 // =============================================================================

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -623,11 +623,25 @@ define_tools! {
                     "type": "string",
                     "description": "Filter to date (ISO 8601)"
                 },
+                "participants": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Filter by participant email addresses"
+                },
+                "host_email": {
+                    "type": "string",
+                    "description": "Filter by host email"
+                },
                 "limit": {
                     "type": "integer",
                     "description": "Maximum number of results (default: 50)",
                     "minimum": 1,
                     "maximum": 50
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Number of results to skip (default: 0)",
+                    "minimum": 0
                 }
             },
             "required": ["query"]
@@ -1430,6 +1444,7 @@ impl ToolHandler {
             skip: params.offset,
         };
 
+        let mut last_error: Option<String> = None;
         for provider in &self.meeting_providers {
             match provider.get_meetings(filter.clone()).await {
                 Ok(meetings) => {
@@ -1450,11 +1465,14 @@ impl ToolHandler {
                         provider.provider_name(),
                         e
                     );
+                    last_error = Some(format!("{}: {}", provider.provider_name(), e));
                 }
             }
         }
 
-        ToolCallResult::error("No meeting notes found".to_string())
+        ToolCallResult::error(
+            last_error.unwrap_or_else(|| "No meeting notes providers configured".to_string()),
+        )
     }
 
     async fn handle_get_meeting_transcript(&self, arguments: Option<Value>) -> ToolCallResult {
@@ -1470,6 +1488,7 @@ impl ToolHandler {
             None => return ToolCallResult::error("meeting_id is required".to_string()),
         };
 
+        let mut last_error: Option<String> = None;
         for provider in &self.meeting_providers {
             match provider.get_transcript(&params.meeting_id).await {
                 Ok(transcript) => {
@@ -1491,14 +1510,14 @@ impl ToolHandler {
                         provider.provider_name(),
                         e
                     );
+                    last_error = Some(format!("{}: {}", provider.provider_name(), e));
                 }
             }
         }
 
-        ToolCallResult::error(format!(
-            "Meeting transcript not found: {}",
-            params.meeting_id
-        ))
+        ToolCallResult::error(
+            last_error.unwrap_or_else(|| "No meeting notes providers configured".to_string()),
+        )
     }
 
     async fn handle_search_meeting_notes(&self, arguments: Option<Value>) -> ToolCallResult {
@@ -1524,6 +1543,7 @@ impl ToolHandler {
             ..Default::default()
         };
 
+        let mut last_error: Option<String> = None;
         for provider in &self.meeting_providers {
             match provider
                 .search_meetings(&params.query, filter.clone())
@@ -1547,11 +1567,14 @@ impl ToolHandler {
                         provider.provider_name(),
                         e
                     );
+                    last_error = Some(format!("{}: {}", provider.provider_name(), e));
                 }
             }
         }
 
-        ToolCallResult::error("No meetings found".to_string())
+        ToolCallResult::error(
+            last_error.unwrap_or_else(|| "No meeting notes providers configured".to_string()),
+        )
     }
 
     // =========================================================================

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -1440,7 +1440,7 @@ impl ToolHandler {
                         Some("get_meeting_notes"),
                         None,
                     ) {
-                        Ok(text) => ToolCallResult::text(text),
+                        Ok(result) => ToolCallResult::text(result.content),
                         Err(e) => ToolCallResult::error(format!("Format error: {e}")),
                     };
                 }
@@ -1481,7 +1481,7 @@ impl ToolHandler {
                         Some("get_meeting_transcript"),
                         None,
                     ) {
-                        Ok(text) => ToolCallResult::text(text),
+                        Ok(result) => ToolCallResult::text(result.content),
                         Err(e) => ToolCallResult::error(format!("Format error: {e}")),
                     };
                 }
@@ -1537,7 +1537,7 @@ impl ToolHandler {
                         Some("search_meeting_notes"),
                         None,
                     ) {
-                        Ok(text) => ToolCallResult::text(text),
+                        Ok(result) => ToolCallResult::text(result.content),
                         Err(e) => ToolCallResult::error(format!("Format error: {e}")),
                     };
                 }

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -1445,7 +1445,7 @@ impl ToolHandler {
                     };
                 }
                 Err(e) => {
-                    tracing::debug!(
+                    tracing::warn!(
                         "Meeting provider {} failed: {}",
                         provider.provider_name(),
                         e

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -17,6 +17,8 @@ pub enum ToolCategory {
     Issues,
     /// Tools that require a merge request provider (GitLab, GitHub).
     MergeRequests,
+    /// Tools that require a meeting notes provider (Fireflies).
+    MeetingNotes,
 }
 
 use devboy_core::{
@@ -544,6 +546,92 @@ define_tools! {
                 }
             }
         }
+    },
+
+    // =====================================================================
+    // Meeting Notes
+    // =====================================================================
+
+    "get_meeting_notes" => handle_get_meeting_notes {
+        category: ToolCategory::MeetingNotes,
+        description: "Get meeting notes and transcripts with optional filters (date range, participants, host).",
+        schema: {
+            "type": "object",
+            "properties": {
+                "from_date": {
+                    "type": "string",
+                    "description": "Filter from date (ISO 8601, e.g., '2025-01-01T00:00:00Z')"
+                },
+                "to_date": {
+                    "type": "string",
+                    "description": "Filter to date (ISO 8601)"
+                },
+                "participants": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Filter by participant email addresses"
+                },
+                "host_email": {
+                    "type": "string",
+                    "description": "Filter by host email"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results (default: 50)",
+                    "minimum": 1,
+                    "maximum": 50
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Number of results to skip (default: 0)",
+                    "minimum": 0
+                }
+            }
+        }
+    },
+
+    "get_meeting_transcript" => handle_get_meeting_transcript {
+        category: ToolCategory::MeetingNotes,
+        description: "Get the full transcript for a meeting. Returns speaker-attributed sentences with timestamps.",
+        schema: {
+            "type": "object",
+            "properties": {
+                "meeting_id": {
+                    "type": "string",
+                    "description": "Meeting ID from get_meeting_notes"
+                }
+            },
+            "required": ["meeting_id"]
+        }
+    },
+
+    "search_meeting_notes" => handle_search_meeting_notes {
+        category: ToolCategory::MeetingNotes,
+        description: "Search across meetings by keywords, topics, or action items.",
+        schema: {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query"
+                },
+                "from_date": {
+                    "type": "string",
+                    "description": "Filter from date (ISO 8601)"
+                },
+                "to_date": {
+                    "type": "string",
+                    "description": "Filter to date (ISO 8601)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results (default: 50)",
+                    "minimum": 1,
+                    "maximum": 50
+                }
+            },
+            "required": ["query"]
+        }
     };
 
     // Context management (handled by McpServer, not ToolHandler)
@@ -558,6 +646,7 @@ fn get_provider_name(provider: &dyn Provider) -> &'static str {
 /// Tool handler that executes tools using providers.
 pub struct ToolHandler {
     providers: Vec<Arc<dyn Provider>>,
+    meeting_providers: Vec<Arc<dyn devboy_core::MeetingNotesProvider>>,
     pipeline_config: PipelineConfig,
 }
 
@@ -566,14 +655,29 @@ impl ToolHandler {
     pub fn new(providers: Vec<Arc<dyn Provider>>) -> Self {
         Self {
             providers,
+            meeting_providers: Vec::new(),
             pipeline_config: PipelineConfig::default(),
         }
+    }
+
+    /// Add meeting notes providers (e.g., Fireflies).
+    pub fn with_meeting_providers(
+        mut self,
+        providers: Vec<Arc<dyn devboy_core::MeetingNotesProvider>>,
+    ) -> Self {
+        self.meeting_providers = providers;
+        self
     }
 
     /// Create with custom pipeline configuration.
     pub fn with_pipeline_config(mut self, config: PipelineConfig) -> Self {
         self.pipeline_config = config;
         self
+    }
+
+    /// Check if meeting notes providers are configured.
+    pub fn has_meeting_providers(&self) -> bool {
+        !self.meeting_providers.is_empty()
     }
 
     // =========================================================================
@@ -1304,6 +1408,150 @@ impl ToolHandler {
     }
 
     // =========================================================================
+    // MEETING NOTES HANDLERS
+    // =========================================================================
+
+    async fn handle_get_meeting_notes(&self, arguments: Option<Value>) -> ToolCallResult {
+        if self.meeting_providers.is_empty() {
+            return ToolCallResult::error("No meeting notes providers configured".to_string());
+        }
+
+        let params: GetMeetingNotesParams = arguments
+            .map(|v| serde_json::from_value(v).unwrap_or_default())
+            .unwrap_or_default();
+
+        let filter = devboy_core::MeetingFilter {
+            keyword: None,
+            from_date: params.from_date,
+            to_date: params.to_date,
+            participants: params.participants,
+            host_email: params.host_email,
+            limit: params.limit,
+            skip: params.offset,
+        };
+
+        for provider in &self.meeting_providers {
+            match provider.get_meetings(filter.clone()).await {
+                Ok(meetings) => {
+                    let output = devboy_executor::ToolOutput::MeetingNotes(meetings);
+                    return match devboy_executor::format_output(
+                        output,
+                        None,
+                        Some("get_meeting_notes"),
+                        None,
+                    ) {
+                        Ok(text) => ToolCallResult::text(text),
+                        Err(e) => ToolCallResult::error(format!("Format error: {e}")),
+                    };
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "Meeting provider {} failed: {}",
+                        provider.provider_name(),
+                        e
+                    );
+                }
+            }
+        }
+
+        ToolCallResult::error("No meeting notes found".to_string())
+    }
+
+    async fn handle_get_meeting_transcript(&self, arguments: Option<Value>) -> ToolCallResult {
+        if self.meeting_providers.is_empty() {
+            return ToolCallResult::error("No meeting notes providers configured".to_string());
+        }
+
+        let params: GetMeetingTranscriptParams = match arguments {
+            Some(v) => match serde_json::from_value(v) {
+                Ok(p) => p,
+                Err(e) => return ToolCallResult::error(format!("Invalid params: {e}")),
+            },
+            None => return ToolCallResult::error("meeting_id is required".to_string()),
+        };
+
+        for provider in &self.meeting_providers {
+            match provider.get_transcript(&params.meeting_id).await {
+                Ok(transcript) => {
+                    let output =
+                        devboy_executor::ToolOutput::MeetingTranscript(Box::new(transcript));
+                    return match devboy_executor::format_output(
+                        output,
+                        None,
+                        Some("get_meeting_transcript"),
+                        None,
+                    ) {
+                        Ok(text) => ToolCallResult::text(text),
+                        Err(e) => ToolCallResult::error(format!("Format error: {e}")),
+                    };
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "Meeting provider {} failed: {}",
+                        provider.provider_name(),
+                        e
+                    );
+                }
+            }
+        }
+
+        ToolCallResult::error(format!(
+            "Meeting transcript not found: {}",
+            params.meeting_id
+        ))
+    }
+
+    async fn handle_search_meeting_notes(&self, arguments: Option<Value>) -> ToolCallResult {
+        if self.meeting_providers.is_empty() {
+            return ToolCallResult::error("No meeting notes providers configured".to_string());
+        }
+
+        let params: SearchMeetingNotesParams = match arguments {
+            Some(v) => match serde_json::from_value(v) {
+                Ok(p) => p,
+                Err(e) => return ToolCallResult::error(format!("Invalid params: {e}")),
+            },
+            None => return ToolCallResult::error("query is required".to_string()),
+        };
+
+        let filter = devboy_core::MeetingFilter {
+            from_date: params.from_date,
+            to_date: params.to_date,
+            limit: params.limit,
+            ..Default::default()
+        };
+
+        for provider in &self.meeting_providers {
+            match provider
+                .search_meetings(&params.query, filter.clone())
+                .await
+            {
+                Ok(meetings) => {
+                    let output = devboy_executor::ToolOutput::MeetingNotes(meetings);
+                    return match devboy_executor::format_output(
+                        output,
+                        None,
+                        Some("search_meeting_notes"),
+                        None,
+                    ) {
+                        Ok(text) => ToolCallResult::text(text),
+                        Err(e) => ToolCallResult::error(format!("Format error: {e}")),
+                    };
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "Meeting provider {} failed: {}",
+                        provider.provider_name(),
+                        e
+                    );
+                }
+            }
+        }
+
+        ToolCallResult::error("No meetings found".to_string())
+    }
+
+    // =========================================================================
     // HELPER METHODS
     // =========================================================================
 
@@ -1465,6 +1713,30 @@ struct GetJobLogsParams {
     offset: Option<usize>,
     limit: Option<usize>,
     full: Option<bool>,
+}
+
+// Meeting notes params
+#[derive(serde::Deserialize, Default)]
+struct GetMeetingNotesParams {
+    from_date: Option<String>,
+    to_date: Option<String>,
+    participants: Option<Vec<String>>,
+    host_email: Option<String>,
+    limit: Option<u32>,
+    offset: Option<u32>,
+}
+
+#[derive(serde::Deserialize)]
+struct GetMeetingTranscriptParams {
+    meeting_id: String,
+}
+
+#[derive(serde::Deserialize)]
+struct SearchMeetingNotesParams {
+    query: String,
+    from_date: Option<String>,
+    to_date: Option<String>,
+    limit: Option<u32>,
 }
 
 // =============================================================================
@@ -2126,8 +2398,8 @@ mod tests {
         let handler = ToolHandler::new(vec![]);
         let tools = handler.available_tools();
 
-        // 6 issue tools + 6 MR tools + 2 pipeline tools = 14 total
-        assert_eq!(tools.len(), 14);
+        // 6 issue tools + 6 MR tools + 2 pipeline tools + 3 meeting tools = 17 total
+        assert_eq!(tools.len(), 17);
     }
 
     #[tokio::test]

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -274,6 +274,7 @@ impl McpServer {
                 "github" | "gitlab"
             )
         });
+        let has_meeting_providers = handler.has_meeting_providers();
 
         // Filter tools based on available providers (dynamic filtering).
         // This prevents exposing tools that would always fail due to missing providers.
@@ -282,6 +283,7 @@ impl McpServer {
                 .map(|cat| match cat {
                     ToolCategory::Issues => has_issue_providers,
                     ToolCategory::MergeRequests => has_mr_providers,
+                    ToolCategory::MeetingNotes => has_meeting_providers,
                 })
                 .unwrap_or(true) // Tools without category are always available
         });

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -27,6 +27,7 @@ pub struct McpServer {
     initialized: bool,
     proxy_manager: ProxyManager,
     builtin_tools_config: BuiltinToolsConfig,
+    meeting_providers: Vec<Arc<dyn devboy_core::MeetingNotesProvider>>,
 }
 
 impl McpServer {
@@ -40,6 +41,7 @@ impl McpServer {
             initialized: false,
             proxy_manager: ProxyManager::new(),
             builtin_tools_config: BuiltinToolsConfig::default(),
+            meeting_providers: Vec::new(),
         }
     }
 
@@ -58,6 +60,10 @@ impl McpServer {
     /// Set the proxy manager for upstream MCP server connections.
     pub fn set_proxy_manager(&mut self, proxy_manager: ProxyManager) {
         self.proxy_manager = proxy_manager;
+    }
+
+    pub fn add_meeting_provider(&mut self, provider: Arc<dyn devboy_core::MeetingNotesProvider>) {
+        self.meeting_providers.push(provider);
     }
 
     /// Add a provider to the server.
@@ -262,7 +268,8 @@ impl McpServer {
     /// This method is public to allow integration testing.
     pub fn handle_tools_list(&self, id: RequestId) -> JsonRpcResponse {
         let providers = self.active_providers();
-        let handler = ToolHandler::new(providers.clone());
+        let handler = ToolHandler::new(providers.clone())
+            .with_meeting_providers(self.meeting_providers.clone());
         let mut tools = handler.available_tools();
 
         // Pre-compute category availability to avoid repeated provider lookups.
@@ -419,7 +426,8 @@ impl McpServer {
                 {
                     proxy_result
                 } else {
-                    let handler = ToolHandler::new(self.active_providers());
+                    let handler = ToolHandler::new(self.active_providers())
+                        .with_meeting_providers(self.meeting_providers.clone());
                     handler.execute(&params.name, params.arguments).await
                 }
             }

--- a/crates/plugins/api/fireflies/Cargo.toml
+++ b/crates/plugins/api/fireflies/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "devboy-fireflies"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+devboy-core = { path = "../../../devboy-core" }
+reqwest.workspace = true
+tokio.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true

--- a/crates/plugins/api/fireflies/Cargo.toml
+++ b/crates/plugins/api/fireflies/Cargo.toml
@@ -11,3 +11,4 @@ serde.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+chrono = "0.4"

--- a/crates/plugins/api/fireflies/src/client.rs
+++ b/crates/plugins/api/fireflies/src/client.rs
@@ -326,14 +326,18 @@ fn parse_array_or_string(value: &Value) -> Vec<String> {
         Value::String(s) => s
             .lines()
             .map(|line| {
-                line.trim()
+                let trimmed = line.trim();
+                // Strip bullet prefixes, then normalize whitespace before stripping bold
+                let stripped = trimmed
                     .trim_start_matches('-')
                     .trim_start_matches('*')
-                    .trim_start_matches("**")
-                    .trim_end_matches("**")
-                    .trim_start_matches("## ")
                     .trim()
-                    .to_string()
+                    .trim_start_matches("## ")
+                    .trim();
+                // Strip bold markers (**text**)
+                let stripped = stripped.strip_prefix("**").unwrap_or(stripped);
+                let stripped = stripped.strip_suffix("**").unwrap_or(stripped);
+                stripped.trim().to_string()
             })
             .filter(|s| !s.is_empty())
             .collect(),

--- a/crates/plugins/api/fireflies/src/client.rs
+++ b/crates/plugins/api/fireflies/src/client.rs
@@ -114,9 +114,7 @@ impl FirefliesClient {
 
         let status = response.status();
         if status == reqwest::StatusCode::UNAUTHORIZED {
-            return Err(Error::Unauthorized(
-                "Invalid Fireflies API key".to_string(),
-            ));
+            return Err(Error::Unauthorized("Invalid Fireflies API key".to_string()));
         }
         if !status.is_success() {
             let text = response.text().await.unwrap_or_default();
@@ -139,9 +137,9 @@ impl FirefliesClient {
             });
         }
 
-        gql_response.data.ok_or_else(|| Error::InvalidData(
-            "Fireflies API returned no data".to_string(),
-        ))
+        gql_response
+            .data
+            .ok_or_else(|| Error::InvalidData("Fireflies API returned no data".to_string()))
     }
 }
 
@@ -154,7 +152,11 @@ impl MeetingNotesProvider for FirefliesClient {
     async fn get_meetings(&self, filter: MeetingFilter) -> Result<Vec<MeetingNote>> {
         let variables = build_filter_variables(&filter);
         let data: TranscriptsData = self.graphql(GET_TRANSCRIPTS_QUERY, variables).await?;
-        Ok(data.transcripts.into_iter().map(convert_transcript).collect())
+        Ok(data
+            .transcripts
+            .into_iter()
+            .map(convert_transcript)
+            .collect())
     }
 
     async fn get_transcript(&self, meeting_id: &str) -> Result<MeetingTranscript> {
@@ -208,7 +210,11 @@ impl MeetingNotesProvider for FirefliesClient {
             obj.insert("keyword".into(), Value::String(query.to_string()));
         }
         let data: TranscriptsData = self.graphql(GET_TRANSCRIPTS_QUERY, variables).await?;
-        Ok(data.transcripts.into_iter().map(convert_transcript).collect())
+        Ok(data
+            .transcripts
+            .into_iter()
+            .map(convert_transcript)
+            .collect())
     }
 }
 
@@ -231,7 +237,12 @@ fn build_filter_variables(filter: &MeetingFilter) -> Value {
     if let Some(ref participants) = filter.participants {
         vars.insert(
             "participants".into(),
-            Value::Array(participants.iter().map(|p| Value::String(p.clone())).collect()),
+            Value::Array(
+                participants
+                    .iter()
+                    .map(|p| Value::String(p.clone()))
+                    .collect(),
+            ),
         );
     }
     vars.insert(
@@ -281,8 +292,7 @@ fn convert_transcript(t: FirefliesTranscript) -> MeetingNote {
         .map(parse_array_or_string)
         .unwrap_or_default();
     let meeting_type = summary_ref.and_then(|s| s.meeting_type.clone());
-    let summary_text = summary_ref
-        .and_then(|s| s.overview.clone().or(s.short_summary.clone()));
+    let summary_text = summary_ref.and_then(|s| s.overview.clone().or(s.short_summary.clone()));
 
     MeetingNote {
         id: t.id,
@@ -377,5 +387,143 @@ mod tests {
 
         let note = convert_transcript(t);
         assert_eq!(note.duration_seconds, Some(2730)); // 45.5 * 60 = 2730
+    }
+
+    #[test]
+    fn test_convert_transcript_with_attendees_and_speakers() {
+        let t = FirefliesTranscript {
+            id: "m-123".into(),
+            title: Some("Sprint Planning".into()),
+            date: None,
+            duration: None,
+            host_email: Some("host@example.com".into()),
+            organizer_email: Some("org@example.com".into()),
+            meeting_attendees: Some(vec![
+                FirefliesAttendee {
+                    display_name: None,
+                    email: Some("alice@example.com".into()),
+                    name: None,
+                },
+                FirefliesAttendee {
+                    display_name: Some("Bob".into()),
+                    email: None,
+                    name: None,
+                },
+            ]),
+            speakers: Some(vec![
+                FirefliesSpeaker {
+                    id: Some("1".into()),
+                    name: Some("Alice".into()),
+                },
+                FirefliesSpeaker {
+                    id: Some("2".into()),
+                    name: Some("Bob".into()),
+                },
+            ]),
+            transcript_url: None,
+            audio_url: None,
+            video_url: None,
+            meeting_link: None,
+            summary: Some(FirefliesSummary {
+                keywords: Some(json!(["rust", "migration"])),
+                action_items: Some(json!("- Review PR\n- Update docs")),
+                topics_discussed: None,
+                meeting_type: Some("planning".into()),
+                overview: Some("Team discussed migration plan.".into()),
+                short_summary: None,
+            }),
+            sentences: None,
+        };
+
+        let note = convert_transcript(t);
+        assert_eq!(note.id, "m-123");
+        assert_eq!(note.title, "Sprint Planning");
+        assert_eq!(note.host_email, Some("host@example.com".into()));
+        assert_eq!(
+            note.participants,
+            vec!["alice@example.com".to_string(), "Bob".to_string()]
+        );
+        assert_eq!(note.speakers.len(), 2);
+        assert_eq!(note.speakers[0].name, "Alice");
+        assert_eq!(note.keywords, vec!["rust", "migration"]);
+        assert_eq!(note.action_items, vec!["Review PR", "Update docs"]);
+        assert_eq!(note.meeting_type, Some("planning".into()));
+        assert_eq!(note.summary, Some("Team discussed migration plan.".into()));
+    }
+
+    #[test]
+    fn test_convert_transcript_no_duration() {
+        let t = FirefliesTranscript {
+            id: "no-dur".into(),
+            title: None,
+            date: None,
+            duration: None,
+            host_email: None,
+            organizer_email: None,
+            meeting_attendees: None,
+            speakers: None,
+            transcript_url: None,
+            audio_url: None,
+            video_url: None,
+            meeting_link: None,
+            summary: None,
+            sentences: None,
+        };
+
+        let note = convert_transcript(t);
+        assert_eq!(note.duration_seconds, None);
+        assert!(note.title.is_empty());
+    }
+
+    #[test]
+    fn test_parse_array_or_string_with_empty_array() {
+        let val = json!([]);
+        let result = parse_array_or_string(&val);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_array_or_string_filters_empty_strings() {
+        let val = json!(["item1", "", "item2"]);
+        let result = parse_array_or_string(&val);
+        assert_eq!(result, vec!["item1", "item2"]);
+    }
+
+    #[test]
+    fn test_build_filter_variables_empty() {
+        let filter = MeetingFilter::default();
+        let vars = build_filter_variables(&filter);
+        let obj = vars.as_object().unwrap();
+        assert_eq!(obj.get("limit").unwrap(), &json!(50));
+        assert!(obj.get("keyword").is_none());
+        assert!(obj.get("fromDate").is_none());
+    }
+
+    #[test]
+    fn test_build_filter_variables_full() {
+        let filter = MeetingFilter {
+            keyword: Some("sprint".into()),
+            from_date: Some("2025-01-01".into()),
+            to_date: Some("2025-12-31".into()),
+            participants: Some(vec!["alice@ex.com".into()]),
+            host_email: Some("host@ex.com".into()),
+            limit: Some(10),
+            skip: Some(5),
+        };
+        let vars = build_filter_variables(&filter);
+        let obj = vars.as_object().unwrap();
+        assert_eq!(obj["keyword"], json!("sprint"));
+        assert_eq!(obj["fromDate"], json!("2025-01-01"));
+        assert_eq!(obj["toDate"], json!("2025-12-31"));
+        assert_eq!(obj["host_email"], json!("host@ex.com"));
+        assert_eq!(obj["participants"], json!(["alice@ex.com"]));
+        assert_eq!(obj["limit"], json!(10));
+        assert_eq!(obj["skip"], json!(5));
+    }
+
+    #[test]
+    fn test_fireflies_client_new() {
+        let client = FirefliesClient::new("test-key");
+        assert_eq!(client.provider_name(), "fireflies");
     }
 }

--- a/crates/plugins/api/fireflies/src/client.rs
+++ b/crates/plugins/api/fireflies/src/client.rs
@@ -168,6 +168,18 @@ impl MeetingNotesProvider for FirefliesClient {
         })?;
 
         let speakers = transcript.speakers.as_deref().unwrap_or(&[]);
+        // Build a HashMap for O(1) speaker name lookup instead of O(n) linear scan
+        let speaker_map: std::collections::HashMap<String, String> = speakers
+            .iter()
+            .filter_map(|sp| {
+                let id = match &sp.id {
+                    Some(Value::String(v)) => v.clone(),
+                    Some(Value::Number(n)) => n.to_string(),
+                    _ => return None,
+                };
+                sp.name.as_ref().map(|name| (id, name.clone()))
+            })
+            .collect();
         let sentences = transcript
             .sentences
             .unwrap_or_default()
@@ -178,17 +190,12 @@ impl MeetingNotesProvider for FirefliesClient {
                     Some(Value::Number(n)) => n.to_string(),
                     _ => String::new(),
                 };
-                let speaker_name = speakers
-                    .iter()
-                    .find(|sp| {
-                        let sp_id = match &sp.id {
-                            Some(Value::String(v)) => v.clone(),
-                            Some(Value::Number(n)) => n.to_string(),
-                            _ => String::new(),
-                        };
-                        sp_id == speaker_id
-                    })
-                    .and_then(|sp| sp.name.clone());
+                // Skip speaker lookup when speaker_id is empty
+                let speaker_name = if speaker_id.is_empty() {
+                    None
+                } else {
+                    speaker_map.get(&speaker_id).cloned()
+                };
 
                 TranscriptSentence {
                     speaker_id,

--- a/crates/plugins/api/fireflies/src/client.rs
+++ b/crates/plugins/api/fireflies/src/client.rs
@@ -180,7 +180,14 @@ impl MeetingNotesProvider for FirefliesClient {
                 };
                 let speaker_name = speakers
                     .iter()
-                    .find(|sp| sp.id.as_deref() == Some(&speaker_id))
+                    .find(|sp| {
+                        let sp_id = match &sp.id {
+                            Some(Value::String(v)) => v.clone(),
+                            Some(Value::Number(n)) => n.to_string(),
+                            _ => String::new(),
+                        };
+                        sp_id == speaker_id
+                    })
                     .and_then(|sp| sp.name.clone());
 
                 TranscriptSentence {
@@ -258,6 +265,8 @@ fn build_filter_variables(filter: &MeetingFilter) -> Value {
 
 /// Convert a Fireflies API transcript to a unified MeetingNote.
 fn convert_transcript(t: FirefliesTranscript) -> MeetingNote {
+    let meeting_date = t.date.and_then(|d| parse_date_value(&d));
+
     let participants: Vec<String> = t
         .meeting_attendees
         .unwrap_or_default()
@@ -269,9 +278,16 @@ fn convert_transcript(t: FirefliesTranscript) -> MeetingNote {
         .speakers
         .unwrap_or_default()
         .into_iter()
-        .map(|s| MeetingSpeaker {
-            id: s.id.unwrap_or_default(),
-            name: s.name.unwrap_or_default(),
+        .map(|s| {
+            let id = match &s.id {
+                Some(Value::String(v)) => v.clone(),
+                Some(Value::Number(n)) => n.to_string(),
+                _ => String::new(),
+            };
+            MeetingSpeaker {
+                id,
+                name: s.name.unwrap_or_default(),
+            }
         })
         .collect();
 
@@ -297,7 +313,7 @@ fn convert_transcript(t: FirefliesTranscript) -> MeetingNote {
     MeetingNote {
         id: t.id,
         title: t.title.unwrap_or_default(),
-        meeting_date: t.date,
+        meeting_date,
         duration_seconds,
         host_email: t.host_email,
         organizer_email: t.organizer_email,
@@ -312,6 +328,21 @@ fn convert_transcript(t: FirefliesTranscript) -> MeetingNote {
         audio_url: t.audio_url,
         video_url: t.video_url,
         meeting_link: t.meeting_link,
+    }
+}
+
+/// Parse a date value that can be either an ISO string or Unix timestamp in milliseconds.
+fn parse_date_value(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) => Some(s.clone()),
+        Value::Number(n) => {
+            // Unix timestamp in milliseconds → ISO 8601 string
+            let ms = n.as_f64()?;
+            let secs = (ms / 1000.0) as i64;
+            let dt = chrono::DateTime::from_timestamp(secs, 0)?;
+            Some(dt.to_rfc3339())
+        }
+        _ => None,
     }
 }
 
@@ -375,7 +406,7 @@ mod tests {
         let t = FirefliesTranscript {
             id: "test-id".into(),
             title: Some("Test Meeting".into()),
-            date: Some("2025-01-15T10:00:00Z".into()),
+            date: Some(Value::String("2025-01-15T10:00:00Z".into())),
             duration: Some(45.5), // 45.5 minutes
             host_email: None,
             organizer_email: None,

--- a/crates/plugins/api/fireflies/src/client.rs
+++ b/crates/plugins/api/fireflies/src/client.rs
@@ -1,0 +1,381 @@
+//! Fireflies.ai GraphQL client implementing `MeetingNotesProvider`.
+
+use async_trait::async_trait;
+use devboy_core::{
+    Error, MeetingFilter, MeetingNote, MeetingNotesProvider, MeetingSpeaker, MeetingTranscript,
+    Result, TranscriptSentence,
+};
+use serde_json::{Value, json};
+use tracing::debug;
+
+use crate::types::*;
+
+const FIREFLIES_API_URL: &str = "https://api.fireflies.ai/graphql";
+
+/// GraphQL query for listing transcripts.
+const GET_TRANSCRIPTS_QUERY: &str = r#"
+query GetTranscripts(
+  $keyword: String
+  $fromDate: DateTime
+  $toDate: DateTime
+  $limit: Int
+  $skip: Int
+  $host_email: String
+  $participants: [String!]
+) {
+  transcripts(
+    keyword: $keyword
+    fromDate: $fromDate
+    toDate: $toDate
+    limit: $limit
+    skip: $skip
+    host_email: $host_email
+    participants: $participants
+  ) {
+    id
+    title
+    date
+    duration
+    host_email
+    organizer_email
+    meeting_attendees { displayName email name }
+    speakers { id name }
+    transcript_url
+    audio_url
+    video_url
+    meeting_link
+    summary {
+      keywords
+      action_items
+      topics_discussed
+      meeting_type
+      overview
+      short_summary
+    }
+  }
+}
+"#;
+
+/// GraphQL query for a single transcript with sentences.
+const GET_TRANSCRIPT_QUERY: &str = r#"
+query GetTranscript($transcriptId: String!) {
+  transcript(id: $transcriptId) {
+    id
+    title
+    date
+    duration
+    speakers { id name }
+    sentences {
+      speaker_id
+      text
+      start_time
+      end_time
+    }
+  }
+}
+"#;
+
+/// Fireflies.ai API client.
+pub struct FirefliesClient {
+    api_key: String,
+    http: reqwest::Client,
+}
+
+impl FirefliesClient {
+    pub fn new(api_key: &str) -> Self {
+        Self {
+            api_key: api_key.to_string(),
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// Execute a GraphQL query against the Fireflies API.
+    async fn graphql<T: serde::de::DeserializeOwned>(
+        &self,
+        query: &str,
+        variables: Value,
+    ) -> Result<T> {
+        let body = json!({
+            "query": query,
+            "variables": variables,
+        });
+
+        debug!(url = FIREFLIES_API_URL, "fireflies graphql request");
+
+        let response = self
+            .http
+            .post(FIREFLIES_API_URL)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| Error::Network(e.to_string()))?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(Error::Unauthorized(
+                "Invalid Fireflies API key".to_string(),
+            ));
+        }
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(Error::Api {
+                status: status.as_u16(),
+                message: text,
+            });
+        }
+
+        let gql_response: GraphQLResponse<T> = response
+            .json()
+            .await
+            .map_err(|e| Error::InvalidData(e.to_string()))?;
+
+        if let Some(errors) = gql_response.errors {
+            let messages: Vec<String> = errors.into_iter().map(|e| e.message).collect();
+            return Err(Error::Api {
+                status: 200,
+                message: messages.join("; "),
+            });
+        }
+
+        gql_response.data.ok_or_else(|| Error::InvalidData(
+            "Fireflies API returned no data".to_string(),
+        ))
+    }
+}
+
+#[async_trait]
+impl MeetingNotesProvider for FirefliesClient {
+    fn provider_name(&self) -> &'static str {
+        "fireflies"
+    }
+
+    async fn get_meetings(&self, filter: MeetingFilter) -> Result<Vec<MeetingNote>> {
+        let variables = build_filter_variables(&filter);
+        let data: TranscriptsData = self.graphql(GET_TRANSCRIPTS_QUERY, variables).await?;
+        Ok(data.transcripts.into_iter().map(convert_transcript).collect())
+    }
+
+    async fn get_transcript(&self, meeting_id: &str) -> Result<MeetingTranscript> {
+        let variables = json!({ "transcriptId": meeting_id });
+        let data: TranscriptData = self.graphql(GET_TRANSCRIPT_QUERY, variables).await?;
+
+        let transcript = data.transcript.ok_or_else(|| {
+            Error::NotFound(format!("Meeting transcript not found: {meeting_id}"))
+        })?;
+
+        let speakers = transcript.speakers.as_deref().unwrap_or(&[]);
+        let sentences = transcript
+            .sentences
+            .unwrap_or_default()
+            .into_iter()
+            .map(|s| {
+                let speaker_id = match &s.speaker_id {
+                    Some(Value::String(id)) => id.clone(),
+                    Some(Value::Number(n)) => n.to_string(),
+                    _ => String::new(),
+                };
+                let speaker_name = speakers
+                    .iter()
+                    .find(|sp| sp.id.as_deref() == Some(&speaker_id))
+                    .and_then(|sp| sp.name.clone());
+
+                TranscriptSentence {
+                    speaker_id,
+                    speaker_name,
+                    text: s.text.unwrap_or_default(),
+                    start_time: s.start_time.unwrap_or(0.0),
+                    end_time: s.end_time.unwrap_or(0.0),
+                }
+            })
+            .collect();
+
+        Ok(MeetingTranscript {
+            meeting_id: transcript.id,
+            title: transcript.title,
+            sentences,
+        })
+    }
+
+    async fn search_meetings(
+        &self,
+        query: &str,
+        filter: MeetingFilter,
+    ) -> Result<Vec<MeetingNote>> {
+        let mut variables = build_filter_variables(&filter);
+        if let Some(obj) = variables.as_object_mut() {
+            obj.insert("keyword".into(), Value::String(query.to_string()));
+        }
+        let data: TranscriptsData = self.graphql(GET_TRANSCRIPTS_QUERY, variables).await?;
+        Ok(data.transcripts.into_iter().map(convert_transcript).collect())
+    }
+}
+
+/// Build GraphQL variables from a MeetingFilter.
+fn build_filter_variables(filter: &MeetingFilter) -> Value {
+    let mut vars = serde_json::Map::new();
+
+    if let Some(ref keyword) = filter.keyword {
+        vars.insert("keyword".into(), Value::String(keyword.clone()));
+    }
+    if let Some(ref from) = filter.from_date {
+        vars.insert("fromDate".into(), Value::String(from.clone()));
+    }
+    if let Some(ref to) = filter.to_date {
+        vars.insert("toDate".into(), Value::String(to.clone()));
+    }
+    if let Some(ref host) = filter.host_email {
+        vars.insert("host_email".into(), Value::String(host.clone()));
+    }
+    if let Some(ref participants) = filter.participants {
+        vars.insert(
+            "participants".into(),
+            Value::Array(participants.iter().map(|p| Value::String(p.clone())).collect()),
+        );
+    }
+    vars.insert(
+        "limit".into(),
+        Value::Number(filter.limit.unwrap_or(50).into()),
+    );
+    if let Some(skip) = filter.skip {
+        vars.insert("skip".into(), Value::Number(skip.into()));
+    }
+
+    Value::Object(vars)
+}
+
+/// Convert a Fireflies API transcript to a unified MeetingNote.
+fn convert_transcript(t: FirefliesTranscript) -> MeetingNote {
+    let participants: Vec<String> = t
+        .meeting_attendees
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|a| a.email.or(a.name).or(a.display_name))
+        .collect();
+
+    let speakers: Vec<MeetingSpeaker> = t
+        .speakers
+        .unwrap_or_default()
+        .into_iter()
+        .map(|s| MeetingSpeaker {
+            id: s.id.unwrap_or_default(),
+            name: s.name.unwrap_or_default(),
+        })
+        .collect();
+
+    // Fireflies duration is in MINUTES, convert to seconds
+    let duration_seconds = t.duration.map(|d| (d * 60.0) as u64);
+
+    let summary_ref = t.summary.as_ref();
+    let action_items = summary_ref
+        .and_then(|s| s.action_items.as_ref())
+        .map(parse_array_or_string)
+        .unwrap_or_default();
+    let keywords = summary_ref
+        .and_then(|s| s.keywords.as_ref())
+        .map(parse_array_or_string)
+        .unwrap_or_default();
+    let topics_discussed = summary_ref
+        .and_then(|s| s.topics_discussed.as_ref())
+        .map(parse_array_or_string)
+        .unwrap_or_default();
+    let meeting_type = summary_ref.and_then(|s| s.meeting_type.clone());
+    let summary_text = summary_ref
+        .and_then(|s| s.overview.clone().or(s.short_summary.clone()));
+
+    MeetingNote {
+        id: t.id,
+        title: t.title.unwrap_or_default(),
+        meeting_date: t.date,
+        duration_seconds,
+        host_email: t.host_email,
+        organizer_email: t.organizer_email,
+        participants,
+        speakers,
+        action_items,
+        keywords,
+        topics_discussed,
+        meeting_type,
+        summary: summary_text,
+        transcript_url: t.transcript_url,
+        audio_url: t.audio_url,
+        video_url: t.video_url,
+        meeting_link: t.meeting_link,
+    }
+}
+
+/// Parse a Fireflies field that can be either a JSON array or a markdown string.
+fn parse_array_or_string(value: &Value) -> Vec<String> {
+    match value {
+        Value::Array(arr) => arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .filter(|s| !s.is_empty())
+            .collect(),
+        Value::String(s) => s
+            .lines()
+            .map(|line| {
+                line.trim()
+                    .trim_start_matches('-')
+                    .trim_start_matches('*')
+                    .trim_start_matches("**")
+                    .trim_end_matches("**")
+                    .trim_start_matches("## ")
+                    .trim()
+                    .to_string()
+            })
+            .filter(|s| !s.is_empty())
+            .collect(),
+        _ => vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_array_or_string_with_array() {
+        let val = json!(["item1", "item2", "item3"]);
+        let result = parse_array_or_string(&val);
+        assert_eq!(result, vec!["item1", "item2", "item3"]);
+    }
+
+    #[test]
+    fn test_parse_array_or_string_with_markdown() {
+        let val = json!("**Actions**\n- Review PR\n- Update docs\n");
+        let result = parse_array_or_string(&val);
+        assert_eq!(result, vec!["Actions", "Review PR", "Update docs"]);
+    }
+
+    #[test]
+    fn test_parse_array_or_string_with_null() {
+        let val = json!(null);
+        let result = parse_array_or_string(&val);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_convert_transcript_duration_conversion() {
+        let t = FirefliesTranscript {
+            id: "test-id".into(),
+            title: Some("Test Meeting".into()),
+            date: Some("2025-01-15T10:00:00Z".into()),
+            duration: Some(45.5), // 45.5 minutes
+            host_email: None,
+            organizer_email: None,
+            meeting_attendees: None,
+            speakers: None,
+            transcript_url: None,
+            audio_url: None,
+            video_url: None,
+            meeting_link: None,
+            summary: None,
+            sentences: None,
+        };
+
+        let note = convert_transcript(t);
+        assert_eq!(note.duration_seconds, Some(2730)); // 45.5 * 60 = 2730
+    }
+}

--- a/crates/plugins/api/fireflies/src/enricher.rs
+++ b/crates/plugins/api/fireflies/src/enricher.rs
@@ -1,0 +1,22 @@
+//! Schema enricher for Fireflies meeting notes tools.
+
+use devboy_core::{ToolCategory, ToolEnricher, ToolSchema};
+use serde_json::Value;
+
+/// Enricher for Fireflies.ai — declares support for MeetingNotes category.
+pub struct FirefliesSchemaEnricher;
+
+impl ToolEnricher for FirefliesSchemaEnricher {
+    fn supported_categories(&self) -> &[ToolCategory] {
+        &[ToolCategory::MeetingNotes]
+    }
+
+    fn enrich_schema(&self, _tool_name: &str, _schema: &mut ToolSchema) {
+        // Fireflies has no dynamic enrichment (no custom fields or metadata-driven enums).
+        // All parameters are statically defined in the base tool definitions.
+    }
+
+    fn transform_args(&self, _tool_name: &str, _args: &mut Value) {
+        // No argument transformation needed.
+    }
+}

--- a/crates/plugins/api/fireflies/src/enricher.rs
+++ b/crates/plugins/api/fireflies/src/enricher.rs
@@ -20,3 +20,27 @@ impl ToolEnricher for FirefliesSchemaEnricher {
         // No argument transformation needed.
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_supported_categories() {
+        let enricher = FirefliesSchemaEnricher;
+        assert_eq!(
+            enricher.supported_categories(),
+            &[ToolCategory::MeetingNotes]
+        );
+    }
+
+    #[test]
+    fn test_enrich_schema_is_noop() {
+        let enricher = FirefliesSchemaEnricher;
+        let mut schema = ToolSchema::new();
+        schema.add_property("test", devboy_core::PropertySchema::string("test field"));
+        let original_len = schema.properties.len();
+        enricher.enrich_schema("get_meeting_notes", &mut schema);
+        assert_eq!(schema.properties.len(), original_len);
+    }
+}

--- a/crates/plugins/api/fireflies/src/lib.rs
+++ b/crates/plugins/api/fireflies/src/lib.rs
@@ -1,0 +1,11 @@
+//! Fireflies.ai meeting notes provider for devboy-tools.
+//!
+//! Integrates with the Fireflies.ai GraphQL API to provide meeting
+//! transcripts, summaries, and search capabilities via MCP tools.
+
+mod client;
+mod enricher;
+mod types;
+
+pub use client::FirefliesClient;
+pub use enricher::FirefliesSchemaEnricher;

--- a/crates/plugins/api/fireflies/src/types.rs
+++ b/crates/plugins/api/fireflies/src/types.rs
@@ -31,7 +31,8 @@ pub(crate) struct TranscriptData {
 pub(crate) struct FirefliesTranscript {
     pub id: String,
     pub title: Option<String>,
-    pub date: Option<String>,
+    /// Date — can be ISO string or Unix timestamp in milliseconds.
+    pub date: Option<serde_json::Value>,
     /// Duration in minutes (float) from Fireflies API.
     pub duration: Option<f64>,
     pub host_email: Option<String>,
@@ -56,7 +57,8 @@ pub(crate) struct FirefliesAttendee {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct FirefliesSpeaker {
-    pub id: Option<String>,
+    /// Speaker ID — can be number or string depending on Fireflies API version.
+    pub id: Option<serde_json::Value>,
     pub name: Option<String>,
 }
 

--- a/crates/plugins/api/fireflies/src/types.rs
+++ b/crates/plugins/api/fireflies/src/types.rs
@@ -1,0 +1,79 @@
+//! Fireflies.ai GraphQL API response types.
+
+use serde::Deserialize;
+
+/// GraphQL response wrapper.
+#[derive(Debug, Deserialize)]
+pub(crate) struct GraphQLResponse<T> {
+    pub data: Option<T>,
+    pub errors: Option<Vec<GraphQLError>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GraphQLError {
+    pub message: String,
+}
+
+/// Response for `transcripts` query.
+#[derive(Debug, Deserialize)]
+pub(crate) struct TranscriptsData {
+    pub transcripts: Vec<FirefliesTranscript>,
+}
+
+/// Response for `transcript` query (single).
+#[derive(Debug, Deserialize)]
+pub(crate) struct TranscriptData {
+    pub transcript: Option<FirefliesTranscript>,
+}
+
+/// A Fireflies transcript record.
+#[derive(Debug, Deserialize)]
+pub(crate) struct FirefliesTranscript {
+    pub id: String,
+    pub title: Option<String>,
+    pub date: Option<String>,
+    /// Duration in minutes (float) from Fireflies API.
+    pub duration: Option<f64>,
+    pub host_email: Option<String>,
+    pub organizer_email: Option<String>,
+    pub meeting_attendees: Option<Vec<FirefliesAttendee>>,
+    pub speakers: Option<Vec<FirefliesSpeaker>>,
+    pub transcript_url: Option<String>,
+    pub audio_url: Option<String>,
+    pub video_url: Option<String>,
+    pub meeting_link: Option<String>,
+    pub summary: Option<FirefliesSummary>,
+    pub sentences: Option<Vec<FirefliesSentence>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct FirefliesAttendee {
+    #[serde(rename = "displayName")]
+    pub display_name: Option<String>,
+    pub email: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct FirefliesSpeaker {
+    pub id: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct FirefliesSummary {
+    pub keywords: Option<serde_json::Value>,
+    pub action_items: Option<serde_json::Value>,
+    pub topics_discussed: Option<serde_json::Value>,
+    pub meeting_type: Option<String>,
+    pub overview: Option<String>,
+    pub short_summary: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct FirefliesSentence {
+    pub speaker_id: Option<serde_json::Value>,
+    pub text: Option<String>,
+    pub start_time: Option<f64>,
+    pub end_time: Option<f64>,
+}

--- a/docs/guide/integrations/_meta.json
+++ b/docs/guide/integrations/_meta.json
@@ -18,5 +18,10 @@
     "type": "file",
     "name": "jira",
     "label": "Jira"
+  },
+  {
+    "type": "file",
+    "name": "fireflies",
+    "label": "Fireflies.ai"
   }
 ]

--- a/docs/guide/integrations/fireflies.mdx
+++ b/docs/guide/integrations/fireflies.mdx
@@ -16,7 +16,7 @@ Fireflies uses a simple API key for authentication:
 
 ```bash
 # Store Fireflies API key in OS keychain
-devboy config set-secret fireflies.api_key <your-api-key>
+devboy config set-secret fireflies.token <your-api-key>
 ```
 
 ### Configuration file
@@ -31,7 +31,7 @@ Settings are stored in `~/.config/devboy-tools/config.toml`:
 ### Environment variables
 
 ```bash
-export FIREFLIES_API_KEY=your-api-key
+export DEVBOY_FIREFLIES_TOKEN=your-api-key
 ```
 
 ## Available Tools
@@ -46,8 +46,8 @@ List meeting notes with optional filters.
 | `to_date` | string | Filter to date (ISO 8601) |
 | `participants` | string[] | Filter by participant emails |
 | `host_email` | string | Filter by host email |
-| `limit` | number | Max results (default: 50, max: 50) |
-| `offset` | number | Skip N results |
+| `limit` | integer | Max results (default: 50, max: 50) |
+| `offset` | integer | Skip N results |
 
 **Example:**
 ```
@@ -82,7 +82,10 @@ Search across meetings by keywords, topics, or action items.
 | `query` | string | Yes | Search keyword |
 | `from_date` | string | No | Filter from date |
 | `to_date` | string | No | Filter to date |
-| `limit` | number | No | Max results (default: 50) |
+| `participants` | string[] | No | Filter by participant emails |
+| `host_email` | string | No | Filter by host email |
+| `limit` | integer | No | Max results (default: 50) |
+| `offset` | integer | No | Skip N results |
 
 **Example:**
 ```

--- a/docs/guide/integrations/fireflies.mdx
+++ b/docs/guide/integrations/fireflies.mdx
@@ -1,0 +1,105 @@
+import ConfigExtractor from '../../components/ConfigExtractor';
+
+# Fireflies.ai Integration
+
+DevBoy tools provides integration with [Fireflies.ai](https://fireflies.ai) for accessing meeting transcripts, summaries, and action items through AI assistants. This is the first provider in the **MeetingNotes** category.
+
+## Authentication
+
+Fireflies uses a simple API key for authentication:
+
+| Auth Method | Token Source |
+|-------------|-------------|
+| Bearer Token (API Key) | [Fireflies API Settings](https://app.fireflies.ai/integrations/custom/fireflies) |
+
+## Configuration
+
+### Basic configuration
+
+```bash
+# Store Fireflies API key in OS keychain
+devboy config set-secret fireflies.api_key <your-api-key>
+```
+
+### Configuration file
+
+Settings are stored in `~/.config/devboy-tools/config.toml`:
+
+```toml
+[fireflies]
+# API key is stored in the OS keychain, not in the config file
+```
+
+### Environment variables
+
+```bash
+export FIREFLIES_API_KEY=your-api-key
+```
+
+## Available Tools
+
+### `get_meeting_notes`
+
+List meeting notes with optional filters.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_date` | string | Filter from date (ISO 8601) |
+| `to_date` | string | Filter to date (ISO 8601) |
+| `participants` | string[] | Filter by participant emails |
+| `host_email` | string | Filter by host email |
+| `limit` | number | Max results (default: 50, max: 50) |
+| `offset` | number | Skip N results |
+
+**Example:**
+```
+get_meeting_notes from_date="2025-01-01T00:00:00Z" limit=10
+```
+
+### `get_meeting_transcript`
+
+Get the full transcript for a meeting with speaker-attributed, timestamped sentences.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `meeting_id` | string | Yes | Meeting ID from `get_meeting_notes` |
+
+**Example output:**
+```
+# Sprint Planning
+
+Showing 45 sentences
+
+[00:00] Alice: Let's discuss the sprint goals.
+[00:15] Bob: I think we should focus on the API migration.
+[01:30] Alice: Agreed. What about the timeline?
+```
+
+### `search_meeting_notes`
+
+Search across meetings by keywords, topics, or action items.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search keyword |
+| `from_date` | string | No | Filter from date |
+| `to_date` | string | No | Filter to date |
+| `limit` | number | No | Max results (default: 50) |
+
+**Example:**
+```
+search_meeting_notes query="database migration"
+```
+
+## Use Cases
+
+1. **Task Context** — When picking up a task, read meeting transcripts where requirements were discussed.
+2. **Action Item Tracking** — Cross-reference meeting action items with open issues.
+3. **Decision Archaeology** — Search past meetings to understand why technical decisions were made.
+
+## API Reference
+
+- **Endpoint:** `https://api.fireflies.ai/graphql`
+- **Protocol:** GraphQL
+- **Rate Limits:** Standard API rate limits apply
+- **Documentation:** [Fireflies GraphQL API](https://docs.fireflies.ai/graphql-api/overview)

--- a/docs/guide/integrations/fireflies.mdx
+++ b/docs/guide/integrations/fireflies.mdx
@@ -1,5 +1,3 @@
-import ConfigExtractor from '../../components/ConfigExtractor';
-
 # Fireflies.ai Integration
 
 DevBoy tools provides integration with [Fireflies.ai](https://fireflies.ai) for accessing meeting transcripts, summaries, and action items through AI assistants. This is the first provider in the **MeetingNotes** category.


### PR DESCRIPTION
## Summary

Closes #83

Adds the first **MeetingNotes** category provider — Fireflies.ai integration via GraphQL API.

### New in devboy-core:
- `MeetingNotes` variant in `ToolCategory`
- `MeetingNotesProvider` trait with `get_meetings()`, `get_transcript()`, `search_meetings()`
- Unified types: `MeetingNote`, `MeetingTranscript`, `TranscriptSentence`, `MeetingSpeaker`, `MeetingFilter`

### New crate: `devboy-fireflies`
- GraphQL client for Fireflies.ai API (`https://api.fireflies.ai/graphql`)
- Bearer API key authentication
- Duration conversion (Fireflies minutes → unified seconds)
- Array-or-string parsing for AI summary fields (keywords, action items, topics)
- `FirefliesSchemaEnricher` for MeetingNotes category

### New MCP tools:
| Tool | Description |
|------|-------------|
| `get_meeting_notes` | List meetings with filters (date range, participants, host) |
| `get_meeting_transcript` | Full transcript with speaker-attributed timestamped sentences |
| `search_meeting_notes` | Search across meetings by keyword |

### Architecture:
- Separate dispatch path in executor for `MeetingNotesProvider` (parallel to existing `Provider` dispatch)
- `create_meeting_notes_provider()` in factory alongside existing `create_provider()`
- Compact text formatting for transcripts (`[MM:SS] Speaker: text`)

## Test plan

- [x] All 122 existing tests pass
- [x] New unit tests for `parse_array_or_string` and duration conversion
- [x] Integration test with real Fireflies API key (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)