### PR TITLE
feat: format pipeline metadata — compression stats + token estimates (#93)

### DIFF
--- a/crates/devboy-core/src/config.rs
+++ b/crates/devboy-core/src/config.rs
@@ -1138,7 +1138,7 @@ mod tests {
             ContextConfig {
                 github: Some(GitHubConfig {
                     owner: "meteora-pro".to_string(),
-                    repo: "dev-boy-monorepo".to_string(),
+                    repo: "my-project".to_string(),
                     base_url: None,
                 }),
                 clickup: Some(ClickUpConfig {

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -5,22 +5,60 @@
 
 use devboy_core::Result;
 use devboy_format_pipeline::{OutputFormat, Pipeline, PipelineConfig};
+use serde::Serialize;
 
 use crate::output::ToolOutput;
 
+/// Metadata about formatting result — compression stats, token estimates.
+#[derive(Debug, Clone, Serialize)]
+pub struct FormatMetadata {
+    /// Size of raw JSON input (UTF-8 bytes)
+    pub raw_chars: usize,
+    /// Size of formatted output (UTF-8 bytes)
+    pub output_chars: usize,
+    /// Size of TOON/JSON output BEFORE budget trimming (UTF-8 bytes).
+    /// If no trimming occurred, equals output_chars.
+    /// toon_saved = raw_chars - pre_trim_chars
+    /// trimmed_chars = pre_trim_chars - output_chars
+    pub pre_trim_chars: usize,
+    /// Estimated token count (output_chars / 3.5)
+    pub estimated_tokens: usize,
+    /// Compression ratio: output_chars / raw_chars (< 1.0 = savings)
+    pub compression_ratio: f32,
+    /// Output format used
+    pub format: String,
+    /// Whether output was truncated by budget trimming
+    pub truncated: bool,
+    /// Total items before truncation (e.g., 50 issues)
+    pub total_items: Option<usize>,
+    /// Items included after truncation (e.g., 20 issues)
+    pub included_items: usize,
+}
+
+/// Result of formatting a tool output — content + metadata.
+#[derive(Debug, Clone, Serialize)]
+pub struct FormatResult {
+    /// Formatted text content (TOON, JSON, etc.)
+    pub content: String,
+    /// Formatting metadata (sizes, compression, tokens)
+    pub metadata: FormatMetadata,
+}
+
 /// Format a `ToolOutput` to text using the pipeline.
+///
+/// Returns `FormatResult` with content and metadata (compression stats, token estimates).
 ///
 /// # Arguments
 /// * `output` — typed result from executor
 /// * `format` — output format string ("toon", "json"), defaults to "toon"
-/// * `tool_name` — tool name for strategy resolution (e.g. "get_issues")
+/// * `tool_name` — tool name (reserved for future strategy resolution)
 /// * `config` — optional pipeline config override
 pub fn format_output(
     output: ToolOutput,
     format: Option<&str>,
     _tool_name: Option<&str>,
     config: Option<PipelineConfig>,
-) -> Result<String> {
+) -> Result<FormatResult> {
     let output_format = match format {
         Some("json") => OutputFormat::Json,
         _ => OutputFormat::Toon,
@@ -37,42 +75,83 @@ pub fn format_output(
         ..pipeline_config
     };
 
+    let format_name = match output_format {
+        OutputFormat::Json => "json",
+        OutputFormat::Toon => "toon",
+    };
+
     let pipeline = Pipeline::with_config(pipeline_config);
 
+    // Helper: convert TransformOutput to FormatResult
+    let to_result = |t: devboy_format_pipeline::TransformOutput| -> FormatResult {
+        let content = t.to_string_with_hints();
+        let output_chars = content.len();
+        let raw_chars = if t.raw_chars > 0 {
+            t.raw_chars
+        } else {
+            output_chars
+        };
+        let pre_trim = if t.pre_trim_chars > 0 {
+            t.pre_trim_chars
+        } else {
+            output_chars
+        };
+        FormatResult {
+            metadata: FormatMetadata {
+                raw_chars,
+                output_chars,
+                pre_trim_chars: pre_trim,
+                estimated_tokens: output_chars * 10 / 35, // chars / 3.5
+                compression_ratio: if raw_chars > 0 {
+                    output_chars as f32 / raw_chars as f32
+                } else {
+                    1.0
+                },
+                format: format_name.to_string(),
+                truncated: t.truncated,
+                total_items: t.total_count,
+                included_items: t.included_count,
+            },
+            content,
+        }
+    };
+
+    // Helper: wrap plain text (no pipeline transform)
+    let text_result = |text: String| -> FormatResult {
+        let chars = text.len();
+        FormatResult {
+            metadata: FormatMetadata {
+                raw_chars: chars,
+                output_chars: chars,
+                pre_trim_chars: chars,
+                estimated_tokens: chars * 10 / 35,
+                compression_ratio: 1.0,
+                format: "text".to_string(),
+                truncated: false,
+                total_items: None,
+                included_items: 0,
+            },
+            content: text,
+        }
+    };
+
     match output {
-        ToolOutput::Issues(issues) => {
-            let result = pipeline.transform_issues(issues)?;
-            Ok(result.to_string_with_hints())
-        }
-        ToolOutput::SingleIssue(issue) => {
-            let result = pipeline.transform_issues(vec![*issue])?;
-            Ok(result.to_string_with_hints())
-        }
-        ToolOutput::MergeRequests(mrs) => {
-            let result = pipeline.transform_merge_requests(mrs)?;
-            Ok(result.to_string_with_hints())
-        }
+        ToolOutput::Issues(issues) => Ok(to_result(pipeline.transform_issues(issues)?)),
+        ToolOutput::SingleIssue(issue) => Ok(to_result(pipeline.transform_issues(vec![*issue])?)),
+        ToolOutput::MergeRequests(mrs) => Ok(to_result(pipeline.transform_merge_requests(mrs)?)),
         ToolOutput::SingleMergeRequest(mr) => {
-            let result = pipeline.transform_merge_requests(vec![*mr])?;
-            Ok(result.to_string_with_hints())
+            Ok(to_result(pipeline.transform_merge_requests(vec![*mr])?))
         }
         ToolOutput::Discussions(discussions) => {
-            let result = pipeline.transform_discussions(discussions)?;
-            Ok(result.to_string_with_hints())
+            Ok(to_result(pipeline.transform_discussions(discussions)?))
         }
-        ToolOutput::Diffs(diffs) => {
-            let result = pipeline.transform_diffs(diffs)?;
-            Ok(result.to_string_with_hints())
-        }
-        ToolOutput::Comments(comments) => {
-            let result = pipeline.transform_comments(comments)?;
-            Ok(result.to_string_with_hints())
-        }
-        ToolOutput::Pipeline(info) => Ok(format_pipeline(&info)),
-        ToolOutput::JobLog(log) => Ok(format_job_log(&log)),
-        ToolOutput::Statuses(statuses) => Ok(format_statuses(&statuses)),
-        ToolOutput::Users(users) => Ok(format_users(&users)),
-        ToolOutput::Text(text) => Ok(text),
+        ToolOutput::Diffs(diffs) => Ok(to_result(pipeline.transform_diffs(diffs)?)),
+        ToolOutput::Comments(comments) => Ok(to_result(pipeline.transform_comments(comments)?)),
+        ToolOutput::Pipeline(info) => Ok(text_result(format_pipeline(&info))),
+        ToolOutput::JobLog(log) => Ok(text_result(format_job_log(&log))),
+        ToolOutput::Statuses(statuses) => Ok(text_result(format_statuses(&statuses))),
+        ToolOutput::Users(users) => Ok(text_result(format_users(&users))),
+        ToolOutput::Text(text) => Ok(text_result(text)),
     }
 }
 
@@ -211,7 +290,7 @@ pub async fn execute_and_format(
     args: serde_json::Value,
     ctx: &crate::context::AdditionalContext,
     pipeline_config: Option<PipelineConfig>,
-) -> Result<String> {
+) -> Result<FormatResult> {
     // Extract format from args before execution
     let format = args
         .get("format")
@@ -247,43 +326,103 @@ mod tests {
     #[test]
     fn test_format_issues_toon() {
         let output = ToolOutput::Issues(vec![sample_issue()]);
-        let result = format_output(output, Some("toon"), None, None).unwrap();
+        let result = format_output(output, Some("toon"), None, None)
+            .unwrap()
+            .content;
         assert!(result.contains("gh#1"));
         assert!(result.contains("Test Issue"));
     }
 
     #[test]
+    fn test_format_metadata_toon_compression() {
+        let output = ToolOutput::Issues(vec![sample_issue()]);
+        let result = format_output(output, Some("toon"), None, None).unwrap();
+
+        assert!(result.metadata.raw_chars > 0, "raw_chars should be > 0");
+        assert!(
+            result.metadata.output_chars > 0,
+            "output_chars should be > 0"
+        );
+        assert!(result.metadata.estimated_tokens > 0, "tokens should be > 0");
+        assert_eq!(result.metadata.format, "toon");
+        assert!(!result.metadata.truncated);
+        // Compression ratio should be reasonable (TOON may slightly expand very small inputs)
+        assert!(
+            result.metadata.compression_ratio < 2.0,
+            "compression_ratio should be reasonable, got {}",
+            result.metadata.compression_ratio
+        );
+    }
+
+    #[test]
+    fn test_format_metadata_text_passthrough() {
+        let output = ToolOutput::Text("plain text".into());
+        let result = format_output(output, None, None, None).unwrap();
+
+        assert_eq!(result.metadata.raw_chars, 10);
+        assert_eq!(result.metadata.output_chars, 10);
+        assert_eq!(result.metadata.compression_ratio, 1.0);
+        assert_eq!(result.metadata.format, "text");
+        assert!(!result.metadata.truncated);
+    }
+
+    #[test]
+    fn test_format_metadata_truncated() {
+        let output = ToolOutput::Issues(vec![sample_issue()]);
+        let config = PipelineConfig {
+            max_chars: 50, // very small — will truncate
+            ..PipelineConfig::default()
+        };
+        let result = format_output(output, Some("toon"), None, Some(config)).unwrap();
+
+        assert!(result.metadata.truncated);
+        // output_chars tracks content size (may include hint text appended after truncation)
+        assert!(
+            result.metadata.output_chars < result.metadata.raw_chars,
+            "truncated output ({}) should be smaller than raw ({})",
+            result.metadata.output_chars,
+            result.metadata.raw_chars
+        );
+    }
+
+    #[test]
     fn test_format_issues_json() {
         let output = ToolOutput::Issues(vec![sample_issue()]);
-        let result = format_output(output, Some("json"), None, None).unwrap();
+        let result = format_output(output, Some("json"), None, None)
+            .unwrap()
+            .content;
         assert!(result.contains("gh#1"));
     }
 
     #[test]
     fn test_format_issues_toon_explicit() {
         let output = ToolOutput::Issues(vec![sample_issue()]);
-        let result = format_output(output, Some("toon"), None, None).unwrap();
+        let result = format_output(output, Some("toon"), None, None)
+            .unwrap()
+            .content;
         assert!(result.contains("gh#1"));
     }
 
     #[test]
     fn test_format_text_passthrough() {
         let output = ToolOutput::Text("Comment created".into());
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert_eq!(result, "Comment created");
     }
 
     #[test]
     fn test_format_default_is_toon() {
         let output = ToolOutput::Issues(vec![sample_issue()]);
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("gh#1"));
     }
 
     #[test]
     fn test_format_single_issue() {
         let output = ToolOutput::SingleIssue(Box::new(sample_issue()));
-        let result = format_output(output, Some("toon"), None, None).unwrap();
+        let result = format_output(output, Some("toon"), None, None)
+            .unwrap()
+            .content;
         assert!(result.contains("gh#1"));
     }
 
@@ -310,14 +449,18 @@ mod tests {
     #[test]
     fn test_format_merge_requests() {
         let output = ToolOutput::MergeRequests(vec![sample_mr()]);
-        let result = format_output(output, Some("toon"), None, None).unwrap();
+        let result = format_output(output, Some("toon"), None, None)
+            .unwrap()
+            .content;
         assert!(result.contains("pr#1"));
     }
 
     #[test]
     fn test_format_single_merge_request() {
         let output = ToolOutput::SingleMergeRequest(Box::new(sample_mr()));
-        let result = format_output(output, Some("toon"), None, None).unwrap();
+        let result = format_output(output, Some("toon"), None, None)
+            .unwrap()
+            .content;
         assert!(result.contains("pr#1"));
     }
 
@@ -337,7 +480,9 @@ mod tests {
             }],
             position: None,
         }]);
-        let result = format_output(output, Some("toon"), None, None).unwrap();
+        let result = format_output(output, Some("toon"), None, None)
+            .unwrap()
+            .content;
         assert!(result.contains("Review comment"));
     }
 
@@ -353,7 +498,9 @@ mod tests {
             additions: Some(1),
             deletions: Some(0),
         }]);
-        let result = format_output(output, Some("toon"), None, None).unwrap();
+        let result = format_output(output, Some("toon"), None, None)
+            .unwrap()
+            .content;
         assert!(result.contains("src/main.rs"));
     }
 
@@ -367,7 +514,9 @@ mod tests {
             updated_at: None,
             position: None,
         }]);
-        let result = format_output(output, Some("json"), None, None).unwrap();
+        let result = format_output(output, Some("json"), None, None)
+            .unwrap()
+            .content;
         assert!(result.contains("A comment body"));
     }
 
@@ -379,7 +528,9 @@ mod tests {
             max_chars: 500,
             ..PipelineConfig::default()
         };
-        let result = format_output(output, Some("toon"), None, Some(config)).unwrap();
+        let result = format_output(output, Some("toon"), None, Some(config))
+            .unwrap()
+            .content;
         assert!(result.contains("gh#1"));
     }
 
@@ -416,7 +567,7 @@ mod tests {
                 error_snippet: Some("error: test failed".into()),
             }],
         }));
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("Pipeline 100"));
         assert!(result.contains("failed"));
         assert!(result.contains("main"));
@@ -434,7 +585,7 @@ mod tests {
             mode: "smart".into(),
             total_lines: Some(100),
         }));
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("Job Log"));
         assert!(result.contains("202"));
         assert!(result.contains("smart"));
@@ -461,7 +612,7 @@ mod tests {
             stages: vec![],
             failed_jobs: vec![],
         }));
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("Pipeline 200"));
         assert!(result.contains("success"));
         assert!(result.contains("develop"));
@@ -488,7 +639,7 @@ mod tests {
             stages: vec![],
             failed_jobs: vec![],
         }));
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("running"));
         assert!(result.contains("https://ci.example.com/301"));
         assert!(result.contains("60s"));
@@ -508,7 +659,7 @@ mod tests {
             stages: vec![],
             failed_jobs: vec![],
         }));
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("pending"));
     }
 
@@ -526,7 +677,7 @@ mod tests {
             stages: vec![],
             failed_jobs: vec![],
         }));
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("canceled"));
     }
 
@@ -553,7 +704,7 @@ mod tests {
             }],
             failed_jobs: vec![],
         }));
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("[logs](https://ci.example.com/jobs/j1)"));
     }
 
@@ -576,7 +727,7 @@ mod tests {
                 error_snippet: None,
             }],
         }));
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("lint"));
         assert!(result.contains("fj1"));
         assert!(!result.contains("```")); // no code block when no snippet
@@ -602,7 +753,7 @@ mod tests {
                 order: None,
             },
         ]);
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("Available Statuses"));
         assert!(result.contains("To Do"));
         assert!(result.contains("In Progress"));
@@ -614,7 +765,7 @@ mod tests {
     #[test]
     fn test_format_statuses_empty() {
         let output = ToolOutput::Statuses(vec![]);
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert_eq!(result, "No statuses found.");
     }
 
@@ -638,7 +789,7 @@ mod tests {
                 avatar_url: None,
             },
         ]);
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("# Users"));
         assert!(result.contains("johndoe"));
         assert!(result.contains("John Doe"));
@@ -650,7 +801,7 @@ mod tests {
     #[test]
     fn test_format_users_empty() {
         let output = ToolOutput::Users(vec![]);
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert_eq!(result, "No users found.");
     }
 
@@ -665,7 +816,7 @@ mod tests {
             mode: "full".into(),
             total_lines: None,
         }));
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("Job Log (999)"));
         assert!(result.contains("**Mode:** full"));
         assert!(!result.contains("Total lines"));
@@ -677,7 +828,7 @@ mod tests {
     #[test]
     fn test_format_text_empty_string() {
         let output = ToolOutput::Text("".into());
-        let result = format_output(output, None, None, None).unwrap();
+        let result = format_output(output, None, None, None).unwrap().content;
         assert_eq!(result, "");
     }
 
@@ -685,7 +836,9 @@ mod tests {
     fn test_format_text_with_json_format_param() {
         // Even with "json" format, Text variant just passes through
         let output = ToolOutput::Text("raw text".into());
-        let result = format_output(output, Some("json"), None, None).unwrap();
+        let result = format_output(output, Some("json"), None, None)
+            .unwrap()
+            .content;
         assert_eq!(result, "raw text");
     }
 }

--- a/crates/devboy-executor/src/lib.rs
+++ b/crates/devboy-executor/src/lib.rs
@@ -57,6 +57,6 @@ pub use devboy_core::{ToolEnricher, ToolSchema, sanitize_field_name};
 pub use enricher::PipelineFormatEnricher;
 pub use executor::{Executor, SUPPORTED_TOOLS};
 pub use factory::create_enricher;
-pub use format::{execute_and_format, format_output};
+pub use format::{FormatMetadata, FormatResult, execute_and_format, format_output};
 pub use output::ToolOutput;
 pub use tools::ToolDefinition;

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -1219,7 +1219,7 @@ impl ToolHandler {
                         Some("get_pipeline"),
                         None,
                     ) {
-                        Ok(text) => ToolCallResult::text(text),
+                        Ok(result) => ToolCallResult::text(result.content),
                         Err(e) => ToolCallResult::error(format!("Format error: {}", e)),
                     };
                 }
@@ -1286,7 +1286,7 @@ impl ToolHandler {
                         Some("get_job_logs"),
                         None,
                     ) {
-                        Ok(text) => ToolCallResult::text(text),
+                        Ok(result) => ToolCallResult::text(result.content),
                         Err(e) => ToolCallResult::error(format!("Format error: {}", e)),
                     };
                 }

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -52,11 +52,19 @@ pub struct TransformOutput {
     pub agent_hint: Option<String>,
     /// Cursor for fetching the next page (if overflow exists)
     pub page_cursor: Option<String>,
+    /// Size of raw input data before formatting (UTF-8 bytes)
+    pub raw_chars: usize,
+    /// Size of formatted output (UTF-8 bytes) — updated after apply_char_limit
+    pub output_chars: usize,
+    /// Size of output BEFORE budget trimming (UTF-8 bytes).
+    /// Set by apply_char_limit when truncation occurs.
+    pub pre_trim_chars: usize,
 }
 
 impl TransformOutput {
     /// Create a new output with content.
     pub fn new(content: String) -> Self {
+        let output_chars = content.len();
         Self {
             content,
             truncated: false,
@@ -64,7 +72,16 @@ impl TransformOutput {
             included_count: 0,
             agent_hint: None,
             page_cursor: None,
+            raw_chars: 0,
+            output_chars,
+            pre_trim_chars: 0,
         }
+    }
+
+    /// Set raw input size (before formatting).
+    pub fn with_raw_chars(mut self, raw_chars: usize) -> Self {
+        self.raw_chars = raw_chars;
+        self
     }
 
     /// Mark output as truncated with a hint.
@@ -152,12 +169,15 @@ impl Pipeline {
         let truncated_issues = self.truncate_items(issues);
         let included = truncated_issues.len();
 
+        let raw_json = serde_json::to_string(&truncated_issues)?;
+        let raw_chars = raw_json.len();
+
         let content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&truncated_issues)?,
             OutputFormat::Toon => toon::encode_issues(&truncated_issues, toon::TrimLevel::Full)?,
         };
 
-        let mut output = TransformOutput::new(content);
+        let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
         output.included_count = included;
 
         if included < total && self.config.include_hints {
@@ -174,6 +194,9 @@ impl Pipeline {
         let truncated_mrs = self.truncate_items(mrs);
         let included = truncated_mrs.len();
 
+        let raw_json = serde_json::to_string(&truncated_mrs)?;
+        let raw_chars = raw_json.len();
+
         let content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&truncated_mrs)?,
             OutputFormat::Toon => {
@@ -181,7 +204,7 @@ impl Pipeline {
             }
         };
 
-        let mut output = TransformOutput::new(content);
+        let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
         output.included_count = included;
 
         if included < total && self.config.include_hints {
@@ -208,12 +231,15 @@ impl Pipeline {
 
         let included = truncated_diffs.len();
 
+        let raw_json = serde_json::to_string(&truncated_diffs)?;
+        let raw_chars = raw_json.len();
+
         let content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&truncated_diffs)?,
             OutputFormat::Toon => toon::encode_diffs(&truncated_diffs)?,
         };
 
-        let mut output = TransformOutput::new(content);
+        let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
         output.included_count = included;
 
         if included < total && self.config.include_hints {
@@ -230,12 +256,15 @@ impl Pipeline {
         let truncated_comments = self.truncate_items(comments);
         let included = truncated_comments.len();
 
+        let raw_json = serde_json::to_string(&truncated_comments)?;
+        let raw_chars = raw_json.len();
+
         let content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&truncated_comments)?,
             OutputFormat::Toon => toon::encode_comments(&truncated_comments)?,
         };
 
-        let mut output = TransformOutput::new(content);
+        let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
         output.included_count = included;
 
         if included < total && self.config.include_hints {
@@ -252,12 +281,15 @@ impl Pipeline {
         let truncated_discussions = self.truncate_items(discussions);
         let included = truncated_discussions.len();
 
+        let raw_json = serde_json::to_string(&truncated_discussions)?;
+        let raw_chars = raw_json.len();
+
         let content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&truncated_discussions)?,
             OutputFormat::Toon => toon::encode_discussions(&truncated_discussions)?,
         };
 
-        let mut output = TransformOutput::new(content);
+        let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
         output.included_count = included;
 
         if included < total && self.config.include_hints {
@@ -276,7 +308,9 @@ impl Pipeline {
     /// Apply character limit to output.
     fn apply_char_limit(&self, mut output: TransformOutput) -> TransformOutput {
         if output.content.len() > self.config.max_chars {
+            output.pre_trim_chars = output.output_chars; // save size before trimming
             output.content = truncation::truncate_string(&output.content, self.config.max_chars);
+            output.output_chars = output.content.len();
             if !output.truncated {
                 output.truncated = true;
                 output.agent_hint = Some(format!(

--- a/docs/guide/architecture/format-pipeline.md
+++ b/docs/guide/architecture/format-pipeline.md
@@ -24,8 +24,23 @@ ToolOutput (typed data)
     ▼
 TransformOutput {
     content: String,        // TOON or JSON
+    raw_chars: usize,       // input size (JSON)
+    output_chars: usize,    // output size (TOON/JSON)
     page_cursor: Option,    // for next page
     agent_hint: Option,     // pagination hint
+}
+    │
+    ▼
+FormatResult {
+    content: String,            // final text
+    metadata: FormatMetadata {
+        raw_chars,              // input JSON size
+        output_chars,           // output size
+        estimated_tokens,       // output_chars * 10 / 35
+        compression_ratio,      // output / raw (< 1.0 = savings)
+        format,                 // "toon" | "json" | "text"
+        truncated,              // budget trimming applied?
+    }
 }
 ```
 
@@ -278,3 +293,39 @@ crates/plugins/format-pipeline/src/
 ├── pagination.rs       # Cursor-based pagination
 └── truncation.rs       # String/diff truncation utilities
 ```
+
+## Metadata & Compression Stats
+
+Every `format_output()` call returns `FormatResult` with metadata:
+
+```rust
+use devboy_executor::{format_output, FormatResult, FormatMetadata};
+
+let result: FormatResult = format_output(output, Some("toon"), Some("get_issues"), None)?;
+
+println!("Content: {} chars", result.content.len());
+println!("Raw JSON: {} chars", result.metadata.raw_chars);
+println!("Output: {} chars", result.metadata.output_chars);
+println!("Tokens: ~{}", result.metadata.estimated_tokens);
+println!("Compression: {:.0}%", (1.0 - result.metadata.compression_ratio) * 100.0);
+println!("Truncated: {}", result.metadata.truncated);
+```
+
+### NAPI Bridge Integration
+
+When using `format_output()` from a NAPI bridge, serialize `FormatResult` as JSON to expose metadata:
+
+```rust
+let result = devboy_executor::format_output(output, format, tool_name, None)?;
+let json = serde_json::json!({
+    "content": result.content,
+    "metadata": result.metadata,
+});
+// Returns: { content: "...", metadata: { raw_chars, output_chars, estimated_tokens, ... } }
+```
+
+> Note: The NAPI `callToolWithMetadata()` function is implemented in the consuming project's NAPI bridge layer, not in this repository.
+
+### Token Estimation
+
+Tokens are estimated as `chars * 10 / 35` (~chars / 3.5), which approximates Claude's tokenizer for mixed English/code content.

--- a/docs/guide/configuration/contexts.md
+++ b/docs/guide/configuration/contexts.md
@@ -17,7 +17,7 @@ repo = "devboy-tools"
 
 [contexts.dashboard.github]
 owner = "meteora-pro"
-repo = "dev-boy-monorepo"
+repo = "my-project"
 
 [contexts.dashboard.clickup]
 list_id = "abc123"
@@ -108,7 +108,7 @@ repo = "devboy-tools"
 
 [contexts.dashboard.github]
 owner = "meteora-pro"
-repo = "dev-boy-monorepo"
+repo = "my-project"
 
 [contexts.dashboard.gitlab]
 url = "https://gitlab.example.com"

--- a/docs/guide/configuration/proxy.md
+++ b/docs/guide/configuration/proxy.md
@@ -29,7 +29,7 @@ The token is automatically stored in keychain as `proxy.my-server.token`.
 
 ## Use case
 
-You have a remote MCP server (e.g. DevBoy Cloud) with additional tools (knowledge base, meeting notes, messengers). Instead of configuring multiple MCP servers in your AI assistant, you configure DevBoy to proxy them all through one connection.
+You have a remote MCP server with additional tools (knowledge base, meeting notes, messengers). Instead of configuring multiple MCP servers in your AI assistant, you configure DevBoy to proxy them all through one connection.
 
 ## Configuration
 
@@ -64,7 +64,7 @@ devboy config set-secret devboy-cloud.token <YOUR_TOKEN>
 ### Transport types
 
 - **`sse`** — Legacy MCP transport. Uses GET for SSE stream, POST for requests. Used by most self-hosted MCP servers.
-- **`streamable-http`** — Modern HTTP POST-based transport with `mcp-session-id` header. Used by DevBoy Cloud and other hosted MCP services.
+- **`streamable-http`** — Modern HTTP POST-based transport with `mcp-session-id` header. Used by hosted MCP services.
 
 ### Multiple servers
 


### PR DESCRIPTION
## Summary

Add `FormatResult` and `FormatMetadata` structs to expose compression statistics and token estimates from the format pipeline.

## Changes

### format-pipeline crate
- `TransformOutput`: add `raw_chars` and `output_chars` fields
- `with_raw_chars()` builder method
- All `transform_*()` methods compute `raw_chars` from JSON serialization

### devboy-executor
- New `FormatResult` struct: `{ content, metadata }`
- New `FormatMetadata` struct: `{ raw_chars, output_chars, estimated_tokens, compression_ratio, format, truncated }`
- `format_output()` returns `FormatResult` instead of `String`
- `execute_and_format()` returns `FormatResult`
- All tests updated to use `result.content`

### devboy-mcp
- `handlers.rs`: use `result.content` from `format_output()`

### NAPI bridge (monorepo)
- New `call_tool_with_metadata()` function
- Returns JSON with `content` + `metadata` (sizes, compression, tokens)
- Existing `call_tool()` unchanged (backward compatible)

## Test Plan

- [x] 291 workspace tests pass
- [x] NAPI builds successfully
- [x] `cargo clippy --workspace` clean

## Breaking Change

`format_output()` now returns `FormatResult` instead of `String`. Use `.content` for the text output.

Closes #93 (Part 1: metadata + NAPI)