### PR TITLE
fix: remove max_items, integrate budget pipeline, add ProviderResult (#95)

### DIFF
--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -1495,7 +1495,8 @@ async fn handle_issues_command(state: &str, limit: u32) -> Result<()> {
         let issues = client
             .get_issues(filter)
             .await
-            .context("Failed to fetch issues")?;
+            .context("Failed to fetch issues")?
+            .items;
 
         if issues.is_empty() {
             println!("No issues found with state: {}", state);
@@ -1544,7 +1545,8 @@ async fn handle_mrs_command(state: &str, limit: u32) -> Result<()> {
         let prs = client
             .get_merge_requests(filter)
             .await
-            .context("Failed to fetch PRs")?;
+            .context("Failed to fetch PRs")?
+            .items;
 
         if prs.is_empty() {
             println!("No pull requests found with state: {}", state);
@@ -2920,7 +2922,7 @@ async fn run_benchmark(
         limit: Some(limit),
         ..Default::default()
     };
-    let issues = client.get_issues(filter).await?;
+    let issues = client.get_issues(filter).await?.items;
     if !issues.is_empty() {
         print_comparison("Issues", &issues, budget)?;
     } else {
@@ -2934,7 +2936,7 @@ async fn run_benchmark(
         limit: Some(limit),
         ..Default::default()
     };
-    let mrs = client.get_merge_requests(mr_filter).await?;
+    let mrs = client.get_merge_requests(mr_filter).await?.items;
     if !mrs.is_empty() {
         print_comparison("Pull Requests", &mrs, budget)?;
     } else {
@@ -2946,8 +2948,8 @@ async fn run_benchmark(
     if let Some(mr) = open_mrs.first() {
         println!("\nFetching diffs for {}...", mr.key);
         match client.get_diffs(&mr.key).await {
-            Ok(diffs) if !diffs.is_empty() => {
-                print_comparison("Diffs", &diffs, budget)?;
+            Ok(result) if !result.items.is_empty() => {
+                print_comparison("Diffs", &result.items, budget)?;
             }
             Ok(_) => println!("  No diffs in this PR."),
             Err(e) => println!("  Failed to fetch diffs: {}", e),

--- a/crates/devboy-cli/tests/common/test_provider.rs
+++ b/crates/devboy-cli/tests/common/test_provider.rs
@@ -277,7 +277,8 @@ impl IssueProvider for TestProvider {
                 created_at: Some("2024-01-01T00:00:00Z".to_string()),
                 updated_at: None,
                 position: None,
-            }].into())
+            }]
+            .into())
         }
     }
 
@@ -333,7 +334,8 @@ impl MergeRequestProvider for TestProvider {
                     position: None,
                 }],
                 position: None,
-            }].into())
+            }]
+            .into())
         }
     }
 
@@ -354,7 +356,8 @@ impl MergeRequestProvider for TestProvider {
                 diff: "+added line\n-removed line".to_string(),
                 additions: Some(1),
                 deletions: Some(1),
-            }].into())
+            }]
+            .into())
         }
     }
 
@@ -404,7 +407,11 @@ mod tests {
     async fn test_provider_loads_fixtures_in_replay() {
         temp_env::async_with_vars([("GITHUB_TOKEN", None::<&str>)], async {
             let provider = TestProvider::github();
-            let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
+            let issues = provider
+                .get_issues(IssueFilter::default())
+                .await
+                .unwrap()
+                .items;
             assert!(!issues.is_empty());
             assert!(issues[0].key.starts_with("gh#"));
         })

--- a/crates/devboy-cli/tests/common/test_provider.rs
+++ b/crates/devboy-cli/tests/common/test_provider.rs
@@ -7,7 +7,7 @@ use std::env;
 use async_trait::async_trait;
 use devboy_core::{
     Comment, CreateCommentInput, CreateIssueInput, Discussion, Error, FileDiff, Issue, IssueFilter,
-    IssueProvider, MergeRequest, MergeRequestProvider, MrFilter, Provider, Result,
+    IssueProvider, MergeRequest, MergeRequestProvider, MrFilter, Provider, ProviderResult, Result,
     UpdateIssueInput, User,
 };
 use devboy_github::GitHubClient;
@@ -87,7 +87,8 @@ impl TestProvider {
                 };
 
                 match client.get_issues(filter).await {
-                    Ok(issues) => {
+                    Ok(result) => {
+                        let issues = result.items;
                         // Save to fixtures for future replay
                         if let Err(e) = self.fixture_provider.save_issues(&issues) {
                             eprintln!("⚠️  Failed to save fixtures: {}", e);
@@ -123,7 +124,8 @@ impl TestProvider {
                 };
 
                 match client.get_merge_requests(filter).await {
-                    Ok(mrs) => {
+                    Ok(result) => {
+                        let mrs = result.items;
                         // Save to fixtures for future replay
                         if let Err(e) = self.fixture_provider.save_merge_requests(&mrs) {
                             eprintln!("⚠️  Failed to save fixtures: {}", e);
@@ -230,17 +232,19 @@ impl TestProvider {
 /// Implement IssueProvider for TestProvider.
 #[async_trait]
 impl IssueProvider for TestProvider {
-    async fn get_issues(&self, filter: IssueFilter) -> Result<Vec<Issue>> {
+    async fn get_issues(&self, filter: IssueFilter) -> Result<ProviderResult<Issue>> {
         self.get_issues_with_fallback(filter)
             .await
             .into_result()
+            .map(|v| v.into())
             .map_err(Error::Config)
     }
 
     async fn get_issue(&self, key: &str) -> Result<Issue> {
         // Find in the list
-        let issues = self.get_issues(IssueFilter::default()).await?;
-        issues
+        let result = self.get_issues(IssueFilter::default()).await?;
+        result
+            .items
             .into_iter()
             .find(|i| i.key == key)
             .ok_or_else(|| Error::NotFound(format!("Issue {} not found", key)))
@@ -258,7 +262,7 @@ impl IssueProvider for TestProvider {
         ))
     }
 
-    async fn get_comments(&self, issue_key: &str) -> Result<Vec<Comment>> {
+    async fn get_comments(&self, issue_key: &str) -> Result<ProviderResult<Comment>> {
         if self.mode.is_record() {
             let Some(client) = &self.github_client else {
                 return Err(Error::Config("GitHub client not initialized".to_string()));
@@ -273,7 +277,7 @@ impl IssueProvider for TestProvider {
                 created_at: Some("2024-01-01T00:00:00Z".to_string()),
                 updated_at: None,
                 position: None,
-            }])
+            }].into())
         }
     }
 
@@ -291,21 +295,24 @@ impl IssueProvider for TestProvider {
 /// Implement MergeRequestProvider for TestProvider.
 #[async_trait]
 impl MergeRequestProvider for TestProvider {
-    async fn get_merge_requests(&self, filter: MrFilter) -> Result<Vec<MergeRequest>> {
+    async fn get_merge_requests(&self, filter: MrFilter) -> Result<ProviderResult<MergeRequest>> {
         self.get_merge_requests_with_fallback(filter)
             .await
             .into_result()
+            .map(|v| v.into())
             .map_err(Error::Config)
     }
 
     async fn get_merge_request(&self, key: &str) -> Result<MergeRequest> {
-        let mrs = self.get_merge_requests(MrFilter::default()).await?;
-        mrs.into_iter()
+        let result = self.get_merge_requests(MrFilter::default()).await?;
+        result
+            .items
+            .into_iter()
             .find(|mr| mr.key == key)
             .ok_or_else(|| Error::NotFound(format!("MR {} not found", key)))
     }
 
-    async fn get_discussions(&self, mr_key: &str) -> Result<Vec<Discussion>> {
+    async fn get_discussions(&self, mr_key: &str) -> Result<ProviderResult<Discussion>> {
         if self.mode.is_record() {
             let Some(client) = &self.github_client else {
                 return Err(Error::Config("GitHub client not initialized".to_string()));
@@ -326,11 +333,11 @@ impl MergeRequestProvider for TestProvider {
                     position: None,
                 }],
                 position: None,
-            }])
+            }].into())
         }
     }
 
-    async fn get_diffs(&self, mr_key: &str) -> Result<Vec<FileDiff>> {
+    async fn get_diffs(&self, mr_key: &str) -> Result<ProviderResult<FileDiff>> {
         if self.mode.is_record() {
             let Some(client) = &self.github_client else {
                 return Err(Error::Config("GitHub client not initialized".to_string()));
@@ -347,7 +354,7 @@ impl MergeRequestProvider for TestProvider {
                 diff: "+added line\n-removed line".to_string(),
                 additions: Some(1),
                 deletions: Some(1),
-            }])
+            }].into())
         }
     }
 
@@ -397,7 +404,7 @@ mod tests {
     async fn test_provider_loads_fixtures_in_replay() {
         temp_env::async_with_vars([("GITHUB_TOKEN", None::<&str>)], async {
             let provider = TestProvider::github();
-            let issues = provider.get_issues(IssueFilter::default()).await.unwrap();
+            let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
             assert!(!issues.is_empty());
             assert!(issues[0].key.starts_with("gh#"));
         })
@@ -411,7 +418,8 @@ mod tests {
             let mrs = provider
                 .get_merge_requests(MrFilter::default())
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
             assert!(!mrs.is_empty());
             assert!(mrs[0].key.starts_with("pr#"));
         })

--- a/crates/devboy-cli/tests/github_test.rs
+++ b/crates/devboy-cli/tests/github_test.rs
@@ -51,7 +51,7 @@ async fn test_mode_detection() {
 async fn test_get_issues() {
     let provider = TestProvider::github();
 
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap();
+    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
 
     assert!(!issues.is_empty(), "Should have at least one issue");
 
@@ -76,7 +76,7 @@ async fn test_get_issues_with_filter() {
         ..Default::default()
     };
 
-    let issues = provider.get_issues(filter).await.unwrap();
+    let issues = provider.get_issues(filter).await.unwrap().items;
 
     // All issues should be open
     for issue in &issues {
@@ -90,7 +90,7 @@ async fn test_get_issue() {
     let provider = TestProvider::github();
 
     // First get all issues
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap();
+    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
     assert!(!issues.is_empty());
 
     // Then get a specific issue
@@ -108,7 +108,8 @@ async fn test_get_pull_requests() {
     let prs = provider
         .get_merge_requests(MrFilter::default())
         .await
-        .unwrap();
+        .unwrap()
+        .items;
 
     assert!(!prs.is_empty(), "Should have at least one PR");
 
@@ -132,7 +133,7 @@ async fn test_get_pull_requests_with_filter() {
         ..Default::default()
     };
 
-    let prs = provider.get_merge_requests(filter).await.unwrap();
+    let prs = provider.get_merge_requests(filter).await.unwrap().items;
 
     // All PRs should be open
     for pr in &prs {
@@ -164,7 +165,7 @@ async fn test_provider_name() {
 async fn test_issue_url_format() {
     let provider = TestProvider::github();
 
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap();
+    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
     assert!(!issues.is_empty());
 
     for issue in &issues {
@@ -186,7 +187,8 @@ async fn test_pr_url_format() {
     let prs = provider
         .get_merge_requests(MrFilter::default())
         .await
-        .unwrap();
+        .unwrap()
+        .items;
     assert!(!prs.is_empty());
 
     for pr in &prs {
@@ -206,12 +208,12 @@ async fn test_get_issue_comments() {
     let provider = TestProvider::github();
 
     // First get all issues
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap();
+    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
     assert!(!issues.is_empty());
 
     // Get comments for the first issue
     let key = &issues[0].key;
-    let comments = provider.get_comments(key).await.unwrap();
+    let comments = provider.get_comments(key).await.unwrap().items;
 
     // Comments should be a vector (may be empty)
     for comment in &comments {
@@ -229,7 +231,8 @@ async fn test_get_pull_request() {
     let prs = provider
         .get_merge_requests(MrFilter::default())
         .await
-        .unwrap();
+        .unwrap()
+        .items;
     assert!(!prs.is_empty());
 
     // Get a specific PR
@@ -249,12 +252,13 @@ async fn test_get_pull_request_discussions() {
     let prs = provider
         .get_merge_requests(MrFilter::default())
         .await
-        .unwrap();
+        .unwrap()
+        .items;
     assert!(!prs.is_empty());
 
     // Get discussions for the first PR
     let key = &prs[0].key;
-    let discussions = provider.get_discussions(key).await.unwrap();
+    let discussions = provider.get_discussions(key).await.unwrap().items;
 
     // Discussions should be a vector (may be empty)
     for discussion in &discussions {
@@ -271,12 +275,13 @@ async fn test_get_pull_request_diffs() {
     let prs = provider
         .get_merge_requests(MrFilter::default())
         .await
-        .unwrap();
+        .unwrap()
+        .items;
     assert!(!prs.is_empty());
 
     // Get diffs for the first PR
     let key = &prs[0].key;
-    let diffs = provider.get_diffs(key).await.unwrap();
+    let diffs = provider.get_diffs(key).await.unwrap().items;
 
     // Diffs should be a vector (may be empty for PRs without changes)
     for diff in &diffs {
@@ -317,11 +322,12 @@ async fn test_pr_issue_distinction() {
     let provider = TestProvider::github();
 
     // Get issues and PRs
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap();
+    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
     let prs = provider
         .get_merge_requests(MrFilter::default())
         .await
-        .unwrap();
+        .unwrap()
+        .items;
 
     // Extract numbers from keys
     let issue_numbers: Vec<u64> = issues
@@ -352,7 +358,7 @@ async fn test_add_issue_comment_not_supported() {
     let provider = TestProvider::github();
 
     // First get all issues
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap();
+    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
     assert!(!issues.is_empty(), "Should have at least one issue");
 
     // Add a comment to the first issue
@@ -383,7 +389,8 @@ async fn test_add_pr_comment_not_supported() {
     let prs = provider
         .get_merge_requests(MrFilter::default())
         .await
-        .unwrap();
+        .unwrap()
+        .items;
     assert!(!prs.is_empty(), "Should have at least one PR");
 
     // Add a comment to the first PR
@@ -420,7 +427,8 @@ async fn test_add_pr_inline_comment_not_supported() {
     let prs = provider
         .get_merge_requests(MrFilter::default())
         .await
-        .unwrap();
+        .unwrap()
+        .items;
     assert!(!prs.is_empty(), "Should have at least one PR");
 
     let key = &prs[0].key;
@@ -486,7 +494,7 @@ async fn test_update_issue_not_supported() {
     let provider = TestProvider::github();
 
     // First get all issues
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap();
+    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
     assert!(
         !issues.is_empty(),
         "Should have at least one issue to update"

--- a/crates/devboy-cli/tests/github_test.rs
+++ b/crates/devboy-cli/tests/github_test.rs
@@ -51,7 +51,11 @@ async fn test_mode_detection() {
 async fn test_get_issues() {
     let provider = TestProvider::github();
 
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
+    let issues = provider
+        .get_issues(IssueFilter::default())
+        .await
+        .unwrap()
+        .items;
 
     assert!(!issues.is_empty(), "Should have at least one issue");
 
@@ -90,7 +94,11 @@ async fn test_get_issue() {
     let provider = TestProvider::github();
 
     // First get all issues
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
+    let issues = provider
+        .get_issues(IssueFilter::default())
+        .await
+        .unwrap()
+        .items;
     assert!(!issues.is_empty());
 
     // Then get a specific issue
@@ -165,7 +173,11 @@ async fn test_provider_name() {
 async fn test_issue_url_format() {
     let provider = TestProvider::github();
 
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
+    let issues = provider
+        .get_issues(IssueFilter::default())
+        .await
+        .unwrap()
+        .items;
     assert!(!issues.is_empty());
 
     for issue in &issues {
@@ -208,7 +220,11 @@ async fn test_get_issue_comments() {
     let provider = TestProvider::github();
 
     // First get all issues
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
+    let issues = provider
+        .get_issues(IssueFilter::default())
+        .await
+        .unwrap()
+        .items;
     assert!(!issues.is_empty());
 
     // Get comments for the first issue
@@ -322,7 +338,11 @@ async fn test_pr_issue_distinction() {
     let provider = TestProvider::github();
 
     // Get issues and PRs
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
+    let issues = provider
+        .get_issues(IssueFilter::default())
+        .await
+        .unwrap()
+        .items;
     let prs = provider
         .get_merge_requests(MrFilter::default())
         .await
@@ -358,7 +378,11 @@ async fn test_add_issue_comment_not_supported() {
     let provider = TestProvider::github();
 
     // First get all issues
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
+    let issues = provider
+        .get_issues(IssueFilter::default())
+        .await
+        .unwrap()
+        .items;
     assert!(!issues.is_empty(), "Should have at least one issue");
 
     // Add a comment to the first issue
@@ -493,7 +517,11 @@ async fn test_update_issue_not_supported() {
     let provider = TestProvider::github();
 
     // First get all issues
-    let issues = provider.get_issues(IssueFilter::default()).await.unwrap().items;
+    let issues = provider
+        .get_issues(IssueFilter::default())
+        .await
+        .unwrap()
+        .items;
     assert!(
         !issues.is_empty(),
         "Should have at least one issue to update"

--- a/crates/devboy-cli/tests/pipeline_test.rs
+++ b/crates/devboy-cli/tests/pipeline_test.rs
@@ -98,7 +98,7 @@ fn test_json_vs_toon_token_savings() {
 
     let pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-        max_items: 100,
+
         max_chars: 100_000,
         ..Default::default()
     });
@@ -126,7 +126,7 @@ fn test_pull_requests_toon_output() {
 
     let pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-        max_items: 100,
+
         max_chars: 100_000,
         ..Default::default()
     });
@@ -150,8 +150,7 @@ fn test_truncation_with_pagination_hints() {
 
     let pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-        max_items: 2,
-        max_chars: 100_000,
+        max_chars: 300,
         include_hints: true,
         ..Default::default()
     });
@@ -160,12 +159,10 @@ fn test_truncation_with_pagination_hints() {
 
     assert!(output.truncated, "Output should be marked as truncated");
     assert_eq!(output.total_count, Some(5));
-    assert_eq!(output.included_count, 2);
+    assert!(output.included_count < 5);
 
     let hint = output.agent_hint.as_ref().expect("Should have agent hint");
-    assert!(hint.contains("2/5"));
-    assert!(hint.contains("3 more"));
-    assert!(hint.contains("offset"));
+    assert!(hint.contains("trimmed by budget"));
 }
 
 #[test]
@@ -174,7 +171,6 @@ fn test_no_truncation_when_under_limit() {
 
     let pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-        max_items: 10,
         max_chars: 100_000,
         include_hints: true,
         ..Default::default()
@@ -192,7 +188,7 @@ fn test_character_limit_truncation() {
 
     let pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-        max_items: 100,
+
         max_chars: 500,
         include_hints: true,
         ..Default::default()
@@ -214,7 +210,7 @@ fn test_diffs_toon_output() {
 
     let pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-        max_items: 100,
+
         max_chars: 100_000,
         max_chars_per_item: 1000,
         ..Default::default()
@@ -250,7 +246,7 @@ fn test_diff_content_truncation() {
 
     let pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-        max_items: 100,
+
         max_chars: 100_000,
         max_chars_per_item: 200,
         ..Default::default()
@@ -281,7 +277,7 @@ fn test_format_comparison_demo() {
     // TOON
     let toon_pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-        max_items: 100,
+
         max_chars: 100_000,
         ..Default::default()
     });

--- a/crates/devboy-cli/tests/pipeline_test.rs
+++ b/crates/devboy-cli/tests/pipeline_test.rs
@@ -98,7 +98,6 @@ fn test_json_vs_toon_token_savings() {
 
     let pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-
         max_chars: 100_000,
         ..Default::default()
     });
@@ -126,7 +125,6 @@ fn test_pull_requests_toon_output() {
 
     let pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-
         max_chars: 100_000,
         ..Default::default()
     });
@@ -210,7 +208,6 @@ fn test_diffs_toon_output() {
 
     let pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-
         max_chars: 100_000,
         max_chars_per_item: 1000,
         ..Default::default()
@@ -246,7 +243,6 @@ fn test_diff_content_truncation() {
 
     let pipeline = Pipeline::with_config(PipelineConfig {
         format: OutputFormat::Toon,
-
         max_chars: 100_000,
         max_chars_per_item: 200,
         ..Default::default()

--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -10,9 +10,9 @@
 //! # Example
 //!
 //! ```ignore
-//! use devboy_core::{IssueProvider, IssueFilter, Issue, Result};
+//! use devboy_core::{IssueProvider, IssueFilter, Issue, ProviderResult, Result};
 //!
-//! async fn list_open_issues(provider: &dyn IssueProvider) -> Result<Vec<Issue>> {
+//! async fn list_open_issues(provider: &dyn IssueProvider) -> Result<ProviderResult<Issue>> {
 //!     let filter = IssueFilter {
 //!         state: Some("opened".to_string()),
 //!         limit: Some(10),

--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -43,8 +43,8 @@ pub use types::{
     Discussion, FailedJob, FileDiff, GetPipelineInput, GetUsersOptions, Issue, IssueFilter,
     IssueStatus, JobLogMode, JobLogOptions, JobLogOutput, MeetingFilter, MeetingNote,
     MeetingSpeaker, MeetingTranscript, MergeRequest, MrFilter, Pagination, PipelineInfo,
-    PipelineJob, PipelineStage, PipelineStatus, PipelineSummary, Release, ReleaseAsset,
-    TranscriptSentence, UpdateIssueInput, User,
+    PipelineJob, PipelineStage, PipelineStatus, PipelineSummary, ProviderResult, Release,
+    ReleaseAsset, SortInfo, TranscriptSentence, UpdateIssueInput, User,
 };
 
 // Re-export enricher traits and utilities

--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -44,7 +44,7 @@ pub use types::{
     IssueLink, IssueRelations, IssueStatus, JobLogMode, JobLogOptions, JobLogOutput, MeetingFilter,
     MeetingNote, MeetingSpeaker, MeetingTranscript, MergeRequest, MrFilter, Pagination,
     PipelineInfo, PipelineJob, PipelineStage, PipelineStatus, PipelineSummary, ProviderResult,
-    Release, ReleaseAsset, SortInfo, TranscriptSentence, UpdateIssueInput, User,
+    Release, ReleaseAsset, SortInfo, SortOrder, TranscriptSentence, UpdateIssueInput, User,
 };
 
 // Re-export enricher traits and utilities

--- a/crates/devboy-core/src/provider.rs
+++ b/crates/devboy-core/src/provider.rs
@@ -195,6 +195,9 @@ pub trait MeetingNotesProvider: Send + Sync {
     async fn get_transcript(&self, meeting_id: &str) -> Result<MeetingTranscript>;
 
     /// Search meetings by keyword across titles, action items, keywords, and topics.
-    async fn search_meetings(&self, query: &str, filter: MeetingFilter)
-    -> Result<ProviderResult<MeetingNote>>;
+    async fn search_meetings(
+        &self,
+        query: &str,
+        filter: MeetingFilter,
+    ) -> Result<ProviderResult<MeetingNote>>;
 }

--- a/crates/devboy-core/src/provider.rs
+++ b/crates/devboy-core/src/provider.rs
@@ -10,7 +10,7 @@ use crate::types::{
     Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, Discussion, FileDiff,
     GetPipelineInput, GetUsersOptions, Issue, IssueFilter, IssueStatus, JobLogOptions,
     JobLogOutput, MeetingFilter, MeetingNote, MeetingTranscript, MergeRequest, MrFilter,
-    PipelineInfo, Release, UpdateIssueInput, User,
+    PipelineInfo, ProviderResult, Release, UpdateIssueInput, User,
 };
 
 /// Provider for working with issues.
@@ -19,7 +19,7 @@ use crate::types::{
 #[async_trait]
 pub trait IssueProvider: Send + Sync {
     /// Get a list of issues with optional filters.
-    async fn get_issues(&self, filter: IssueFilter) -> Result<Vec<Issue>>;
+    async fn get_issues(&self, filter: IssueFilter) -> Result<ProviderResult<Issue>>;
 
     /// Get a single issue by key (e.g., "gitlab#123", "gh#456").
     async fn get_issue(&self, key: &str) -> Result<Issue>;
@@ -31,14 +31,14 @@ pub trait IssueProvider: Send + Sync {
     async fn update_issue(&self, key: &str, input: UpdateIssueInput) -> Result<Issue>;
 
     /// Get comments for an issue.
-    async fn get_comments(&self, issue_key: &str) -> Result<Vec<Comment>>;
+    async fn get_comments(&self, issue_key: &str) -> Result<ProviderResult<Comment>>;
 
     /// Add a comment to an issue.
     async fn add_comment(&self, issue_key: &str, body: &str) -> Result<Comment>;
 
     /// Get available statuses for the issue tracker.
     /// Default returns ProviderUnsupported — override in providers that support statuses.
-    async fn get_statuses(&self) -> Result<Vec<IssueStatus>> {
+    async fn get_statuses(&self) -> Result<ProviderResult<IssueStatus>> {
         Err(Error::ProviderUnsupported {
             provider: self.provider_name().to_string(),
             operation: "get_statuses".to_string(),
@@ -59,7 +59,7 @@ pub trait IssueProvider: Send + Sync {
     }
 
     /// Get users from the issue tracker (Jira only).
-    async fn get_users(&self, _options: GetUsersOptions) -> Result<Vec<User>> {
+    async fn get_users(&self, _options: GetUsersOptions) -> Result<ProviderResult<User>> {
         Err(Error::ProviderUnsupported {
             provider: self.provider_name().to_string(),
             operation: "get_users".to_string(),
@@ -81,7 +81,7 @@ pub trait MergeRequestProvider: Send + Sync {
     fn provider_name(&self) -> &'static str;
 
     /// Get a list of merge requests with optional filters.
-    async fn get_merge_requests(&self, _filter: MrFilter) -> Result<Vec<MergeRequest>> {
+    async fn get_merge_requests(&self, _filter: MrFilter) -> Result<ProviderResult<MergeRequest>> {
         Err(Error::ProviderUnsupported {
             provider: self.provider_name().to_string(),
             operation: "get_merge_requests".to_string(),
@@ -97,7 +97,7 @@ pub trait MergeRequestProvider: Send + Sync {
     }
 
     /// Get discussions/comments for a merge request.
-    async fn get_discussions(&self, _mr_key: &str) -> Result<Vec<Discussion>> {
+    async fn get_discussions(&self, _mr_key: &str) -> Result<ProviderResult<Discussion>> {
         Err(Error::ProviderUnsupported {
             provider: self.provider_name().to_string(),
             operation: "get_discussions".to_string(),
@@ -105,7 +105,7 @@ pub trait MergeRequestProvider: Send + Sync {
     }
 
     /// Get file diffs for a merge request.
-    async fn get_diffs(&self, _mr_key: &str) -> Result<Vec<FileDiff>> {
+    async fn get_diffs(&self, _mr_key: &str) -> Result<ProviderResult<FileDiff>> {
         Err(Error::ProviderUnsupported {
             provider: self.provider_name().to_string(),
             operation: "get_diffs".to_string(),
@@ -129,7 +129,7 @@ pub trait MergeRequestProvider: Send + Sync {
     }
 
     /// Get releases/tags for the repository.
-    async fn get_releases(&self) -> Result<Vec<Release>> {
+    async fn get_releases(&self) -> Result<ProviderResult<Release>> {
         Err(Error::ProviderUnsupported {
             provider: self.provider_name().to_string(),
             operation: "get_releases".to_string(),
@@ -181,12 +181,12 @@ pub trait MeetingNotesProvider: Send + Sync {
     fn provider_name(&self) -> &'static str;
 
     /// Get a list of meeting notes with optional filters.
-    async fn get_meetings(&self, filter: MeetingFilter) -> Result<Vec<MeetingNote>>;
+    async fn get_meetings(&self, filter: MeetingFilter) -> Result<ProviderResult<MeetingNote>>;
 
     /// Get the full transcript for a meeting.
     async fn get_transcript(&self, meeting_id: &str) -> Result<MeetingTranscript>;
 
     /// Search meetings by keyword across titles, action items, keywords, and topics.
     async fn search_meetings(&self, query: &str, filter: MeetingFilter)
-    -> Result<Vec<MeetingNote>>;
+    -> Result<ProviderResult<MeetingNote>>;
 }

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -384,11 +384,22 @@ pub struct Pagination {
 // Sort Info
 // =============================================================================
 
+/// Sort direction.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Asc,
+    #[default]
+    Desc,
+}
+
 /// Sorting metadata from provider API.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SortInfo {
-    /// Current sort applied (e.g., "updated_at:desc")
-    pub current_sort: Option<String>,
+    /// Current sort field (e.g., "updated_at", "created_at")
+    pub sort_by: Option<String>,
+    /// Current sort order
+    pub sort_order: SortOrder,
     /// Available sort fields for this endpoint
     pub available_sorts: Vec<String>,
 }
@@ -576,13 +587,15 @@ mod tests {
     #[test]
     fn test_provider_result_with_sort_info() {
         let sort_info = SortInfo {
-            current_sort: Some("updated_at:desc".into()),
+            sort_by: Some("updated_at".into()),
+            sort_order: SortOrder::Desc,
             available_sorts: vec!["created_at".into(), "updated_at".into()],
         };
         let result = ProviderResult::new(vec![42]).with_sort_info(sort_info);
         assert_eq!(result.items, vec![42]);
         let si = result.sort_info.unwrap();
-        assert_eq!(si.current_sort, Some("updated_at:desc".into()));
+        assert_eq!(si.sort_by, Some("updated_at".into()));
+        assert_eq!(si.sort_order, SortOrder::Desc);
         assert_eq!(si.available_sorts.len(), 2);
     }
 
@@ -605,7 +618,8 @@ mod tests {
                 has_more: true,
             })
             .with_sort_info(SortInfo {
-                current_sort: Some("priority:asc".into()),
+                sort_by: Some("priority".into()),
+                sort_order: SortOrder::Asc,
                 available_sorts: vec![],
             });
         assert!(result.pagination.is_some());

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -183,6 +183,12 @@ pub struct MrFilter {
     pub labels: Option<Vec<String>>,
     /// Maximum number of results
     pub limit: Option<u32>,
+    /// Number of results to skip (offset)
+    pub offset: Option<u32>,
+    /// Sort by field (e.g., "created_at", "updated_at")
+    pub sort_by: Option<String>,
+    /// Sort order ("asc" or "desc")
+    pub sort_order: Option<String>,
 }
 
 // =============================================================================
@@ -285,6 +291,66 @@ pub struct Pagination {
     pub total: Option<u32>,
     /// Whether there are more items
     pub has_more: bool,
+}
+
+// =============================================================================
+// Sort Info
+// =============================================================================
+
+/// Sorting metadata from provider API.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SortInfo {
+    /// Current sort applied (e.g., "updated_at:desc")
+    pub current_sort: Option<String>,
+    /// Available sort fields for this endpoint
+    pub available_sorts: Vec<String>,
+}
+
+// =============================================================================
+// Provider Result
+// =============================================================================
+
+/// Wrapper for provider list responses with pagination and sorting metadata.
+///
+/// Providers return this instead of plain `Vec<T>` to convey API-level
+/// pagination state and sorting info to the format pipeline.
+#[derive(Debug, Clone, Default)]
+pub struct ProviderResult<T> {
+    /// The actual items returned by the provider
+    pub items: Vec<T>,
+    /// Pagination metadata from the API (total count, has_more, etc.)
+    pub pagination: Option<Pagination>,
+    /// Sorting metadata (current sort, available sort fields)
+    pub sort_info: Option<SortInfo>,
+}
+
+impl<T> ProviderResult<T> {
+    /// Create a new ProviderResult with just items (no metadata).
+    pub fn new(items: Vec<T>) -> Self {
+        Self {
+            items,
+            pagination: None,
+            sort_info: None,
+        }
+    }
+
+    /// Set pagination metadata.
+    pub fn with_pagination(mut self, pagination: Pagination) -> Self {
+        self.pagination = Some(pagination);
+        self
+    }
+
+    /// Set sort info metadata.
+    pub fn with_sort_info(mut self, sort_info: SortInfo) -> Self {
+        self.sort_info = Some(sort_info);
+        self
+    }
+}
+
+impl<T> From<Vec<T>> for ProviderResult<T> {
+    fn from(items: Vec<T>) -> Self {
+        Self::new(items)
+    }
 }
 
 #[cfg(test)]

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -545,6 +545,73 @@ mod tests {
         assert_eq!(PipelineStatus::Failed.as_str(), "failed");
         assert_eq!(PipelineStatus::Running.as_str(), "running");
     }
+
+    // --- ProviderResult tests ---
+
+    #[test]
+    fn test_provider_result_new() {
+        let result = ProviderResult::new(vec![1, 2, 3]);
+        assert_eq!(result.items, vec![1, 2, 3]);
+        assert!(result.pagination.is_none());
+        assert!(result.sort_info.is_none());
+    }
+
+    #[test]
+    fn test_provider_result_with_pagination() {
+        let pagination = Pagination {
+            offset: 0,
+            limit: 10,
+            total: Some(100),
+            has_more: true,
+        };
+        let result = ProviderResult::new(vec!["a", "b"]).with_pagination(pagination);
+        assert_eq!(result.items, vec!["a", "b"]);
+        let pag = result.pagination.unwrap();
+        assert_eq!(pag.total, Some(100));
+        assert!(pag.has_more);
+        assert_eq!(pag.offset, 0);
+        assert_eq!(pag.limit, 10);
+    }
+
+    #[test]
+    fn test_provider_result_with_sort_info() {
+        let sort_info = SortInfo {
+            current_sort: Some("updated_at:desc".into()),
+            available_sorts: vec!["created_at".into(), "updated_at".into()],
+        };
+        let result = ProviderResult::new(vec![42]).with_sort_info(sort_info);
+        assert_eq!(result.items, vec![42]);
+        let si = result.sort_info.unwrap();
+        assert_eq!(si.current_sort, Some("updated_at:desc".into()));
+        assert_eq!(si.available_sorts.len(), 2);
+    }
+
+    #[test]
+    fn test_provider_result_from_vec() {
+        let items = vec![1, 2, 3, 4];
+        let result: ProviderResult<i32> = items.into();
+        assert_eq!(result.items, vec![1, 2, 3, 4]);
+        assert!(result.pagination.is_none());
+        assert!(result.sort_info.is_none());
+    }
+
+    #[test]
+    fn test_provider_result_chained() {
+        let result = ProviderResult::new(vec!["x"])
+            .with_pagination(Pagination {
+                offset: 10,
+                limit: 5,
+                total: Some(50),
+                has_more: true,
+            })
+            .with_sort_info(SortInfo {
+                current_sort: Some("priority:asc".into()),
+                available_sorts: vec![],
+            });
+        assert!(result.pagination.is_some());
+        assert!(result.sort_info.is_some());
+        assert_eq!(result.items, vec!["x"]);
+    }
 }
 
 // =============================================================================

--- a/crates/devboy-executor/src/enricher.rs
+++ b/crates/devboy-executor/src/enricher.rs
@@ -4,15 +4,14 @@
 //! so that provider crates can implement enrichers without depending
 //! on the executor. This module provides built-in enrichers.
 
-use devboy_core::{ToolCategory, ToolEnricher, ToolSchema};
+use devboy_core::{PropertySchema, ToolCategory, ToolEnricher, ToolSchema};
 use serde_json::Value;
 
 // Re-export core enricher types for convenience
 pub use devboy_core::{ToolSchema as Schema, sanitize_field_name};
 
-/// Pipeline format enricher — adds `format` enum parameter to list tools.
-pub struct PipelineFormatEnricher;
-
+/// Tools that return lists and go through the format pipeline.
+/// These get `format`, `budget`, `offset`, `limit` parameters automatically.
 const LIST_TOOLS: &[&str] = &[
     "get_issues",
     "get_issue",
@@ -23,44 +22,145 @@ const LIST_TOOLS: &[&str] = &[
     "get_merge_request_diffs",
 ];
 
-impl ToolEnricher for PipelineFormatEnricher {
+/// Format pipeline enricher — adds pagination and budget parameters to list tools.
+///
+/// Automatically adds these parameters to all list-returning tools:
+/// - `format` — output format (toon/json)
+/// - `budget` — token budget for response size control
+/// - `offset` — pagination offset
+/// - `limit` — pagination limit
+///
+/// This avoids duplicating these params in every tool schema definition.
+pub struct FormatPipelineEnricher;
+
+impl ToolEnricher for FormatPipelineEnricher {
     fn supported_categories(&self) -> &[ToolCategory] {
         &[ToolCategory::IssueTracker, ToolCategory::GitRepository]
     }
 
     fn enrich_schema(&self, tool_name: &str, schema: &mut ToolSchema) {
-        if LIST_TOOLS.contains(&tool_name) {
-            schema.add_enum_param("format", &["toon", "json"], "Output format. Default: toon");
+        if !LIST_TOOLS.contains(&tool_name) {
+            return;
+        }
+
+        // Output format
+        if !schema.properties.contains_key("format") {
+            schema.add_enum_param("format", &["toon", "json"], "Output format (default: toon)");
+        }
+
+        // Token budget — LLM controls response size
+        if !schema.properties.contains_key("budget") {
+            schema.add_property(
+                "budget",
+                PropertySchema::integer(
+                    "Token budget for response. Lower = less data + chunk index for navigation. \
+                     Higher = more data per call. Default: from server config (~28000 tokens).",
+                    Some(100.0),
+                    Some(100000.0),
+                ),
+            );
+        }
+
+        // Pagination — offset and limit
+        if !schema.properties.contains_key("offset") {
+            schema.add_property(
+                "offset",
+                PropertySchema::integer(
+                    "Skip N items for pagination. Use with chunk index offsets.",
+                    Some(0.0),
+                    None,
+                ),
+            );
+        }
+
+        if !schema.properties.contains_key("limit") {
+            schema.add_property(
+                "limit",
+                PropertySchema::integer(
+                    "Maximum items to return (default: 20, max: 100)",
+                    Some(1.0),
+                    Some(100.0),
+                ),
+            );
         }
     }
 
     fn transform_args(&self, _tool_name: &str, _args: &mut Value) {
-        // format is consumed by the pipeline layer, not the provider
+        // These params are consumed by the pipeline layer, not the provider
     }
 }
+
+/// Backward-compatible alias.
+pub type PipelineFormatEnricher = FormatPipelineEnricher;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
-    fn test_pipeline_format_enricher() {
-        let enricher = PipelineFormatEnricher;
-
-        assert!(
-            enricher
-                .supported_categories()
-                .contains(&ToolCategory::IssueTracker)
-        );
-        assert!(
-            enricher
-                .supported_categories()
-                .contains(&ToolCategory::GitRepository)
-        );
-
+    fn test_format_pipeline_enricher_adds_all_params() {
+        let enricher = FormatPipelineEnricher;
         let mut schema = ToolSchema::new();
         enricher.enrich_schema("get_issues", &mut schema);
 
+        // format
         let format = schema.properties.get("format").unwrap();
         assert_eq!(format.enum_values, Some(vec!["toon".into(), "json".into()]));
+
+        // budget
+        let budget = schema.properties.get("budget").unwrap();
+        assert_eq!(budget.schema_type, "integer");
+        assert_eq!(budget.minimum, Some(100.0));
+        assert_eq!(budget.maximum, Some(100000.0));
+
+        // offset
+        let offset = schema.properties.get("offset").unwrap();
+        assert_eq!(offset.schema_type, "integer");
+        assert_eq!(offset.minimum, Some(0.0));
+
+        // limit
+        let limit = schema.properties.get("limit").unwrap();
+        assert_eq!(limit.schema_type, "integer");
+        assert_eq!(limit.minimum, Some(1.0));
+        assert_eq!(limit.maximum, Some(100.0));
+    }
+
+    #[test]
+    fn test_enricher_skips_non_list_tools() {
+        let enricher = FormatPipelineEnricher;
+        let mut schema = ToolSchema::new();
+        enricher.enrich_schema("create_issue", &mut schema);
+
+        assert!(schema.properties.is_empty());
+    }
+
+    #[test]
+    fn test_enricher_does_not_overwrite_existing() {
+        let enricher = FormatPipelineEnricher;
+        let mut schema = ToolSchema::new();
+        // Pre-existing limit with different bounds
+        schema.add_property(
+            "limit",
+            PropertySchema::integer("Custom limit", Some(1.0), Some(50.0)),
+        );
+
+        enricher.enrich_schema("get_merge_request_discussions", &mut schema);
+
+        // limit should NOT be overwritten
+        let limit = schema.properties.get("limit").unwrap();
+        assert_eq!(limit.maximum, Some(50.0));
+
+        // but format/budget/offset should be added
+        assert!(schema.properties.contains_key("format"));
+        assert!(schema.properties.contains_key("budget"));
+        assert!(schema.properties.contains_key("offset"));
+    }
+
+    #[test]
+    fn test_enricher_categories() {
+        let enricher = FormatPipelineEnricher;
+        let cats = enricher.supported_categories();
+        assert!(cats.contains(&ToolCategory::IssueTracker));
+        assert!(cats.contains(&ToolCategory::GitRepository));
     }
 }

--- a/crates/devboy-executor/src/enricher.rs
+++ b/crates/devboy-executor/src/enricher.rs
@@ -11,7 +11,6 @@ use serde_json::Value;
 pub use devboy_core::{ToolSchema as Schema, sanitize_field_name};
 
 /// Tools that return lists and go through the format pipeline.
-/// These get `format`, `budget`, `offset`, `limit` parameters automatically.
 const LIST_TOOLS: &[&str] = &[
     "get_issues",
     "get_issue",
@@ -22,15 +21,47 @@ const LIST_TOOLS: &[&str] = &[
     "get_merge_request_diffs",
 ];
 
-/// Format pipeline enricher — adds pagination and budget parameters to list tools.
+// =============================================================================
+// Safe parameter insertion
+// =============================================================================
+
+/// Find a free parameter name: try `preferred`, then `_preferred`, `__preferred`, etc.
 ///
-/// Automatically adds these parameters to all list-returning tools:
+/// If a tool already has a parameter with the same name (e.g., the tool defines
+/// its own `chunk`), the enricher uses a prefixed variant to avoid collisions.
+fn safe_param_name(schema: &ToolSchema, preferred: &str) -> String {
+    if !schema.properties.contains_key(preferred) {
+        return preferred.to_string();
+    }
+    // Prefix with underscores until we find a free name
+    let mut name = format!("_{preferred}");
+    while schema.properties.contains_key(&name) {
+        name = format!("_{name}");
+    }
+    name
+}
+
+/// Insert a property only if the preferred name (or a safe variant) is available.
+/// Returns the actual name used.
+fn safe_insert(schema: &mut ToolSchema, preferred: &str, prop: PropertySchema) -> String {
+    let name = safe_param_name(schema, preferred);
+    schema.add_property(&name, prop);
+    name
+}
+
+// =============================================================================
+// FormatPipelineEnricher
+// =============================================================================
+
+/// Format pipeline enricher — adds pipeline-level parameters to list tools.
+///
+/// Adds these parameters (using safe naming to avoid collisions):
 /// - `format` — output format (toon/json)
 /// - `budget` — token budget for response size control
-/// - `offset` — pagination offset
-/// - `limit` — pagination limit
+/// - `chunk`  — chunk number for navigating large results
 ///
-/// This avoids duplicating these params in every tool schema definition.
+/// API-level `limit`/`offset` are defined by individual tools where
+/// the provider API supports pagination. The enricher does NOT add them.
 pub struct FormatPipelineEnricher;
 
 impl ToolEnricher for FormatPipelineEnricher {
@@ -44,49 +75,44 @@ impl ToolEnricher for FormatPipelineEnricher {
         }
 
         // Output format
-        if !schema.properties.contains_key("format") {
-            schema.add_enum_param("format", &["toon", "json"], "Output format (default: toon)");
-        }
+        safe_insert(
+            schema,
+            "format",
+            PropertySchema::string_enum(&["toon", "json"], "Output format (default: toon)"),
+        );
 
         // Token budget — LLM controls response size
-        if !schema.properties.contains_key("budget") {
-            schema.add_property(
-                "budget",
-                PropertySchema::integer(
-                    "Token budget for response. Lower = less data + chunk index for navigation. \
-                     Higher = more data per call. Default: from server config (~28000 tokens).",
-                    Some(100.0),
-                    Some(100000.0),
-                ),
-            );
-        }
+        safe_insert(
+            schema,
+            "budget",
+            PropertySchema::integer(
+                "Token budget for this response. Lower = less data + chunk index for navigation. \
+                 Higher = more data per call. Default: from server config.",
+                Some(100.0),
+                Some(100000.0),
+            ),
+        );
 
-        // Pagination — offset and limit
-        if !schema.properties.contains_key("offset") {
-            schema.add_property(
-                "offset",
-                PropertySchema::integer(
-                    "Skip N items for pagination. Use with chunk index offsets.",
-                    Some(0.0),
-                    None,
-                ),
-            );
-        }
-
-        if !schema.properties.contains_key("limit") {
-            schema.add_property(
-                "limit",
-                PropertySchema::integer(
-                    "Maximum items to return (default: 20, max: 100)",
-                    Some(1.0),
-                    Some(100.0),
-                ),
-            );
-        }
+        // Chunk navigation — for fetching specific chunks from large results
+        safe_insert(
+            schema,
+            "chunk",
+            PropertySchema::integer(
+                "Chunk number to fetch (from chunk index). \
+                 When a response exceeds budget, it returns chunk 1 + an index of all chunks. \
+                 Use this parameter to fetch a specific chunk by number.",
+                Some(1.0),
+                None,
+            ),
+        );
     }
 
-    fn transform_args(&self, _tool_name: &str, _args: &mut Value) {
-        // These params are consumed by the pipeline layer, not the provider
+    fn transform_args(&self, _tool_name: &str, args: &mut Value) {
+        // Convert `chunk` to `offset`/`limit` for the pipeline.
+        // The chunk index includes offset/limit per chunk, but the LLM
+        // just sends a chunk number. We resolve it at runtime in the handler.
+        // For now, pass through — the handler reads `chunk` from args directly.
+        let _ = args;
     }
 }
 
@@ -98,7 +124,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_format_pipeline_enricher_adds_all_params() {
+    fn test_safe_param_name_no_conflict() {
+        let schema = ToolSchema::new();
+        assert_eq!(safe_param_name(&schema, "budget"), "budget");
+        assert_eq!(safe_param_name(&schema, "chunk"), "chunk");
+    }
+
+    #[test]
+    fn test_safe_param_name_with_conflict() {
+        let mut schema = ToolSchema::new();
+        schema.add_property("chunk", PropertySchema::string("existing"));
+        assert_eq!(safe_param_name(&schema, "chunk"), "_chunk");
+
+        schema.add_property("_chunk", PropertySchema::string("also taken"));
+        assert_eq!(safe_param_name(&schema, "chunk"), "__chunk");
+    }
+
+    #[test]
+    fn test_format_pipeline_enricher_adds_params() {
         let enricher = FormatPipelineEnricher;
         let mut schema = ToolSchema::new();
         enricher.enrich_schema("get_issues", &mut schema);
@@ -111,18 +154,15 @@ mod tests {
         let budget = schema.properties.get("budget").unwrap();
         assert_eq!(budget.schema_type, "integer");
         assert_eq!(budget.minimum, Some(100.0));
-        assert_eq!(budget.maximum, Some(100000.0));
 
-        // offset
-        let offset = schema.properties.get("offset").unwrap();
-        assert_eq!(offset.schema_type, "integer");
-        assert_eq!(offset.minimum, Some(0.0));
+        // chunk (new)
+        let chunk = schema.properties.get("chunk").unwrap();
+        assert_eq!(chunk.schema_type, "integer");
+        assert_eq!(chunk.minimum, Some(1.0));
 
-        // limit
-        let limit = schema.properties.get("limit").unwrap();
-        assert_eq!(limit.schema_type, "integer");
-        assert_eq!(limit.minimum, Some(1.0));
-        assert_eq!(limit.maximum, Some(100.0));
+        // NO offset/limit — those are API-level, defined by tools themselves
+        assert!(!schema.properties.contains_key("offset"));
+        assert!(!schema.properties.contains_key("limit"));
     }
 
     #[test]
@@ -130,30 +170,29 @@ mod tests {
         let enricher = FormatPipelineEnricher;
         let mut schema = ToolSchema::new();
         enricher.enrich_schema("create_issue", &mut schema);
-
         assert!(schema.properties.is_empty());
     }
 
     #[test]
-    fn test_enricher_does_not_overwrite_existing() {
+    fn test_enricher_safe_naming_on_collision() {
         let enricher = FormatPipelineEnricher;
         let mut schema = ToolSchema::new();
-        // Pre-existing limit with different bounds
-        schema.add_property(
-            "limit",
-            PropertySchema::integer("Custom limit", Some(1.0), Some(50.0)),
-        );
+        // Tool already defines `chunk` for its own purpose
+        schema.add_property("chunk", PropertySchema::string("tool's own chunk param"));
 
-        enricher.enrich_schema("get_merge_request_discussions", &mut schema);
+        enricher.enrich_schema("get_merge_request_diffs", &mut schema);
 
-        // limit should NOT be overwritten
-        let limit = schema.properties.get("limit").unwrap();
-        assert_eq!(limit.maximum, Some(50.0));
+        // Original `chunk` preserved
+        let original = schema.properties.get("chunk").unwrap();
+        assert_eq!(original.schema_type, "string");
 
-        // but format/budget/offset should be added
+        // Enricher's chunk renamed to `_chunk`
+        let enriched = schema.properties.get("_chunk").unwrap();
+        assert_eq!(enriched.schema_type, "integer");
+
+        // format and budget added normally (no collision)
         assert!(schema.properties.contains_key("format"));
         assert!(schema.properties.contains_key("budget"));
-        assert!(schema.properties.contains_key("offset"));
     }
 
     #[test]

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 
 use crate::context::AdditionalContext;
 use crate::factory;
-use crate::output::ToolOutput;
+use crate::output::{ResultMeta, ToolOutput};
 use devboy_core::ToolEnricher;
 
 /// Tool execution engine.
@@ -209,7 +209,11 @@ async fn execute_get_meeting_notes(
         skip: params.offset,
     };
     let result = provider.get_meetings(filter).await?;
-    Ok(ToolOutput::MeetingNotes(result.items))
+    let meta = ResultMeta {
+        pagination: result.pagination,
+        sort_info: result.sort_info,
+    };
+    Ok(ToolOutput::MeetingNotes(result.items, Some(meta)))
 }
 
 #[derive(Deserialize)]
@@ -254,7 +258,11 @@ async fn execute_search_meeting_notes(
         skip: params.offset,
     };
     let result = provider.search_meetings(&params.query, filter).await?;
-    Ok(ToolOutput::MeetingNotes(result.items))
+    let meta = ResultMeta {
+        pagination: result.pagination,
+        sort_info: result.sort_info,
+    };
+    Ok(ToolOutput::MeetingNotes(result.items, Some(meta)))
 }
 
 // --- Issue tool handlers ---
@@ -287,7 +295,11 @@ async fn execute_get_issues(
         sort_order: params.sort_order,
     };
     let result = provider.get_issues(filter).await?;
-    Ok(ToolOutput::Issues(result.items))
+    let meta = ResultMeta {
+        pagination: result.pagination,
+        sort_info: result.sort_info,
+    };
+    Ok(ToolOutput::Issues(result.items, Some(meta)))
 }
 
 #[derive(Deserialize)]
@@ -312,7 +324,11 @@ async fn execute_get_issue_comments(
     let params: KeyParam = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("missing 'key' parameter: {e}")))?;
     let result = provider.get_comments(&params.key).await?;
-    Ok(ToolOutput::Comments(result.items))
+    let meta = ResultMeta {
+        pagination: result.pagination,
+        sort_info: result.sort_info,
+    };
+    Ok(ToolOutput::Comments(result.items, Some(meta)))
 }
 
 async fn execute_get_issue_relations(
@@ -421,6 +437,9 @@ struct GetMergeRequestsParams {
     source_branch: Option<String>,
     target_branch: Option<String>,
     limit: Option<u32>,
+    offset: Option<u32>,
+    sort_by: Option<String>,
+    sort_order: Option<String>,
 }
 
 async fn execute_get_merge_requests(
@@ -435,10 +454,16 @@ async fn execute_get_merge_requests(
         author: params.author,
         labels: params.labels,
         limit: params.limit.or(Some(20)),
-        ..Default::default()
+        offset: params.offset,
+        sort_by: params.sort_by,
+        sort_order: params.sort_order,
     };
     let result = provider.get_merge_requests(filter).await?;
-    Ok(ToolOutput::MergeRequests(result.items))
+    let meta = ResultMeta {
+        pagination: result.pagination,
+        sort_info: result.sort_info,
+    };
+    Ok(ToolOutput::MergeRequests(result.items, Some(meta)))
 }
 
 async fn execute_get_merge_request(
@@ -458,7 +483,11 @@ async fn execute_get_merge_request_discussions(
     let params: KeyParam = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("missing 'key' parameter: {e}")))?;
     let result = provider.get_discussions(&params.key).await?;
-    Ok(ToolOutput::Discussions(result.items))
+    let meta = ResultMeta {
+        pagination: result.pagination,
+        sort_info: result.sort_info,
+    };
+    Ok(ToolOutput::Discussions(result.items, Some(meta)))
 }
 
 async fn execute_get_merge_request_diffs(
@@ -468,7 +497,11 @@ async fn execute_get_merge_request_diffs(
     let params: KeyParam = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("missing 'key' parameter: {e}")))?;
     let result = provider.get_diffs(&params.key).await?;
-    Ok(ToolOutput::Diffs(result.items))
+    let meta = ResultMeta {
+        pagination: result.pagination,
+        sort_info: result.sort_info,
+    };
+    Ok(ToolOutput::Diffs(result.items, Some(meta)))
 }
 
 #[derive(Deserialize)]
@@ -621,7 +654,11 @@ async fn execute_get_available_statuses(
     provider: &dyn devboy_core::Provider,
 ) -> Result<ToolOutput> {
     let result = IssueProvider::get_statuses(provider).await?;
-    Ok(ToolOutput::Statuses(result.items))
+    let meta = ResultMeta {
+        pagination: result.pagination,
+        sort_info: result.sort_info,
+    };
+    Ok(ToolOutput::Statuses(result.items, Some(meta)))
 }
 
 #[derive(Deserialize, Default)]
@@ -648,7 +685,11 @@ async fn execute_get_users(
         max_results: params.max_results,
     };
     let result = IssueProvider::get_users(provider, options).await?;
-    Ok(ToolOutput::Users(result.items))
+    let meta = ResultMeta {
+        pagination: result.pagination,
+        sort_info: result.sort_info,
+    };
+    Ok(ToolOutput::Users(result.items, Some(meta)))
 }
 
 #[derive(Deserialize)]
@@ -707,7 +748,11 @@ async fn execute_get_epics(
         sort_order: None,
     };
     let result = provider.get_issues(filter).await?;
-    Ok(ToolOutput::Issues(result.items))
+    let meta = ResultMeta {
+        pagination: result.pagination,
+        sort_info: result.sort_info,
+    };
+    Ok(ToolOutput::Issues(result.items, Some(meta)))
 }
 
 #[derive(Deserialize)]
@@ -1018,7 +1063,7 @@ mod tests {
         let provider = MockProvider;
         let args = serde_json::json!({"state": "open", "limit": 10});
         let result = dispatch_tool("get_issues", &args, &provider).await.unwrap();
-        assert!(matches!(result, ToolOutput::Issues(v) if v.len() == 1));
+        assert!(matches!(result, ToolOutput::Issues(v, _) if v.len() == 1));
     }
 
     #[tokio::test]
@@ -1027,7 +1072,7 @@ mod tests {
         let result = dispatch_tool("get_issues", &Value::Null, &provider)
             .await
             .unwrap();
-        assert!(matches!(result, ToolOutput::Issues(_)));
+        assert!(matches!(result, ToolOutput::Issues(_, _)));
     }
 
     #[tokio::test]
@@ -1052,7 +1097,7 @@ mod tests {
         let result = dispatch_tool("get_issue_comments", &args, &provider)
             .await
             .unwrap();
-        assert!(matches!(result, ToolOutput::Comments(v) if v.len() == 1));
+        assert!(matches!(result, ToolOutput::Comments(v, _) if v.len() == 1));
     }
 
     #[tokio::test]
@@ -1119,7 +1164,7 @@ mod tests {
         let result = dispatch_tool("get_merge_requests", &args, &provider)
             .await
             .unwrap();
-        assert!(matches!(result, ToolOutput::MergeRequests(v) if v.len() == 1));
+        assert!(matches!(result, ToolOutput::MergeRequests(v, _) if v.len() == 1));
     }
 
     #[tokio::test]
@@ -1128,7 +1173,7 @@ mod tests {
         let result = dispatch_tool("get_merge_requests", &Value::Null, &provider)
             .await
             .unwrap();
-        assert!(matches!(result, ToolOutput::MergeRequests(_)));
+        assert!(matches!(result, ToolOutput::MergeRequests(_, _)));
     }
 
     #[tokio::test]
@@ -1148,7 +1193,7 @@ mod tests {
         let result = dispatch_tool("get_merge_request_discussions", &args, &provider)
             .await
             .unwrap();
-        assert!(matches!(result, ToolOutput::Discussions(v) if v.len() == 1));
+        assert!(matches!(result, ToolOutput::Discussions(v, _) if v.len() == 1));
     }
 
     #[tokio::test]
@@ -1158,7 +1203,7 @@ mod tests {
         let result = dispatch_tool("get_merge_request_diffs", &args, &provider)
             .await
             .unwrap();
-        assert!(matches!(result, ToolOutput::Diffs(v) if v.len() == 1));
+        assert!(matches!(result, ToolOutput::Diffs(v, _) if v.len() == 1));
     }
 
     #[tokio::test]
@@ -1327,7 +1372,7 @@ mod tests {
         let provider = MockProvider;
         let args = serde_json::json!({"state": "open", "limit": 10});
         let result = dispatch_tool("get_epics", &args, &provider).await.unwrap();
-        assert!(matches!(result, ToolOutput::Issues(v) if v.len() == 1));
+        assert!(matches!(result, ToolOutput::Issues(v, _) if v.len() == 1));
     }
 
     #[tokio::test]
@@ -1336,7 +1381,7 @@ mod tests {
         let result = dispatch_tool("get_epics", &Value::Null, &provider)
             .await
             .unwrap();
-        assert!(matches!(result, ToolOutput::Issues(_)));
+        assert!(matches!(result, ToolOutput::Issues(_, _)));
     }
 
     #[tokio::test]
@@ -1428,7 +1473,7 @@ mod tests {
             .await
             .unwrap();
         match result {
-            ToolOutput::MeetingNotes(meetings) => {
+            ToolOutput::MeetingNotes(meetings, _) => {
                 assert_eq!(meetings.len(), 1);
                 assert_eq!(meetings[0].title, "Test Meeting");
             }
@@ -1461,7 +1506,7 @@ mod tests {
             .await
             .unwrap();
         match result {
-            ToolOutput::MeetingNotes(meetings) => {
+            ToolOutput::MeetingNotes(meetings, _) => {
                 assert_eq!(meetings.len(), 1);
                 assert_eq!(meetings[0].title, "Search Result Meeting");
             }

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -207,8 +207,8 @@ async fn execute_get_meeting_notes(
         limit: params.limit,
         skip: params.offset,
     };
-    let meetings = provider.get_meetings(filter).await?;
-    Ok(ToolOutput::MeetingNotes(meetings))
+    let result = provider.get_meetings(filter).await?;
+    Ok(ToolOutput::MeetingNotes(result.items))
 }
 
 #[derive(Deserialize)]
@@ -252,8 +252,8 @@ async fn execute_search_meeting_notes(
         limit: params.limit,
         skip: params.offset,
     };
-    let meetings = provider.search_meetings(&params.query, filter).await?;
-    Ok(ToolOutput::MeetingNotes(meetings))
+    let result = provider.search_meetings(&params.query, filter).await?;
+    Ok(ToolOutput::MeetingNotes(result.items))
 }
 
 // --- Issue tool handlers ---
@@ -285,8 +285,8 @@ async fn execute_get_issues(
         sort_by: params.sort_by,
         sort_order: params.sort_order,
     };
-    let issues = provider.get_issues(filter).await?;
-    Ok(ToolOutput::Issues(issues))
+    let result = provider.get_issues(filter).await?;
+    Ok(ToolOutput::Issues(result.items))
 }
 
 #[derive(Deserialize)]
@@ -310,8 +310,8 @@ async fn execute_get_issue_comments(
 ) -> Result<ToolOutput> {
     let params: KeyParam = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("missing 'key' parameter: {e}")))?;
-    let comments = provider.get_comments(&params.key).await?;
-    Ok(ToolOutput::Comments(comments))
+    let result = provider.get_comments(&params.key).await?;
+    Ok(ToolOutput::Comments(result.items))
 }
 
 #[derive(Deserialize)]
@@ -417,8 +417,8 @@ async fn execute_get_merge_requests(
         limit: params.limit.or(Some(20)),
         ..Default::default()
     };
-    let mrs = provider.get_merge_requests(filter).await?;
-    Ok(ToolOutput::MergeRequests(mrs))
+    let result = provider.get_merge_requests(filter).await?;
+    Ok(ToolOutput::MergeRequests(result.items))
 }
 
 async fn execute_get_merge_request(
@@ -437,8 +437,8 @@ async fn execute_get_merge_request_discussions(
 ) -> Result<ToolOutput> {
     let params: KeyParam = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("missing 'key' parameter: {e}")))?;
-    let discussions = provider.get_discussions(&params.key).await?;
-    Ok(ToolOutput::Discussions(discussions))
+    let result = provider.get_discussions(&params.key).await?;
+    Ok(ToolOutput::Discussions(result.items))
 }
 
 async fn execute_get_merge_request_diffs(
@@ -447,8 +447,8 @@ async fn execute_get_merge_request_diffs(
 ) -> Result<ToolOutput> {
     let params: KeyParam = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("missing 'key' parameter: {e}")))?;
-    let diffs = provider.get_diffs(&params.key).await?;
-    Ok(ToolOutput::Diffs(diffs))
+    let result = provider.get_diffs(&params.key).await?;
+    Ok(ToolOutput::Diffs(result.items))
 }
 
 #[derive(Deserialize)]
@@ -600,8 +600,8 @@ async fn execute_get_job_logs(
 async fn execute_get_available_statuses(
     provider: &dyn devboy_core::Provider,
 ) -> Result<ToolOutput> {
-    let statuses = IssueProvider::get_statuses(provider).await?;
-    Ok(ToolOutput::Statuses(statuses))
+    let result = IssueProvider::get_statuses(provider).await?;
+    Ok(ToolOutput::Statuses(result.items))
 }
 
 #[derive(Deserialize, Default)]
@@ -627,8 +627,8 @@ async fn execute_get_users(
         start_at: params.start_at,
         max_results: params.max_results,
     };
-    let users = IssueProvider::get_users(provider, options).await?;
-    Ok(ToolOutput::Users(users))
+    let result = IssueProvider::get_users(provider, options).await?;
+    Ok(ToolOutput::Users(result.items))
 }
 
 #[derive(Deserialize)]
@@ -686,8 +686,8 @@ async fn execute_get_epics(
         sort_by: None,
         sort_order: None,
     };
-    let issues = provider.get_issues(filter).await?;
-    Ok(ToolOutput::Issues(issues))
+    let result = provider.get_issues(filter).await?;
+    Ok(ToolOutput::Issues(result.items))
 }
 
 #[derive(Deserialize)]
@@ -856,8 +856,8 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for MockProvider {
-        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<Vec<Issue>> {
-            Ok(vec![sample_issue()])
+        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
+            Ok(vec![sample_issue()].into())
         }
         async fn get_issue(&self, _key: &str) -> devboy_core::Result<Issue> {
             Ok(sample_issue())
@@ -875,8 +875,8 @@ mod tests {
         ) -> devboy_core::Result<Issue> {
             Ok(sample_issue())
         }
-        async fn get_comments(&self, _key: &str) -> devboy_core::Result<Vec<Comment>> {
-            Ok(vec![sample_comment()])
+        async fn get_comments(&self, _key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
+            Ok(vec![sample_comment()].into())
         }
         async fn add_comment(&self, _key: &str, _body: &str) -> devboy_core::Result<Comment> {
             Ok(sample_comment())
@@ -891,17 +891,17 @@ mod tests {
         async fn get_merge_requests(
             &self,
             _filter: MrFilter,
-        ) -> devboy_core::Result<Vec<MergeRequest>> {
-            Ok(vec![sample_mr()])
+        ) -> devboy_core::Result<devboy_core::ProviderResult<MergeRequest>> {
+            Ok(vec![sample_mr()].into())
         }
         async fn get_merge_request(&self, _key: &str) -> devboy_core::Result<MergeRequest> {
             Ok(sample_mr())
         }
-        async fn get_discussions(&self, _key: &str) -> devboy_core::Result<Vec<Discussion>> {
-            Ok(vec![sample_discussion()])
+        async fn get_discussions(&self, _key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
+            Ok(vec![sample_discussion()].into())
         }
-        async fn get_diffs(&self, _key: &str) -> devboy_core::Result<Vec<FileDiff>> {
-            Ok(vec![sample_diff()])
+        async fn get_diffs(&self, _key: &str) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
+            Ok(vec![sample_diff()].into())
         }
         async fn add_comment(
             &self,
@@ -1305,12 +1305,12 @@ mod tests {
         async fn get_meetings(
             &self,
             _filter: MeetingFilter,
-        ) -> devboy_core::Result<Vec<devboy_core::MeetingNote>> {
+        ) -> devboy_core::Result<devboy_core::ProviderResult<devboy_core::MeetingNote>> {
             Ok(vec![devboy_core::MeetingNote {
                 id: "m1".into(),
                 title: "Test Meeting".into(),
                 ..Default::default()
-            }])
+            }].into())
         }
 
         async fn get_transcript(
@@ -1334,12 +1334,12 @@ mod tests {
             &self,
             _query: &str,
             _filter: MeetingFilter,
-        ) -> devboy_core::Result<Vec<devboy_core::MeetingNote>> {
+        ) -> devboy_core::Result<devboy_core::ProviderResult<devboy_core::MeetingNote>> {
             Ok(vec![devboy_core::MeetingNote {
                 id: "m2".into(),
                 title: "Search Result Meeting".into(),
                 ..Default::default()
-            }])
+            }].into())
         }
     }
 

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -884,7 +884,10 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for MockProvider {
-        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
+        async fn get_issues(
+            &self,
+            _filter: IssueFilter,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
             Ok(vec![sample_issue()].into())
         }
         async fn get_issue(&self, _key: &str) -> devboy_core::Result<Issue> {
@@ -903,7 +906,10 @@ mod tests {
         ) -> devboy_core::Result<Issue> {
             Ok(sample_issue())
         }
-        async fn get_comments(&self, _key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
+        async fn get_comments(
+            &self,
+            _key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
             Ok(vec![sample_comment()].into())
         }
         async fn add_comment(&self, _key: &str, _body: &str) -> devboy_core::Result<Comment> {
@@ -936,10 +942,16 @@ mod tests {
         async fn get_merge_request(&self, _key: &str) -> devboy_core::Result<MergeRequest> {
             Ok(sample_mr())
         }
-        async fn get_discussions(&self, _key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
+        async fn get_discussions(
+            &self,
+            _key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
             Ok(vec![sample_discussion()].into())
         }
-        async fn get_diffs(&self, _key: &str) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
+        async fn get_diffs(
+            &self,
+            _key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
             Ok(vec![sample_diff()].into())
         }
         async fn add_comment(
@@ -1373,7 +1385,8 @@ mod tests {
                 id: "m1".into(),
                 title: "Test Meeting".into(),
                 ..Default::default()
-            }].into())
+            }]
+            .into())
         }
 
         async fn get_transcript(
@@ -1402,7 +1415,8 @@ mod tests {
                 id: "m2".into(),
                 title: "Search Result Meeting".into(),
                 ..Default::default()
-            }].into())
+            }]
+            .into())
         }
     }
 

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -277,6 +277,9 @@ struct GetIssuesParams {
     offset: Option<u32>,
     sort_by: Option<String>,
     sort_order: Option<String>,
+    /// Token budget for response size control (consumed by format layer via execute_and_format).
+    #[allow(dead_code)]
+    budget: Option<usize>,
 }
 
 async fn execute_get_issues(
@@ -305,6 +308,10 @@ async fn execute_get_issues(
 #[derive(Deserialize)]
 struct KeyParam {
     key: String,
+    /// Token budget for response size control (consumed by format layer via execute_and_format).
+    #[serde(default)]
+    #[allow(dead_code)]
+    budget: Option<usize>,
 }
 
 async fn execute_get_issue(
@@ -440,6 +447,9 @@ struct GetMergeRequestsParams {
     offset: Option<u32>,
     sort_by: Option<String>,
     sort_order: Option<String>,
+    /// Token budget for response size control (consumed by format layer via execute_and_format).
+    #[allow(dead_code)]
+    budget: Option<usize>,
 }
 
 async fn execute_get_merge_requests(

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -415,6 +415,7 @@ async fn execute_get_merge_requests(
         author: params.author,
         labels: params.labels,
         limit: params.limit.or(Some(20)),
+        ..Default::default()
     };
     let mrs = provider.get_merge_requests(filter).await?;
     Ok(ToolOutput::MergeRequests(mrs))

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -435,11 +435,26 @@ pub async fn execute_and_format(
     ctx: &crate::context::AdditionalContext,
     pipeline_config: Option<PipelineConfig>,
 ) -> Result<FormatResult> {
-    // Extract format from args before execution
+    // Extract format and budget from args before execution
     let format = args
         .get("format")
         .and_then(|v| v.as_str())
         .map(String::from);
+
+    let budget = args
+        .get("budget")
+        .and_then(|v| v.as_u64())
+        .map(|b| b as usize);
+
+    // Apply budget override to pipeline config
+    let pipeline_config = if let Some(b) = budget {
+        let mut config = pipeline_config.unwrap_or_default();
+        // Convert token budget to max_chars (tokens * 3.5)
+        config.max_chars = (b as f64 * 3.5).floor() as usize;
+        Some(config)
+    } else {
+        pipeline_config
+    };
 
     let output = executor.execute(tool, args, ctx).await?;
     format_output(output, format.as_deref(), Some(tool), pipeline_config)

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -3,7 +3,7 @@
 //! This module bridges the executor's typed output with the pipeline's
 //! text formatting. Supports TOON (default) and JSON output formats.
 
-use devboy_core::Result;
+use devboy_core::{Pagination, Result, SortInfo};
 use devboy_format_pipeline::{OutputFormat, Pipeline, PipelineConfig};
 use serde::Serialize;
 
@@ -33,6 +33,10 @@ pub struct FormatMetadata {
     pub total_items: Option<usize>,
     /// Items included after truncation (e.g., 20 issues)
     pub included_items: usize,
+    /// Pagination metadata from the provider (offset, limit, total, has_more)
+    pub provider_pagination: Option<Pagination>,
+    /// Sort metadata from the provider (current sort, available sorts)
+    pub provider_sort: Option<SortInfo>,
 }
 
 /// Result of formatting a tool output — content + metadata.
@@ -82,8 +86,15 @@ pub fn format_output(
 
     let pipeline = Pipeline::with_config(pipeline_config);
 
+    // Extract provider metadata before consuming output
+    let provider_pagination = output.result_meta().and_then(|m| m.pagination.clone());
+    let provider_sort = output.result_meta().and_then(|m| m.sort_info.clone());
+
     // Helper: convert TransformOutput to FormatResult
-    let to_result = |t: devboy_format_pipeline::TransformOutput| -> FormatResult {
+    let to_result = |t: devboy_format_pipeline::TransformOutput,
+                     pag: Option<Pagination>,
+                     sort: Option<SortInfo>|
+     -> FormatResult {
         let content = t.to_string_with_hints();
         let output_chars = content.len();
         let raw_chars = if t.raw_chars > 0 {
@@ -111,57 +122,100 @@ pub fn format_output(
                 truncated: t.truncated,
                 total_items: t.total_count,
                 included_items: t.included_count,
+                provider_pagination: pag,
+                provider_sort: sort,
             },
             content,
         }
     };
 
     // Helper: wrap plain text (no pipeline transform)
-    let text_result = |text: String| -> FormatResult {
-        let chars = text.len();
-        FormatResult {
-            metadata: FormatMetadata {
-                raw_chars: chars,
-                output_chars: chars,
-                pre_trim_chars: chars,
-                estimated_tokens: chars * 10 / 35,
-                compression_ratio: 1.0,
-                format: "text".to_string(),
-                truncated: false,
-                total_items: None,
-                included_items: 0,
-            },
-            content: text,
-        }
-    };
+    let text_result =
+        |text: String, pag: Option<Pagination>, sort: Option<SortInfo>| -> FormatResult {
+            let chars = text.len();
+            FormatResult {
+                metadata: FormatMetadata {
+                    raw_chars: chars,
+                    output_chars: chars,
+                    pre_trim_chars: chars,
+                    estimated_tokens: chars * 10 / 35,
+                    compression_ratio: 1.0,
+                    format: "text".to_string(),
+                    truncated: false,
+                    total_items: None,
+                    included_items: 0,
+                    provider_pagination: pag,
+                    provider_sort: sort,
+                },
+                content: text,
+            }
+        };
 
     match output {
-        ToolOutput::Issues(issues) => Ok(to_result(pipeline.transform_issues(issues)?)),
-        ToolOutput::SingleIssue(issue) => Ok(to_result(pipeline.transform_issues(vec![*issue])?)),
-        ToolOutput::MergeRequests(mrs) => Ok(to_result(pipeline.transform_merge_requests(mrs)?)),
-        ToolOutput::SingleMergeRequest(mr) => {
-            Ok(to_result(pipeline.transform_merge_requests(vec![*mr])?))
-        }
-        ToolOutput::Discussions(discussions) => {
-            Ok(to_result(pipeline.transform_discussions(discussions)?))
-        }
-        ToolOutput::Diffs(diffs) => Ok(to_result(pipeline.transform_diffs(diffs)?)),
-        ToolOutput::Comments(comments) => Ok(to_result(pipeline.transform_comments(comments)?)),
-        ToolOutput::Pipeline(info) => Ok(text_result(format_pipeline(&info))),
-        ToolOutput::JobLog(log) => Ok(text_result(format_job_log(&log))),
-        ToolOutput::Statuses(statuses) => Ok(text_result(format_statuses(&statuses))),
-        ToolOutput::Users(users) => Ok(text_result(format_users(&users))),
-        ToolOutput::MeetingNotes(meetings) => Ok(text_result(format_meeting_notes(&meetings))),
-        ToolOutput::MeetingTranscript(transcript) => {
-            Ok(text_result(format_meeting_transcript(&transcript)))
-        }
+        ToolOutput::Issues(issues, _) => Ok(to_result(
+            pipeline.transform_issues(issues)?,
+            provider_pagination,
+            provider_sort,
+        )),
+        ToolOutput::SingleIssue(issue) => Ok(to_result(
+            pipeline.transform_issues(vec![*issue])?,
+            None,
+            None,
+        )),
+        ToolOutput::MergeRequests(mrs, _) => Ok(to_result(
+            pipeline.transform_merge_requests(mrs)?,
+            provider_pagination,
+            provider_sort,
+        )),
+        ToolOutput::SingleMergeRequest(mr) => Ok(to_result(
+            pipeline.transform_merge_requests(vec![*mr])?,
+            None,
+            None,
+        )),
+        ToolOutput::Discussions(discussions, _) => Ok(to_result(
+            pipeline.transform_discussions(discussions)?,
+            provider_pagination,
+            provider_sort,
+        )),
+        ToolOutput::Diffs(diffs, _) => Ok(to_result(
+            pipeline.transform_diffs(diffs)?,
+            provider_pagination,
+            provider_sort,
+        )),
+        ToolOutput::Comments(comments, _) => Ok(to_result(
+            pipeline.transform_comments(comments)?,
+            provider_pagination,
+            provider_sort,
+        )),
+        ToolOutput::Pipeline(info) => Ok(text_result(format_pipeline(&info), None, None)),
+        ToolOutput::JobLog(log) => Ok(text_result(format_job_log(&log), None, None)),
+        ToolOutput::Statuses(statuses, _) => Ok(text_result(
+            format_statuses(&statuses),
+            provider_pagination,
+            provider_sort,
+        )),
+        ToolOutput::Users(users, _) => Ok(text_result(
+            format_users(&users),
+            provider_pagination,
+            provider_sort,
+        )),
+        ToolOutput::MeetingNotes(meetings, _) => Ok(text_result(
+            format_meeting_notes(&meetings),
+            provider_pagination,
+            provider_sort,
+        )),
+        ToolOutput::MeetingTranscript(transcript) => Ok(text_result(
+            format_meeting_transcript(&transcript),
+            None,
+            None,
+        )),
         ToolOutput::Relations(relations) => {
             let json = serde_json::to_string_pretty(&*relations).map_err(|e| {
                 devboy_core::Error::InvalidData(format!("failed to serialize relations: {e}"))
             })?;
-            Ok(text_result(json))
+            Ok(text_result(json, None, None))
         }
-        ToolOutput::Text(text) => Ok(text_result(text)),
+        ToolOutput::Text(text) => Ok(text_result(text, None, None)),
     }
 }
 
@@ -417,7 +471,7 @@ mod tests {
 
     #[test]
     fn test_format_issues_toon() {
-        let output = ToolOutput::Issues(vec![sample_issue()]);
+        let output = ToolOutput::Issues(vec![sample_issue()], None);
         let result = format_output(output, Some("toon"), None, None)
             .unwrap()
             .content;
@@ -427,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_format_metadata_toon_compression() {
-        let output = ToolOutput::Issues(vec![sample_issue()]);
+        let output = ToolOutput::Issues(vec![sample_issue()], None);
         let result = format_output(output, Some("toon"), None, None).unwrap();
 
         assert!(result.metadata.raw_chars > 0, "raw_chars should be > 0");
@@ -460,7 +514,7 @@ mod tests {
 
     #[test]
     fn test_format_metadata_truncated() {
-        let output = ToolOutput::Issues(vec![sample_issue()]);
+        let output = ToolOutput::Issues(vec![sample_issue()], None);
         let config = PipelineConfig {
             max_chars: 50, // very small — will truncate
             ..PipelineConfig::default()
@@ -479,7 +533,7 @@ mod tests {
 
     #[test]
     fn test_format_issues_json() {
-        let output = ToolOutput::Issues(vec![sample_issue()]);
+        let output = ToolOutput::Issues(vec![sample_issue()], None);
         let result = format_output(output, Some("json"), None, None)
             .unwrap()
             .content;
@@ -488,7 +542,7 @@ mod tests {
 
     #[test]
     fn test_format_issues_toon_explicit() {
-        let output = ToolOutput::Issues(vec![sample_issue()]);
+        let output = ToolOutput::Issues(vec![sample_issue()], None);
         let result = format_output(output, Some("toon"), None, None)
             .unwrap()
             .content;
@@ -504,7 +558,7 @@ mod tests {
 
     #[test]
     fn test_format_default_is_toon() {
-        let output = ToolOutput::Issues(vec![sample_issue()]);
+        let output = ToolOutput::Issues(vec![sample_issue()], None);
         let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("gh#1"));
     }
@@ -540,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_format_merge_requests() {
-        let output = ToolOutput::MergeRequests(vec![sample_mr()]);
+        let output = ToolOutput::MergeRequests(vec![sample_mr()], None);
         let result = format_output(output, Some("toon"), None, None)
             .unwrap()
             .content;
@@ -558,20 +612,23 @@ mod tests {
 
     #[test]
     fn test_format_discussions() {
-        let output = ToolOutput::Discussions(vec![devboy_core::Discussion {
-            id: "d1".into(),
-            resolved: false,
-            resolved_by: None,
-            comments: vec![devboy_core::Comment {
-                id: "c1".into(),
-                body: "Review comment".into(),
-                author: None,
-                created_at: None,
-                updated_at: None,
+        let output = ToolOutput::Discussions(
+            vec![devboy_core::Discussion {
+                id: "d1".into(),
+                resolved: false,
+                resolved_by: None,
+                comments: vec![devboy_core::Comment {
+                    id: "c1".into(),
+                    body: "Review comment".into(),
+                    author: None,
+                    created_at: None,
+                    updated_at: None,
+                    position: None,
+                }],
                 position: None,
             }],
-            position: None,
-        }]);
+            None,
+        );
         let result = format_output(output, Some("toon"), None, None)
             .unwrap()
             .content;
@@ -580,16 +637,19 @@ mod tests {
 
     #[test]
     fn test_format_diffs() {
-        let output = ToolOutput::Diffs(vec![devboy_core::FileDiff {
-            file_path: "src/main.rs".into(),
-            old_path: None,
-            new_file: false,
-            deleted_file: false,
-            renamed_file: false,
-            diff: "+added line".into(),
-            additions: Some(1),
-            deletions: Some(0),
-        }]);
+        let output = ToolOutput::Diffs(
+            vec![devboy_core::FileDiff {
+                file_path: "src/main.rs".into(),
+                old_path: None,
+                new_file: false,
+                deleted_file: false,
+                renamed_file: false,
+                diff: "+added line".into(),
+                additions: Some(1),
+                deletions: Some(0),
+            }],
+            None,
+        );
         let result = format_output(output, Some("toon"), None, None)
             .unwrap()
             .content;
@@ -598,14 +658,17 @@ mod tests {
 
     #[test]
     fn test_format_comments() {
-        let output = ToolOutput::Comments(vec![devboy_core::Comment {
-            id: "c1".into(),
-            body: "A comment body".into(),
-            author: None,
-            created_at: None,
-            updated_at: None,
-            position: None,
-        }]);
+        let output = ToolOutput::Comments(
+            vec![devboy_core::Comment {
+                id: "c1".into(),
+                body: "A comment body".into(),
+                author: None,
+                created_at: None,
+                updated_at: None,
+                position: None,
+            }],
+            None,
+        );
         let result = format_output(output, Some("json"), None, None)
             .unwrap()
             .content;
@@ -614,7 +677,7 @@ mod tests {
 
     #[test]
     fn test_format_with_custom_pipeline_config() {
-        let output = ToolOutput::Issues(vec![sample_issue()]);
+        let output = ToolOutput::Issues(vec![sample_issue()], None);
         let config = PipelineConfig {
             max_chars: 500,
             ..PipelineConfig::default()
@@ -828,22 +891,25 @@ mod tests {
 
     #[test]
     fn test_format_statuses() {
-        let output = ToolOutput::Statuses(vec![
-            devboy_core::IssueStatus {
-                id: "1".into(),
-                name: "To Do".into(),
-                category: "todo".into(),
-                color: Some("#blue".into()),
-                order: Some(0),
-            },
-            devboy_core::IssueStatus {
-                id: "2".into(),
-                name: "In Progress".into(),
-                category: "in_progress".into(),
-                color: None,
-                order: None,
-            },
-        ]);
+        let output = ToolOutput::Statuses(
+            vec![
+                devboy_core::IssueStatus {
+                    id: "1".into(),
+                    name: "To Do".into(),
+                    category: "todo".into(),
+                    color: Some("#blue".into()),
+                    order: Some(0),
+                },
+                devboy_core::IssueStatus {
+                    id: "2".into(),
+                    name: "In Progress".into(),
+                    category: "in_progress".into(),
+                    color: None,
+                    order: None,
+                },
+            ],
+            None,
+        );
         let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("Available Statuses"));
         assert!(result.contains("To Do"));
@@ -855,7 +921,7 @@ mod tests {
 
     #[test]
     fn test_format_statuses_empty() {
-        let output = ToolOutput::Statuses(vec![]);
+        let output = ToolOutput::Statuses(vec![], None);
         let result = format_output(output, None, None, None).unwrap().content;
         assert_eq!(result, "No statuses found.");
     }
@@ -864,22 +930,25 @@ mod tests {
 
     #[test]
     fn test_format_users() {
-        let output = ToolOutput::Users(vec![
-            devboy_core::User {
-                id: "u1".into(),
-                username: "johndoe".into(),
-                name: Some("John Doe".into()),
-                email: Some("john@example.com".into()),
-                avatar_url: None,
-            },
-            devboy_core::User {
-                id: "u2".into(),
-                username: "janesmith".into(),
-                name: None,
-                email: None,
-                avatar_url: None,
-            },
-        ]);
+        let output = ToolOutput::Users(
+            vec![
+                devboy_core::User {
+                    id: "u1".into(),
+                    username: "johndoe".into(),
+                    name: Some("John Doe".into()),
+                    email: Some("john@example.com".into()),
+                    avatar_url: None,
+                },
+                devboy_core::User {
+                    id: "u2".into(),
+                    username: "janesmith".into(),
+                    name: None,
+                    email: None,
+                    avatar_url: None,
+                },
+            ],
+            None,
+        );
         let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("# Users"));
         assert!(result.contains("johndoe"));
@@ -891,7 +960,7 @@ mod tests {
 
     #[test]
     fn test_format_users_empty() {
-        let output = ToolOutput::Users(vec![]);
+        let output = ToolOutput::Users(vec![], None);
         let result = format_output(output, None, None, None).unwrap().content;
         assert_eq!(result, "No users found.");
     }
@@ -949,7 +1018,7 @@ mod tests {
             summary: Some("Discussed sprint goals.".into()),
             ..Default::default()
         }];
-        let output = ToolOutput::MeetingNotes(meetings);
+        let output = ToolOutput::MeetingNotes(meetings, None);
         let result = format_output(output, None, None, None).unwrap().content;
         assert!(result.contains("Sprint Planning"));
         assert!(result.contains("2025-01-15T10:00:00Z"));
@@ -964,7 +1033,7 @@ mod tests {
 
     #[test]
     fn test_format_meeting_notes_empty() {
-        let output = ToolOutput::MeetingNotes(vec![]);
+        let output = ToolOutput::MeetingNotes(vec![], None);
         let result = format_output(output, None, None, None).unwrap().content;
         assert_eq!(result, "No meeting notes found.");
     }

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -608,7 +608,6 @@ mod tests {
     fn test_format_with_custom_pipeline_config() {
         let output = ToolOutput::Issues(vec![sample_issue()]);
         let config = PipelineConfig {
-            max_items: 1,
             max_chars: 500,
             ..PipelineConfig::default()
         };

--- a/crates/devboy-executor/src/lib.rs
+++ b/crates/devboy-executor/src/lib.rs
@@ -58,5 +58,5 @@ pub use enricher::PipelineFormatEnricher;
 pub use executor::{Executor, SUPPORTED_TOOLS};
 pub use factory::create_enricher;
 pub use format::{FormatMetadata, FormatResult, execute_and_format, format_output};
-pub use output::ToolOutput;
+pub use output::{ResultMeta, ToolOutput};
 pub use tools::ToolDefinition;

--- a/crates/devboy-executor/src/lib.rs
+++ b/crates/devboy-executor/src/lib.rs
@@ -14,12 +14,12 @@
 //!
 //! ```rust,no_run
 //! use devboy_executor::{Executor, AdditionalContext, ProviderConfig, GitLabScope};
-//! use devboy_executor::enricher::PipelineFormatEnricher;
+//! use devboy_executor::enricher::FormatPipelineEnricher;
 //! use std::collections::HashMap;
 //!
 //! # async fn example() -> devboy_core::Result<()> {
 //! let mut executor = Executor::new();
-//! executor.add_enricher(Box::new(PipelineFormatEnricher));
+//! executor.add_enricher(Box::new(FormatPipelineEnricher));
 //!
 //! let ctx = AdditionalContext {
 //!     provider: ProviderConfig::GitLab {

--- a/crates/devboy-executor/src/output.rs
+++ b/crates/devboy-executor/src/output.rs
@@ -295,7 +295,8 @@ mod tests {
                 has_more: true,
             }),
             sort_info: Some(devboy_core::SortInfo {
-                current_sort: Some("created_at:desc".into()),
+                sort_by: Some("created_at".into()),
+                sort_order: devboy_core::SortOrder::Desc,
                 available_sorts: vec!["created_at".into()],
             }),
         };

--- a/crates/devboy-executor/src/output.rs
+++ b/crates/devboy-executor/src/output.rs
@@ -1,7 +1,14 @@
 use devboy_core::{
     Comment, Discussion, FileDiff, Issue, IssueRelations, IssueStatus, JobLogOutput, MeetingNote,
-    MeetingTranscript, MergeRequest, PipelineInfo, User,
+    MeetingTranscript, MergeRequest, Pagination, PipelineInfo, SortInfo, User,
 };
+
+/// Metadata from provider result (pagination + sort info).
+#[derive(Debug, Clone, Default)]
+pub struct ResultMeta {
+    pub pagination: Option<Pagination>,
+    pub sort_info: Option<SortInfo>,
+}
 
 /// Typed result of tool execution.
 ///
@@ -11,29 +18,29 @@ use devboy_core::{
 #[derive(Debug)]
 pub enum ToolOutput {
     /// List of merge requests / pull requests
-    MergeRequests(Vec<MergeRequest>),
+    MergeRequests(Vec<MergeRequest>, Option<ResultMeta>),
     /// Single merge request / pull request
     SingleMergeRequest(Box<MergeRequest>),
     /// MR/PR discussions with comments and code positions
-    Discussions(Vec<Discussion>),
+    Discussions(Vec<Discussion>, Option<ResultMeta>),
     /// File diffs from a merge request / pull request
-    Diffs(Vec<FileDiff>),
+    Diffs(Vec<FileDiff>, Option<ResultMeta>),
     /// List of issues / tasks
-    Issues(Vec<Issue>),
+    Issues(Vec<Issue>, Option<ResultMeta>),
     /// Single issue / task
     SingleIssue(Box<Issue>),
     /// Comments on an issue or merge request
-    Comments(Vec<Comment>),
+    Comments(Vec<Comment>, Option<ResultMeta>),
     /// CI/CD pipeline status with jobs
     Pipeline(Box<PipelineInfo>),
     /// Job log output
     JobLog(Box<JobLogOutput>),
     /// Available issue statuses
-    Statuses(Vec<IssueStatus>),
+    Statuses(Vec<IssueStatus>, Option<ResultMeta>),
     /// List of users
-    Users(Vec<User>),
+    Users(Vec<User>, Option<ResultMeta>),
     /// List of meeting notes
-    MeetingNotes(Vec<MeetingNote>),
+    MeetingNotes(Vec<MeetingNote>, Option<ResultMeta>),
     /// Single meeting transcript with sentences
     MeetingTranscript(Box<MeetingTranscript>),
     /// Issue relations (parent, subtasks, linked issues)
@@ -46,14 +53,14 @@ impl ToolOutput {
     /// Returns the number of items in collection outputs, or 1 for single items.
     pub fn item_count(&self) -> usize {
         match self {
-            Self::MergeRequests(v) => v.len(),
-            Self::Discussions(v) => v.len(),
-            Self::Diffs(v) => v.len(),
-            Self::Issues(v) => v.len(),
-            Self::Comments(v) => v.len(),
-            Self::Statuses(v) => v.len(),
-            Self::Users(v) => v.len(),
-            Self::MeetingNotes(v) => v.len(),
+            Self::MergeRequests(v, _) => v.len(),
+            Self::Discussions(v, _) => v.len(),
+            Self::Diffs(v, _) => v.len(),
+            Self::Issues(v, _) => v.len(),
+            Self::Comments(v, _) => v.len(),
+            Self::Statuses(v, _) => v.len(),
+            Self::Users(v, _) => v.len(),
+            Self::MeetingNotes(v, _) => v.len(),
             Self::SingleMergeRequest(_)
             | Self::SingleIssue(_)
             | Self::Pipeline(_)
@@ -67,21 +74,36 @@ impl ToolOutput {
     /// Returns a human-readable type name for this output.
     pub fn type_name(&self) -> &'static str {
         match self {
-            Self::MergeRequests(_) => "merge_requests",
+            Self::MergeRequests(..) => "merge_requests",
             Self::SingleMergeRequest(_) => "merge_request",
-            Self::Discussions(_) => "discussions",
-            Self::Diffs(_) => "diffs",
-            Self::Issues(_) => "issues",
+            Self::Discussions(..) => "discussions",
+            Self::Diffs(..) => "diffs",
+            Self::Issues(..) => "issues",
             Self::SingleIssue(_) => "issue",
-            Self::Comments(_) => "comments",
+            Self::Comments(..) => "comments",
             Self::Pipeline(_) => "pipeline",
             Self::JobLog(_) => "job_log",
-            Self::Statuses(_) => "statuses",
-            Self::Users(_) => "users",
-            Self::MeetingNotes(_) => "meeting_notes",
+            Self::Statuses(..) => "statuses",
+            Self::Users(..) => "users",
+            Self::MeetingNotes(..) => "meeting_notes",
             Self::MeetingTranscript(_) => "meeting_transcript",
             Self::Relations(_) => "issue_relations",
             Self::Text(_) => "text",
+        }
+    }
+
+    /// Returns the result metadata (pagination + sort info) if present.
+    pub fn result_meta(&self) -> Option<&ResultMeta> {
+        match self {
+            Self::MergeRequests(_, meta)
+            | Self::Discussions(_, meta)
+            | Self::Diffs(_, meta)
+            | Self::Issues(_, meta)
+            | Self::Comments(_, meta)
+            | Self::Statuses(_, meta)
+            | Self::Users(_, meta)
+            | Self::MeetingNotes(_, meta) => meta.as_ref(),
+            _ => None,
         }
     }
 }
@@ -132,16 +154,19 @@ mod tests {
 
     #[test]
     fn test_item_count_all_variants() {
-        assert_eq!(ToolOutput::Issues(vec![issue(), issue()]).item_count(), 2);
-        assert_eq!(ToolOutput::MergeRequests(vec![]).item_count(), 0);
+        assert_eq!(
+            ToolOutput::Issues(vec![issue(), issue()], None).item_count(),
+            2
+        );
+        assert_eq!(ToolOutput::MergeRequests(vec![], None).item_count(), 0);
         assert_eq!(ToolOutput::SingleIssue(Box::new(issue())).item_count(), 1);
         assert_eq!(
             ToolOutput::SingleMergeRequest(Box::new(mr())).item_count(),
             1
         );
-        assert_eq!(ToolOutput::Discussions(vec![]).item_count(), 0);
-        assert_eq!(ToolOutput::Diffs(vec![]).item_count(), 0);
-        assert_eq!(ToolOutput::Comments(vec![]).item_count(), 0);
+        assert_eq!(ToolOutput::Discussions(vec![], None).item_count(), 0);
+        assert_eq!(ToolOutput::Diffs(vec![], None).item_count(), 0);
+        assert_eq!(ToolOutput::Comments(vec![], None).item_count(), 0);
         assert_eq!(
             ToolOutput::Pipeline(Box::new(devboy_core::PipelineInfo {
                 id: "1".into(),
@@ -170,38 +195,44 @@ mod tests {
             1
         );
         assert_eq!(
-            ToolOutput::Statuses(vec![IssueStatus {
-                id: "1".into(),
-                name: "Open".into(),
-                category: "open".into(),
-                color: None,
-                order: None,
-            }])
+            ToolOutput::Statuses(
+                vec![IssueStatus {
+                    id: "1".into(),
+                    name: "Open".into(),
+                    category: "open".into(),
+                    color: None,
+                    order: None,
+                }],
+                None
+            )
             .item_count(),
             1
         );
-        assert_eq!(ToolOutput::Statuses(vec![]).item_count(), 0);
+        assert_eq!(ToolOutput::Statuses(vec![], None).item_count(), 0);
         assert_eq!(
-            ToolOutput::Users(vec![User {
-                id: "1".into(),
-                username: "test".into(),
-                name: None,
-                email: None,
-                avatar_url: None,
-            }])
+            ToolOutput::Users(
+                vec![User {
+                    id: "1".into(),
+                    username: "test".into(),
+                    name: None,
+                    email: None,
+                    avatar_url: None,
+                }],
+                None
+            )
             .item_count(),
             1
         );
-        assert_eq!(ToolOutput::Users(vec![]).item_count(), 0);
+        assert_eq!(ToolOutput::Users(vec![], None).item_count(), 0);
         assert_eq!(ToolOutput::Relations(Box::default()).item_count(), 1);
         assert_eq!(ToolOutput::Text("x".into()).item_count(), 1);
     }
 
     #[test]
     fn test_type_name_all_variants() {
-        assert_eq!(ToolOutput::Issues(vec![]).type_name(), "issues");
+        assert_eq!(ToolOutput::Issues(vec![], None).type_name(), "issues");
         assert_eq!(
-            ToolOutput::MergeRequests(vec![]).type_name(),
+            ToolOutput::MergeRequests(vec![], None).type_name(),
             "merge_requests"
         );
         assert_eq!(
@@ -212,9 +243,12 @@ mod tests {
             ToolOutput::SingleMergeRequest(Box::new(mr())).type_name(),
             "merge_request"
         );
-        assert_eq!(ToolOutput::Discussions(vec![]).type_name(), "discussions");
-        assert_eq!(ToolOutput::Diffs(vec![]).type_name(), "diffs");
-        assert_eq!(ToolOutput::Comments(vec![]).type_name(), "comments");
+        assert_eq!(
+            ToolOutput::Discussions(vec![], None).type_name(),
+            "discussions"
+        );
+        assert_eq!(ToolOutput::Diffs(vec![], None).type_name(), "diffs");
+        assert_eq!(ToolOutput::Comments(vec![], None).type_name(), "comments");
         assert_eq!(
             ToolOutput::Pipeline(Box::new(devboy_core::PipelineInfo {
                 id: "1".into(),
@@ -242,8 +276,8 @@ mod tests {
             .type_name(),
             "job_log"
         );
-        assert_eq!(ToolOutput::Statuses(vec![]).type_name(), "statuses");
-        assert_eq!(ToolOutput::Users(vec![]).type_name(), "users");
+        assert_eq!(ToolOutput::Statuses(vec![], None).type_name(), "statuses");
+        assert_eq!(ToolOutput::Users(vec![], None).type_name(), "users");
         assert_eq!(
             ToolOutput::Relations(Box::default()).type_name(),
             "issue_relations"

--- a/crates/devboy-executor/src/output.rs
+++ b/crates/devboy-executor/src/output.rs
@@ -284,4 +284,70 @@ mod tests {
         );
         assert_eq!(ToolOutput::Text("x".into()).type_name(), "text");
     }
+
+    #[test]
+    fn test_result_meta_present() {
+        let meta = ResultMeta {
+            pagination: Some(devboy_core::Pagination {
+                offset: 0,
+                limit: 10,
+                total: Some(50),
+                has_more: true,
+            }),
+            sort_info: Some(devboy_core::SortInfo {
+                current_sort: Some("created_at:desc".into()),
+                available_sorts: vec!["created_at".into()],
+            }),
+        };
+
+        let output = ToolOutput::Issues(vec![issue()], Some(meta));
+        let rm = output.result_meta().unwrap();
+        assert!(rm.pagination.is_some());
+        assert!(rm.sort_info.is_some());
+        assert_eq!(rm.pagination.as_ref().unwrap().total, Some(50));
+    }
+
+    #[test]
+    fn test_result_meta_none_for_single_variants() {
+        assert!(
+            ToolOutput::SingleIssue(Box::new(issue()))
+                .result_meta()
+                .is_none()
+        );
+        assert!(
+            ToolOutput::SingleMergeRequest(Box::new(mr()))
+                .result_meta()
+                .is_none()
+        );
+        assert!(ToolOutput::Text("hello".into()).result_meta().is_none());
+        assert!(
+            ToolOutput::Relations(Box::default())
+                .result_meta()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_result_meta_none_when_not_provided() {
+        assert!(ToolOutput::Issues(vec![], None).result_meta().is_none());
+        assert!(
+            ToolOutput::MergeRequests(vec![], None)
+                .result_meta()
+                .is_none()
+        );
+        assert!(
+            ToolOutput::Discussions(vec![], None)
+                .result_meta()
+                .is_none()
+        );
+        assert!(ToolOutput::Diffs(vec![], None).result_meta().is_none());
+        assert!(ToolOutput::Comments(vec![], None).result_meta().is_none());
+        assert!(ToolOutput::Statuses(vec![], None).result_meta().is_none());
+        assert!(ToolOutput::Users(vec![], None).result_meta().is_none());
+        assert!(
+            ToolOutput::MeetingNotes(vec![], None)
+                .result_meta()
+                .is_none()
+        );
+    }
 }

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -32,6 +32,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("offset", PropertySchema::integer("Number of results to skip (default: 0)", Some(0.0), None));
                 s.add_property("sort_by", PropertySchema::string_enum(&["created_at", "updated_at"], "Sort by field (default: updated_at)"));
                 s.add_property("sort_order", PropertySchema::string_enum(&["asc", "desc"], "Sort order (default: desc)"));
+                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s
             },
         },
@@ -42,6 +43,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
             input_schema: {
                 let mut s = ToolSchema::new();
                 s.add_property("key", PropertySchema::string("Issue key"));
+                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s.set_required("key", true);
                 s
             },
@@ -53,6 +55,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
             input_schema: {
                 let mut s = ToolSchema::new();
                 s.add_property("key", PropertySchema::string("Issue key"));
+                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s.set_required("key", true);
                 s
             },
@@ -129,6 +132,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("source_branch", PropertySchema::string("Filter by source branch"));
                 s.add_property("target_branch", PropertySchema::string("Filter by target branch"));
                 s.add_property("limit", PropertySchema::integer("Maximum results (default: 20)", Some(1.0), Some(100.0)));
+                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s
             },
         },
@@ -139,6 +143,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
             input_schema: {
                 let mut s = ToolSchema::new();
                 s.add_property("key", PropertySchema::string("MR/PR key"));
+                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s.set_required("key", true);
                 s
             },
@@ -152,6 +157,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("key", PropertySchema::string("MR/PR key"));
                 s.add_property("limit", PropertySchema::integer("Max discussions (default: 20)", Some(1.0), Some(100.0)));
                 s.add_property("offset", PropertySchema::integer("Skip N discussions (default: 0)", Some(0.0), None));
+                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s.set_required("key", true);
                 s
             },
@@ -163,6 +169,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
             input_schema: {
                 let mut s = ToolSchema::new();
                 s.add_property("key", PropertySchema::string("MR/PR key"));
+                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s.set_required("key", true);
                 s
             },

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -32,7 +32,6 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("offset", PropertySchema::integer("Number of results to skip (default: 0)", Some(0.0), None));
                 s.add_property("sort_by", PropertySchema::string_enum(&["created_at", "updated_at"], "Sort by field (default: updated_at)"));
                 s.add_property("sort_order", PropertySchema::string_enum(&["asc", "desc"], "Sort order (default: desc)"));
-                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s
             },
         },
@@ -43,7 +42,6 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
             input_schema: {
                 let mut s = ToolSchema::new();
                 s.add_property("key", PropertySchema::string("Issue key"));
-                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s.set_required("key", true);
                 s
             },
@@ -55,7 +53,6 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
             input_schema: {
                 let mut s = ToolSchema::new();
                 s.add_property("key", PropertySchema::string("Issue key"));
-                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s.set_required("key", true);
                 s
             },
@@ -132,7 +129,6 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("source_branch", PropertySchema::string("Filter by source branch"));
                 s.add_property("target_branch", PropertySchema::string("Filter by target branch"));
                 s.add_property("limit", PropertySchema::integer("Maximum results (default: 20)", Some(1.0), Some(100.0)));
-                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s
             },
         },
@@ -143,7 +139,6 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
             input_schema: {
                 let mut s = ToolSchema::new();
                 s.add_property("key", PropertySchema::string("MR/PR key"));
-                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s.set_required("key", true);
                 s
             },
@@ -157,7 +152,6 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("key", PropertySchema::string("MR/PR key"));
                 s.add_property("limit", PropertySchema::integer("Max discussions (default: 20)", Some(1.0), Some(100.0)));
                 s.add_property("offset", PropertySchema::integer("Skip N discussions (default: 0)", Some(0.0), None));
-                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s.set_required("key", true);
                 s
             },
@@ -169,7 +163,6 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
             input_schema: {
                 let mut s = ToolSchema::new();
                 s.add_property("key", PropertySchema::string("MR/PR key"));
-                s.add_property("budget", PropertySchema::integer("Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.", Some(100.0), Some(100000.0)));
                 s.set_required("key", true);
                 s
             },

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -743,13 +743,13 @@ impl ToolHandler {
 
         for provider in &providers {
             match provider.get_issues(filter.clone()).await {
-                Ok(issues) => {
+                Ok(result) => {
                     tracing::debug!(
                         "Got {} issues from {}",
-                        issues.len(),
+                        result.items.len(),
                         get_provider_name(provider.as_ref())
                     );
-                    all_issues.extend(issues);
+                    all_issues.extend(result.items);
                 }
                 Err(e) => {
                     let name = get_provider_name(provider.as_ref());
@@ -822,9 +822,9 @@ impl ToolHandler {
 
         for provider in &self.providers {
             match provider.get_comments(&params.key).await {
-                Ok(comments) => {
+                Ok(result) => {
                     let pipeline = self.create_pipeline(&params.format);
-                    return match pipeline.transform_comments(comments) {
+                    return match pipeline.transform_comments(result.items) {
                         Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
                         Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
                     };
@@ -1002,13 +1002,13 @@ impl ToolHandler {
 
         for provider in &self.providers {
             match provider.get_merge_requests(filter.clone()).await {
-                Ok(mrs) => {
+                Ok(result) => {
                     tracing::debug!(
                         "Got {} MRs from {}",
-                        mrs.len(),
+                        result.items.len(),
                         get_provider_name(provider.as_ref())
                     );
-                    all_mrs.extend(mrs);
+                    all_mrs.extend(result.items);
                 }
                 Err(e) => {
                     let name = get_provider_name(provider.as_ref());
@@ -1094,7 +1094,8 @@ impl ToolHandler {
 
         for provider in &self.providers {
             match provider.get_discussions(&params.key).await {
-                Ok(discussions) => {
+                Ok(result) => {
+                    let discussions = result.items;
                     let offset = params.offset.unwrap_or(0);
                     let limit = params.limit.unwrap_or(20);
                     let total = discussions.len();
@@ -1158,9 +1159,9 @@ impl ToolHandler {
 
         for provider in &self.providers {
             match provider.get_diffs(&params.key).await {
-                Ok(diffs) => {
+                Ok(result) => {
                     let pipeline = self.create_pipeline(&params.format);
-                    return match pipeline.transform_diffs(diffs) {
+                    return match pipeline.transform_diffs(result.items) {
                         Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
                         Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
                     };
@@ -1448,8 +1449,8 @@ impl ToolHandler {
         let mut last_error: Option<String> = None;
         for provider in &self.meeting_providers {
             match provider.get_meetings(filter.clone()).await {
-                Ok(meetings) => {
-                    let output = devboy_executor::ToolOutput::MeetingNotes(meetings);
+                Ok(result) => {
+                    let output = devboy_executor::ToolOutput::MeetingNotes(result.items);
                     return match devboy_executor::format_output(
                         output,
                         None,
@@ -1550,8 +1551,8 @@ impl ToolHandler {
                 .search_meetings(&params.query, filter.clone())
                 .await
             {
-                Ok(meetings) => {
-                    let output = devboy_executor::ToolOutput::MeetingNotes(meetings);
+                Ok(result) => {
+                    let output = devboy_executor::ToolOutput::MeetingNotes(result.items);
                     return match devboy_executor::format_output(
                         output,
                         None,
@@ -1848,8 +1849,8 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for MockProvider {
-        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<Vec<Issue>> {
-            Ok(self.issues.clone())
+        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
+            Ok(self.issues.clone().into())
         }
 
         async fn get_issue(&self, _key: &str) -> devboy_core::Result<Issue> {
@@ -1868,7 +1869,7 @@ mod tests {
             Ok(self.issues[0].clone())
         }
 
-        async fn get_comments(&self, _issue_key: &str) -> devboy_core::Result<Vec<Comment>> {
+        async fn get_comments(&self, _issue_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
             Ok(vec![Comment {
                 id: "1".to_string(),
                 body: "Test comment".to_string(),
@@ -1876,7 +1877,7 @@ mod tests {
                 created_at: None,
                 updated_at: None,
                 position: None,
-            }])
+            }].into())
         }
 
         async fn add_comment(&self, _issue_key: &str, _body: &str) -> devboy_core::Result<Comment> {
@@ -1900,15 +1901,15 @@ mod tests {
         async fn get_merge_requests(
             &self,
             _filter: MrFilter,
-        ) -> devboy_core::Result<Vec<MergeRequest>> {
-            Ok(self.mrs.clone())
+        ) -> devboy_core::Result<devboy_core::ProviderResult<MergeRequest>> {
+            Ok(self.mrs.clone().into())
         }
 
         async fn get_merge_request(&self, _key: &str) -> devboy_core::Result<MergeRequest> {
             Ok(self.mrs[0].clone())
         }
 
-        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<Vec<Discussion>> {
+        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
             Ok(vec![Discussion {
                 id: "1".to_string(),
                 resolved: false,
@@ -1922,10 +1923,10 @@ mod tests {
                     position: None,
                 }],
                 position: None,
-            }])
+            }].into())
         }
 
-        async fn get_diffs(&self, _mr_key: &str) -> devboy_core::Result<Vec<FileDiff>> {
+        async fn get_diffs(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
             Ok(vec![FileDiff {
                 file_path: "src/main.rs".to_string(),
                 old_path: None,
@@ -1935,7 +1936,7 @@ mod tests {
                 diff: "+added line\n-removed line".to_string(),
                 additions: Some(1),
                 deletions: Some(1),
-            }])
+            }].into())
         }
 
         async fn add_comment(
@@ -1987,7 +1988,7 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for ManyDiscussionsProvider {
-        async fn get_issues(&self, filter: IssueFilter) -> devboy_core::Result<Vec<Issue>> {
+        async fn get_issues(&self, filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
             self.base.get_issues(filter).await
         }
 
@@ -2007,7 +2008,7 @@ mod tests {
             self.base.update_issue(key, input).await
         }
 
-        async fn get_comments(&self, issue_key: &str) -> devboy_core::Result<Vec<Comment>> {
+        async fn get_comments(&self, issue_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
             self.base.get_comments(issue_key).await
         }
 
@@ -2025,7 +2026,7 @@ mod tests {
         async fn get_merge_requests(
             &self,
             filter: MrFilter,
-        ) -> devboy_core::Result<Vec<MergeRequest>> {
+        ) -> devboy_core::Result<devboy_core::ProviderResult<MergeRequest>> {
             self.base.get_merge_requests(filter).await
         }
 
@@ -2033,11 +2034,11 @@ mod tests {
             self.base.get_merge_request(key).await
         }
 
-        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<Vec<Discussion>> {
-            Ok(self.discussions.clone())
+        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
+            Ok(self.discussions.clone().into())
         }
 
-        async fn get_diffs(&self, mr_key: &str) -> devboy_core::Result<Vec<FileDiff>> {
+        async fn get_diffs(&self, mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
             self.base.get_diffs(mr_key).await
         }
 
@@ -2136,7 +2137,8 @@ mod tests {
         let merge_requests = provider
             .get_merge_requests(MrFilter::default())
             .await
-            .expect("merge requests should be forwarded");
+            .expect("merge requests should be forwarded")
+            .items;
         assert_eq!(merge_requests.len(), 1);
         assert_eq!(merge_requests[0].key, "pr#1");
 
@@ -2149,14 +2151,16 @@ mod tests {
         let discussions = provider
             .get_discussions("pr#1")
             .await
-            .expect("custom discussions should be returned");
+            .expect("custom discussions should be returned")
+            .items;
         assert_eq!(discussions.len(), 2);
         assert_eq!(discussions[0].comments[0].body, "Review comment 1");
 
         let diffs = provider
             .get_diffs("pr#1")
             .await
-            .expect("diffs should be forwarded");
+            .expect("diffs should be forwarded")
+            .items;
         assert_eq!(diffs.len(), 1);
         assert_eq!(diffs[0].file_path, "src/main.rs");
     }
@@ -2989,7 +2993,7 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for FailingProvider {
-        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<Vec<Issue>> {
+        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
             Err(devboy_core::Error::Api {
                 status: 500,
                 message: "api error".into(),
@@ -3014,7 +3018,7 @@ mod tests {
                 message: "update failed".into(),
             })
         }
-        async fn get_comments(&self, _key: &str) -> devboy_core::Result<Vec<Comment>> {
+        async fn get_comments(&self, _key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
         async fn add_comment(&self, _key: &str, _body: &str) -> devboy_core::Result<Comment> {
@@ -3033,7 +3037,7 @@ mod tests {
         async fn get_merge_requests(
             &self,
             _filter: MrFilter,
-        ) -> devboy_core::Result<Vec<MergeRequest>> {
+        ) -> devboy_core::Result<devboy_core::ProviderResult<MergeRequest>> {
             Err(devboy_core::Error::Api {
                 status: 500,
                 message: "api error".into(),
@@ -3042,10 +3046,10 @@ mod tests {
         async fn get_merge_request(&self, _key: &str) -> devboy_core::Result<MergeRequest> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
-        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<Vec<Discussion>> {
+        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
-        async fn get_diffs(&self, _mr_key: &str) -> devboy_core::Result<Vec<FileDiff>> {
+        async fn get_diffs(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
         async fn add_comment(

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -994,6 +994,7 @@ impl ToolHandler {
             source_branch: params.source_branch,
             target_branch: params.target_branch,
             limit: Some(params.limit.unwrap_or(20) as u32),
+            ..Default::default()
         };
 
         let mut all_mrs = Vec::new();

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -1526,7 +1526,12 @@ impl ToolHandler {
         for provider in &self.meeting_providers {
             match provider.get_meetings(filter.clone()).await {
                 Ok(result) => {
-                    let output = devboy_executor::ToolOutput::MeetingNotes(result.items);
+                    let meta = devboy_executor::ResultMeta {
+                        pagination: result.pagination,
+                        sort_info: result.sort_info,
+                    };
+                    let output =
+                        devboy_executor::ToolOutput::MeetingNotes(result.items, Some(meta));
                     return match devboy_executor::format_output(
                         output,
                         None,
@@ -1628,7 +1633,12 @@ impl ToolHandler {
                 .await
             {
                 Ok(result) => {
-                    let output = devboy_executor::ToolOutput::MeetingNotes(result.items);
+                    let meta = devboy_executor::ResultMeta {
+                        pagination: result.pagination,
+                        sort_info: result.sort_info,
+                    };
+                    let output =
+                        devboy_executor::ToolOutput::MeetingNotes(result.items, Some(meta));
                     return match devboy_executor::format_output(
                         output,
                         None,

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -759,7 +759,7 @@ impl ToolHandler {
             return ToolCallResult::error(format!("Failed to get issues: {}", errors.join(", ")));
         }
 
-        let pipeline = self.create_pipeline(&params.format, params.budget);
+        let pipeline = self.create_pipeline(&params.format, params.budget, params.chunk);
         match pipeline.transform_issues(all_issues) {
             Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
             Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -783,7 +783,8 @@ impl ToolHandler {
         for provider in &self.providers {
             match provider.get_issue(&params.key).await {
                 Ok(issue) => {
-                    let pipeline = self.create_pipeline(&params.format, params.budget);
+                    let pipeline =
+                        self.create_pipeline(&params.format, params.budget, params.chunk);
                     return match pipeline.transform_issues(vec![issue]) {
                         Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
                         Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -819,7 +820,8 @@ impl ToolHandler {
         for provider in &self.providers {
             match provider.get_comments(&params.key).await {
                 Ok(result) => {
-                    let pipeline = self.create_pipeline(&params.format, params.budget);
+                    let pipeline =
+                        self.create_pipeline(&params.format, params.budget, params.chunk);
                     return match pipeline.transform_comments(result.items) {
                         Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
                         Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -1066,7 +1068,7 @@ impl ToolHandler {
             ));
         }
 
-        let pipeline = self.create_pipeline(&params.format, params.budget);
+        let pipeline = self.create_pipeline(&params.format, params.budget, params.chunk);
         match pipeline.transform_merge_requests(all_mrs) {
             Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
             Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -1089,7 +1091,8 @@ impl ToolHandler {
         for provider in &self.providers {
             match provider.get_merge_request(&params.key).await {
                 Ok(mr) => {
-                    let pipeline = self.create_pipeline(&params.format, params.budget);
+                    let pipeline =
+                        self.create_pipeline(&params.format, params.budget, params.chunk);
                     return match pipeline.transform_merge_requests(vec![mr]) {
                         Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
                         Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -1144,7 +1147,8 @@ impl ToolHandler {
                         discussions.into_iter().skip(offset).take(limit).collect();
                     let included = paged_discussions.len();
 
-                    let pipeline = self.create_pipeline(&params.format, params.budget);
+                    let pipeline =
+                        self.create_pipeline(&params.format, params.budget, params.chunk);
                     return match pipeline.transform_discussions(paged_discussions) {
                         Ok(mut output) => {
                             if self.pipeline_config.include_hints && offset + included < total {
@@ -1201,7 +1205,8 @@ impl ToolHandler {
         for provider in &self.providers {
             match provider.get_diffs(&params.key).await {
                 Ok(result) => {
-                    let pipeline = self.create_pipeline(&params.format, params.budget);
+                    let pipeline =
+                        self.create_pipeline(&params.format, params.budget, params.chunk);
                     return match pipeline.transform_diffs(result.items) {
                         Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
                         Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -1640,7 +1645,12 @@ impl ToolHandler {
             .find(|p| get_provider_name(p.as_ref()) == name)
     }
 
-    fn create_pipeline(&self, format: &Option<String>, budget: Option<usize>) -> Pipeline {
+    fn create_pipeline(
+        &self,
+        format: &Option<String>,
+        budget: Option<usize>,
+        chunk: Option<usize>,
+    ) -> Pipeline {
         let output_format = match format.as_deref() {
             Some("json") => OutputFormat::Json,
             _ => OutputFormat::Toon,
@@ -1656,6 +1666,8 @@ impl ToolHandler {
             // Convert token budget to max_chars (tokens * 3.5)
             config.max_chars = (b as f64 * 3.5).floor() as usize;
         }
+
+        config.chunk = chunk;
 
         Pipeline::with_config(config)
     }
@@ -1678,6 +1690,7 @@ struct GetIssuesParams {
     sort_by: Option<String>,
     sort_order: Option<String>,
     budget: Option<usize>,
+    chunk: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1685,6 +1698,7 @@ struct GetIssueParams {
     key: String,
     format: Option<String>,
     budget: Option<usize>,
+    chunk: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1692,6 +1706,7 @@ struct GetIssueCommentsParams {
     key: String,
     format: Option<String>,
     budget: Option<usize>,
+    chunk: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1739,6 +1754,7 @@ struct GetMergeRequestsParams {
     limit: Option<usize>,
     format: Option<String>,
     budget: Option<usize>,
+    chunk: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1746,6 +1762,7 @@ struct GetMergeRequestParams {
     key: String,
     format: Option<String>,
     budget: Option<usize>,
+    chunk: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1755,6 +1772,7 @@ struct GetMergeRequestDiscussionsParams {
     offset: Option<usize>,
     format: Option<String>,
     budget: Option<usize>,
+    chunk: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1762,6 +1780,7 @@ struct GetMergeRequestDiffsParams {
     key: String,
     format: Option<String>,
     budget: Option<usize>,
+    chunk: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -2964,13 +2983,13 @@ mod tests {
     async fn test_create_pipeline_formats() {
         let handler = ToolHandler::new(vec![]);
 
-        let pipeline = handler.create_pipeline(&Some("json".to_string()), None);
+        let pipeline = handler.create_pipeline(&Some("json".to_string()), None, None);
         assert!(pipeline.transform_issues(vec![]).is_ok());
 
-        let pipeline = handler.create_pipeline(&Some("toon".to_string()), None);
+        let pipeline = handler.create_pipeline(&Some("toon".to_string()), None, None);
         assert!(pipeline.transform_issues(vec![]).is_ok());
 
-        let pipeline = handler.create_pipeline(&None, None);
+        let pipeline = handler.create_pipeline(&None, None, None);
         assert!(pipeline.transform_issues(vec![]).is_ok());
     }
 

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -1096,13 +1096,13 @@ impl ToolHandler {
             match provider.get_discussions(&params.key).await {
                 Ok(discussions) => {
                     let offset = params.offset.unwrap_or(0);
-                    let limit = params.limit.unwrap_or(self.pipeline_config.max_items);
+                    let limit = params.limit.unwrap_or(20);
                     let total = discussions.len();
                     let paged_discussions: Vec<_> =
                         discussions.into_iter().skip(offset).take(limit).collect();
                     let included = paged_discussions.len();
 
-                    let pipeline = self.create_pipeline_with_max_items(&params.format, limit);
+                    let pipeline = self.create_pipeline(&params.format);
                     return match pipeline.transform_discussions(paged_discussions) {
                         Ok(mut output) => {
                             if self.pipeline_config.include_hints && offset + included < total {
@@ -1589,21 +1589,12 @@ impl ToolHandler {
     }
 
     fn create_pipeline(&self, format: &Option<String>) -> Pipeline {
-        self.create_pipeline_with_max_items(format, self.pipeline_config.max_items)
-    }
-
-    fn create_pipeline_with_max_items(
-        &self,
-        format: &Option<String>,
-        max_items: usize,
-    ) -> Pipeline {
         let output_format = match format.as_deref() {
             Some("json") => OutputFormat::Json,
             _ => OutputFormat::Toon,
         };
 
         Pipeline::with_config(PipelineConfig {
-            max_items,
             format: output_format,
             ..self.pipeline_config.clone()
         })
@@ -2247,16 +2238,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_merge_request_discussions_handler_uses_custom_configured_max_items() {
+    async fn test_get_merge_request_discussions_handler_uses_limit_parameter() {
         let provider = Arc::new(ManyDiscussionsProvider::new(10)) as Arc<dyn Provider>;
-        let handler = ToolHandler::new(vec![provider]).with_pipeline_config(PipelineConfig {
-            max_items: 3,
-            max_chars: 20_000,
-            ..Default::default()
-        });
+        let handler = ToolHandler::new(vec![provider]);
 
         let args = serde_json::json!({
             "key": "pr#1",
+            "limit": 3,
             "format": "json"
         });
         let result = handler

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -124,11 +124,6 @@ define_tools! {
                     "description": "Number of results to skip for pagination (default: 0)",
                     "minimum": 0
                 },
-                "format": {
-                    "type": "string",
-                    "enum": ["toon", "json"],
-                    "description": "Output format (default: toon)"
-                },
                 "provider": {
                     "type": "string",
                     "enum": ["github", "gitlab", "clickup", "jira"],
@@ -143,12 +138,6 @@ define_tools! {
                     "type": "string",
                     "enum": ["asc", "desc"],
                     "description": "Sort order (default: desc)"
-                },
-                "budget": {
-                    "type": "integer",
-                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
-                    "minimum": 100,
-                    "maximum": 100000
                 }
             }
         }
@@ -164,17 +153,6 @@ define_tools! {
                 "key": {
                     "type": "string",
                     "description": "Issue key (e.g., 'gh#123' for GitHub, 'gitlab#456' for GitLab, 'CU-abc' or custom ID like 'DEV-42' for ClickUp, 'jira#PROJ-123' for Jira)"
-                },
-                "format": {
-                    "type": "string",
-                    "enum": ["toon", "json"],
-                    "description": "Output format (default: toon)"
-                },
-                "budget": {
-                    "type": "integer",
-                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
-                    "minimum": 100,
-                    "maximum": 100000
                 }
             }
         }
@@ -190,17 +168,6 @@ define_tools! {
                 "key": {
                     "type": "string",
                     "description": "Issue key (e.g., 'gh#123')"
-                },
-                "format": {
-                    "type": "string",
-                    "enum": ["toon", "json"],
-                    "description": "Output format (default: toon)"
-                },
-                "budget": {
-                    "type": "integer",
-                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
-                    "minimum": 100,
-                    "maximum": 100000
                 }
             }
         }
@@ -365,17 +332,6 @@ define_tools! {
                     "description": "Maximum number of results (default: 20)",
                     "minimum": 1,
                     "maximum": 100
-                },
-                "format": {
-                    "type": "string",
-                    "enum": ["toon", "json"],
-                    "description": "Output format (default: toon)"
-                },
-                "budget": {
-                    "type": "integer",
-                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
-                    "minimum": 100,
-                    "maximum": 100000
                 }
             }
         }
@@ -391,17 +347,6 @@ define_tools! {
                 "key": {
                     "type": "string",
                     "description": "MR/PR key (e.g., 'pr#123' for GitHub, 'mr#456' for GitLab)"
-                },
-                "format": {
-                    "type": "string",
-                    "enum": ["toon", "json"],
-                    "description": "Output format (default: toon)"
-                },
-                "budget": {
-                    "type": "integer",
-                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
-                    "minimum": 100,
-                    "maximum": 100000
                 }
             }
         }
@@ -428,17 +373,6 @@ define_tools! {
                     "type": "integer",
                     "description": "Number of discussions to skip for pagination (default: 0)",
                     "minimum": 0
-                },
-                "format": {
-                    "type": "string",
-                    "enum": ["toon", "json"],
-                    "description": "Output format (default: toon)"
-                },
-                "budget": {
-                    "type": "integer",
-                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
-                    "minimum": 100,
-                    "maximum": 100000
                 }
             }
         }
@@ -454,17 +388,6 @@ define_tools! {
                 "key": {
                     "type": "string",
                     "description": "MR/PR key (e.g., 'pr#123')"
-                },
-                "format": {
-                    "type": "string",
-                    "enum": ["toon", "json"],
-                    "description": "Output format (default: toon)"
-                },
-                "budget": {
-                    "type": "integer",
-                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
-                    "minimum": 100,
-                    "maximum": 100000
                 }
             }
         }

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -1938,7 +1938,10 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for MockProvider {
-        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
+        async fn get_issues(
+            &self,
+            _filter: IssueFilter,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
             Ok(self.issues.clone().into())
         }
 
@@ -1958,7 +1961,10 @@ mod tests {
             Ok(self.issues[0].clone())
         }
 
-        async fn get_comments(&self, _issue_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
+        async fn get_comments(
+            &self,
+            _issue_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
             Ok(vec![Comment {
                 id: "1".to_string(),
                 body: "Test comment".to_string(),
@@ -1966,7 +1972,8 @@ mod tests {
                 created_at: None,
                 updated_at: None,
                 position: None,
-            }].into())
+            }]
+            .into())
         }
 
         async fn add_comment(&self, _issue_key: &str, _body: &str) -> devboy_core::Result<Comment> {
@@ -2015,7 +2022,10 @@ mod tests {
             Ok(self.mrs[0].clone())
         }
 
-        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
+        async fn get_discussions(
+            &self,
+            _mr_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
             Ok(vec![Discussion {
                 id: "1".to_string(),
                 resolved: false,
@@ -2029,10 +2039,14 @@ mod tests {
                     position: None,
                 }],
                 position: None,
-            }].into())
+            }]
+            .into())
         }
 
-        async fn get_diffs(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
+        async fn get_diffs(
+            &self,
+            _mr_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
             Ok(vec![FileDiff {
                 file_path: "src/main.rs".to_string(),
                 old_path: None,
@@ -2042,7 +2056,8 @@ mod tests {
                 diff: "+added line\n-removed line".to_string(),
                 additions: Some(1),
                 deletions: Some(1),
-            }].into())
+            }]
+            .into())
         }
 
         async fn add_comment(
@@ -2094,7 +2109,10 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for ManyDiscussionsProvider {
-        async fn get_issues(&self, filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
+        async fn get_issues(
+            &self,
+            filter: IssueFilter,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
             self.base.get_issues(filter).await
         }
 
@@ -2114,7 +2132,10 @@ mod tests {
             self.base.update_issue(key, input).await
         }
 
-        async fn get_comments(&self, issue_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
+        async fn get_comments(
+            &self,
+            issue_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
             self.base.get_comments(issue_key).await
         }
 
@@ -2147,11 +2168,17 @@ mod tests {
             self.base.get_merge_request(key).await
         }
 
-        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
+        async fn get_discussions(
+            &self,
+            _mr_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
             Ok(self.discussions.clone().into())
         }
 
-        async fn get_diffs(&self, mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
+        async fn get_diffs(
+            &self,
+            mr_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
             self.base.get_diffs(mr_key).await
         }
 
@@ -3106,7 +3133,10 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for FailingProvider {
-        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
+        async fn get_issues(
+            &self,
+            _filter: IssueFilter,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
             Err(devboy_core::Error::Api {
                 status: 500,
                 message: "api error".into(),
@@ -3131,7 +3161,10 @@ mod tests {
                 message: "update failed".into(),
             })
         }
-        async fn get_comments(&self, _key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
+        async fn get_comments(
+            &self,
+            _key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
         async fn add_comment(&self, _key: &str, _body: &str) -> devboy_core::Result<Comment> {
@@ -3162,10 +3195,16 @@ mod tests {
         async fn get_merge_request(&self, _key: &str) -> devboy_core::Result<MergeRequest> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
-        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
+        async fn get_discussions(
+            &self,
+            _mr_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
-        async fn get_diffs(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
+        async fn get_diffs(
+            &self,
+            _mr_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
         async fn add_comment(

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -143,6 +143,12 @@ define_tools! {
                     "type": "string",
                     "enum": ["asc", "desc"],
                     "description": "Sort order (default: desc)"
+                },
+                "budget": {
+                    "type": "integer",
+                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
+                    "minimum": 100,
+                    "maximum": 100000
                 }
             }
         }
@@ -163,6 +169,12 @@ define_tools! {
                     "type": "string",
                     "enum": ["toon", "json"],
                     "description": "Output format (default: toon)"
+                },
+                "budget": {
+                    "type": "integer",
+                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
+                    "minimum": 100,
+                    "maximum": 100000
                 }
             }
         }
@@ -183,6 +195,12 @@ define_tools! {
                     "type": "string",
                     "enum": ["toon", "json"],
                     "description": "Output format (default: toon)"
+                },
+                "budget": {
+                    "type": "integer",
+                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
+                    "minimum": 100,
+                    "maximum": 100000
                 }
             }
         }
@@ -352,6 +370,12 @@ define_tools! {
                     "type": "string",
                     "enum": ["toon", "json"],
                     "description": "Output format (default: toon)"
+                },
+                "budget": {
+                    "type": "integer",
+                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
+                    "minimum": 100,
+                    "maximum": 100000
                 }
             }
         }
@@ -372,6 +396,12 @@ define_tools! {
                     "type": "string",
                     "enum": ["toon", "json"],
                     "description": "Output format (default: toon)"
+                },
+                "budget": {
+                    "type": "integer",
+                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
+                    "minimum": 100,
+                    "maximum": 100000
                 }
             }
         }
@@ -403,6 +433,12 @@ define_tools! {
                     "type": "string",
                     "enum": ["toon", "json"],
                     "description": "Output format (default: toon)"
+                },
+                "budget": {
+                    "type": "integer",
+                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
+                    "minimum": 100,
+                    "maximum": 100000
                 }
             }
         }
@@ -423,6 +459,12 @@ define_tools! {
                     "type": "string",
                     "enum": ["toon", "json"],
                     "description": "Output format (default: toon)"
+                },
+                "budget": {
+                    "type": "integer",
+                    "description": "Token budget for this response (default: from config, typically ~28000). Lower values return less data with chunk index for navigation. Higher values return more data in one call.",
+                    "minimum": 100,
+                    "maximum": 100000
                 }
             }
         }
@@ -794,7 +836,7 @@ impl ToolHandler {
             return ToolCallResult::error(format!("Failed to get issues: {}", errors.join(", ")));
         }
 
-        let pipeline = self.create_pipeline(&params.format);
+        let pipeline = self.create_pipeline(&params.format, params.budget);
         match pipeline.transform_issues(all_issues) {
             Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
             Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -818,7 +860,7 @@ impl ToolHandler {
         for provider in &self.providers {
             match provider.get_issue(&params.key).await {
                 Ok(issue) => {
-                    let pipeline = self.create_pipeline(&params.format);
+                    let pipeline = self.create_pipeline(&params.format, params.budget);
                     return match pipeline.transform_issues(vec![issue]) {
                         Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
                         Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -854,7 +896,7 @@ impl ToolHandler {
         for provider in &self.providers {
             match provider.get_comments(&params.key).await {
                 Ok(result) => {
-                    let pipeline = self.create_pipeline(&params.format);
+                    let pipeline = self.create_pipeline(&params.format, params.budget);
                     return match pipeline.transform_comments(result.items) {
                         Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
                         Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -1101,7 +1143,7 @@ impl ToolHandler {
             ));
         }
 
-        let pipeline = self.create_pipeline(&params.format);
+        let pipeline = self.create_pipeline(&params.format, params.budget);
         match pipeline.transform_merge_requests(all_mrs) {
             Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
             Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -1124,7 +1166,7 @@ impl ToolHandler {
         for provider in &self.providers {
             match provider.get_merge_request(&params.key).await {
                 Ok(mr) => {
-                    let pipeline = self.create_pipeline(&params.format);
+                    let pipeline = self.create_pipeline(&params.format, params.budget);
                     return match pipeline.transform_merge_requests(vec![mr]) {
                         Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
                         Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -1179,7 +1221,7 @@ impl ToolHandler {
                         discussions.into_iter().skip(offset).take(limit).collect();
                     let included = paged_discussions.len();
 
-                    let pipeline = self.create_pipeline(&params.format);
+                    let pipeline = self.create_pipeline(&params.format, params.budget);
                     return match pipeline.transform_discussions(paged_discussions) {
                         Ok(mut output) => {
                             if self.pipeline_config.include_hints && offset + included < total {
@@ -1236,7 +1278,7 @@ impl ToolHandler {
         for provider in &self.providers {
             match provider.get_diffs(&params.key).await {
                 Ok(result) => {
-                    let pipeline = self.create_pipeline(&params.format);
+                    let pipeline = self.create_pipeline(&params.format, params.budget);
                     return match pipeline.transform_diffs(result.items) {
                         Ok(output) => ToolCallResult::text(output.to_string_with_hints()),
                         Err(e) => ToolCallResult::error(format!("Pipeline error: {}", e)),
@@ -1675,16 +1717,24 @@ impl ToolHandler {
             .find(|p| get_provider_name(p.as_ref()) == name)
     }
 
-    fn create_pipeline(&self, format: &Option<String>) -> Pipeline {
+    fn create_pipeline(&self, format: &Option<String>, budget: Option<usize>) -> Pipeline {
         let output_format = match format.as_deref() {
             Some("json") => OutputFormat::Json,
             _ => OutputFormat::Toon,
         };
 
-        Pipeline::with_config(PipelineConfig {
+        let mut config = PipelineConfig {
             format: output_format,
             ..self.pipeline_config.clone()
-        })
+        };
+
+        // LLM-controlled budget overrides default
+        if let Some(b) = budget {
+            // Convert token budget to max_chars (tokens * 3.5)
+            config.max_chars = (b as f64 * 3.5).floor() as usize;
+        }
+
+        Pipeline::with_config(config)
     }
 }
 
@@ -1704,18 +1754,21 @@ struct GetIssuesParams {
     provider: Option<String>,
     sort_by: Option<String>,
     sort_order: Option<String>,
+    budget: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct GetIssueParams {
     key: String,
     format: Option<String>,
+    budget: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct GetIssueCommentsParams {
     key: String,
     format: Option<String>,
+    budget: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1762,12 +1815,14 @@ struct GetMergeRequestsParams {
     target_branch: Option<String>,
     limit: Option<usize>,
     format: Option<String>,
+    budget: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct GetMergeRequestParams {
     key: String,
     format: Option<String>,
+    budget: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1776,12 +1831,14 @@ struct GetMergeRequestDiscussionsParams {
     limit: Option<usize>,
     offset: Option<usize>,
     format: Option<String>,
+    budget: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct GetMergeRequestDiffsParams {
     key: String,
     format: Option<String>,
+    budget: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -2984,13 +3041,13 @@ mod tests {
     async fn test_create_pipeline_formats() {
         let handler = ToolHandler::new(vec![]);
 
-        let pipeline = handler.create_pipeline(&Some("json".to_string()));
+        let pipeline = handler.create_pipeline(&Some("json".to_string()), None);
         assert!(pipeline.transform_issues(vec![]).is_ok());
 
-        let pipeline = handler.create_pipeline(&Some("toon".to_string()));
+        let pipeline = handler.create_pipeline(&Some("toon".to_string()), None);
         assert!(pipeline.transform_issues(vec![]).is_ok());
 
-        let pipeline = handler.create_pipeline(&None);
+        let pipeline = handler.create_pipeline(&None, None);
         assert!(pipeline.transform_issues(vec![]).is_ok());
     }
 

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -463,8 +463,8 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for TestProvider {
-        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<Vec<Issue>> {
-            Ok(vec![])
+        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
+            Ok(vec![].into())
         }
         async fn get_issue(&self, _key: &str) -> devboy_core::Result<Issue> {
             Err(devboy_core::Error::NotFound("not found".into()))
@@ -479,8 +479,8 @@ mod tests {
         ) -> devboy_core::Result<Issue> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
-        async fn get_comments(&self, _issue_key: &str) -> devboy_core::Result<Vec<Comment>> {
-            Ok(vec![])
+        async fn get_comments(&self, _issue_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
+            Ok(vec![].into())
         }
         async fn add_comment(&self, _issue_key: &str, _body: &str) -> devboy_core::Result<Comment> {
             Err(devboy_core::Error::NotFound("not found".into()))
@@ -495,17 +495,17 @@ mod tests {
         async fn get_merge_requests(
             &self,
             _filter: MrFilter,
-        ) -> devboy_core::Result<Vec<MergeRequest>> {
-            Ok(vec![])
+        ) -> devboy_core::Result<devboy_core::ProviderResult<MergeRequest>> {
+            Ok(vec![].into())
         }
         async fn get_merge_request(&self, _key: &str) -> devboy_core::Result<MergeRequest> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
-        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<Vec<Discussion>> {
-            Ok(vec![])
+        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
+            Ok(vec![].into())
         }
-        async fn get_diffs(&self, _mr_key: &str) -> devboy_core::Result<Vec<FileDiff>> {
-            Ok(vec![])
+        async fn get_diffs(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
+            Ok(vec![].into())
         }
         async fn add_comment(
             &self,
@@ -1065,8 +1065,8 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for IssueOnlyTestProvider {
-        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<Vec<Issue>> {
-            Ok(vec![])
+        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
+            Ok(vec![].into())
         }
         async fn get_issue(&self, _key: &str) -> devboy_core::Result<Issue> {
             Err(devboy_core::Error::NotFound("not found".into()))
@@ -1081,8 +1081,8 @@ mod tests {
         ) -> devboy_core::Result<Issue> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
-        async fn get_comments(&self, _issue_key: &str) -> devboy_core::Result<Vec<Comment>> {
-            Ok(vec![])
+        async fn get_comments(&self, _issue_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
+            Ok(vec![].into())
         }
         async fn add_comment(&self, _issue_key: &str, _body: &str) -> devboy_core::Result<Comment> {
             Err(devboy_core::Error::NotFound("not found".into()))

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -463,7 +463,10 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for TestProvider {
-        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
+        async fn get_issues(
+            &self,
+            _filter: IssueFilter,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
             Ok(vec![].into())
         }
         async fn get_issue(&self, _key: &str) -> devboy_core::Result<Issue> {
@@ -479,7 +482,10 @@ mod tests {
         ) -> devboy_core::Result<Issue> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
-        async fn get_comments(&self, _issue_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
+        async fn get_comments(
+            &self,
+            _issue_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
             Ok(vec![].into())
         }
         async fn add_comment(&self, _issue_key: &str, _body: &str) -> devboy_core::Result<Comment> {
@@ -501,10 +507,16 @@ mod tests {
         async fn get_merge_request(&self, _key: &str) -> devboy_core::Result<MergeRequest> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
-        async fn get_discussions(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
+        async fn get_discussions(
+            &self,
+            _mr_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Discussion>> {
             Ok(vec![].into())
         }
-        async fn get_diffs(&self, _mr_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
+        async fn get_diffs(
+            &self,
+            _mr_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<FileDiff>> {
             Ok(vec![].into())
         }
         async fn add_comment(
@@ -1065,7 +1077,10 @@ mod tests {
 
     #[async_trait]
     impl IssueProvider for IssueOnlyTestProvider {
-        async fn get_issues(&self, _filter: IssueFilter) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
+        async fn get_issues(
+            &self,
+            _filter: IssueFilter,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Issue>> {
             Ok(vec![].into())
         }
         async fn get_issue(&self, _key: &str) -> devboy_core::Result<Issue> {
@@ -1081,7 +1096,10 @@ mod tests {
         ) -> devboy_core::Result<Issue> {
             Err(devboy_core::Error::NotFound("not found".into()))
         }
-        async fn get_comments(&self, _issue_key: &str) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
+        async fn get_comments(
+            &self,
+            _issue_key: &str,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<Comment>> {
             Ok(vec![].into())
         }
         async fn add_comment(&self, _issue_key: &str, _body: &str) -> devboy_core::Result<Comment> {

--- a/crates/devboy-mcp/tests/tool_filtering_test.rs
+++ b/crates/devboy-mcp/tests/tool_filtering_test.rs
@@ -25,7 +25,7 @@ struct ClickUpTestProvider;
 
 #[async_trait]
 impl IssueProvider for ClickUpTestProvider {
-    async fn get_issues(&self, _filter: IssueFilter) -> Result<Vec<Issue>> {
+    async fn get_issues(&self, _filter: IssueFilter) -> Result<devboy_core::ProviderResult<Issue>> {
         Ok(vec![Issue {
             key: "CU-123".to_string(),
             title: "Test Issue".to_string(),
@@ -39,7 +39,7 @@ impl IssueProvider for ClickUpTestProvider {
             url: None,
             created_at: None,
             updated_at: None,
-        }])
+        }].into())
     }
 
     async fn get_issue(&self, _key: &str) -> Result<Issue> {
@@ -54,8 +54,8 @@ impl IssueProvider for ClickUpTestProvider {
         Err(devboy_core::Error::NotFound("not implemented".into()))
     }
 
-    async fn get_comments(&self, _issue_key: &str) -> Result<Vec<Comment>> {
-        Ok(vec![])
+    async fn get_comments(&self, _issue_key: &str) -> Result<devboy_core::ProviderResult<Comment>> {
+        Ok(vec![].into())
     }
 
     async fn add_comment(&self, _issue_key: &str, _body: &str) -> Result<Comment> {
@@ -100,7 +100,7 @@ struct GitLabTestProvider;
 
 #[async_trait]
 impl IssueProvider for GitLabTestProvider {
-    async fn get_issues(&self, _filter: IssueFilter) -> Result<Vec<Issue>> {
+    async fn get_issues(&self, _filter: IssueFilter) -> Result<devboy_core::ProviderResult<Issue>> {
         Ok(vec![Issue {
             key: "gitlab#123".to_string(),
             title: "Test Issue".to_string(),
@@ -114,7 +114,7 @@ impl IssueProvider for GitLabTestProvider {
             url: None,
             created_at: None,
             updated_at: None,
-        }])
+        }].into())
     }
 
     async fn get_issue(&self, _key: &str) -> Result<Issue> {
@@ -129,8 +129,8 @@ impl IssueProvider for GitLabTestProvider {
         Err(devboy_core::Error::NotFound("not implemented".into()))
     }
 
-    async fn get_comments(&self, _issue_key: &str) -> Result<Vec<Comment>> {
-        Ok(vec![])
+    async fn get_comments(&self, _issue_key: &str) -> Result<devboy_core::ProviderResult<Comment>> {
+        Ok(vec![].into())
     }
 
     async fn add_comment(&self, _issue_key: &str, _body: &str) -> Result<Comment> {
@@ -144,7 +144,7 @@ impl IssueProvider for GitLabTestProvider {
 
 #[async_trait]
 impl MergeRequestProvider for GitLabTestProvider {
-    async fn get_merge_requests(&self, _filter: MrFilter) -> Result<Vec<MergeRequest>> {
+    async fn get_merge_requests(&self, _filter: MrFilter) -> Result<devboy_core::ProviderResult<MergeRequest>> {
         Ok(vec![MergeRequest {
             key: "mr#123".to_string(),
             title: "Test MR".to_string(),
@@ -161,19 +161,19 @@ impl MergeRequestProvider for GitLabTestProvider {
             url: None,
             created_at: None,
             updated_at: None,
-        }])
+        }].into())
     }
 
     async fn get_merge_request(&self, _key: &str) -> Result<MergeRequest> {
         Err(devboy_core::Error::NotFound("not implemented".into()))
     }
 
-    async fn get_discussions(&self, _mr_key: &str) -> Result<Vec<Discussion>> {
-        Ok(vec![])
+    async fn get_discussions(&self, _mr_key: &str) -> Result<devboy_core::ProviderResult<Discussion>> {
+        Ok(vec![].into())
     }
 
-    async fn get_diffs(&self, _mr_key: &str) -> Result<Vec<FileDiff>> {
-        Ok(vec![])
+    async fn get_diffs(&self, _mr_key: &str) -> Result<devboy_core::ProviderResult<FileDiff>> {
+        Ok(vec![].into())
     }
 
     async fn add_comment(&self, _mr_key: &str, _input: CreateCommentInput) -> Result<Comment> {

--- a/crates/devboy-mcp/tests/tool_filtering_test.rs
+++ b/crates/devboy-mcp/tests/tool_filtering_test.rs
@@ -41,7 +41,8 @@ impl IssueProvider for ClickUpTestProvider {
             updated_at: None,
             parent: None,
             subtasks: vec![],
-        }].into())
+        }]
+        .into())
     }
 
     async fn get_issue(&self, _key: &str) -> Result<Issue> {
@@ -118,7 +119,8 @@ impl IssueProvider for GitLabTestProvider {
             updated_at: None,
             parent: None,
             subtasks: vec![],
-        }].into())
+        }]
+        .into())
     }
 
     async fn get_issue(&self, _key: &str) -> Result<Issue> {
@@ -148,7 +150,10 @@ impl IssueProvider for GitLabTestProvider {
 
 #[async_trait]
 impl MergeRequestProvider for GitLabTestProvider {
-    async fn get_merge_requests(&self, _filter: MrFilter) -> Result<devboy_core::ProviderResult<MergeRequest>> {
+    async fn get_merge_requests(
+        &self,
+        _filter: MrFilter,
+    ) -> Result<devboy_core::ProviderResult<MergeRequest>> {
         Ok(vec![MergeRequest {
             key: "mr#123".to_string(),
             title: "Test MR".to_string(),
@@ -165,14 +170,18 @@ impl MergeRequestProvider for GitLabTestProvider {
             url: None,
             created_at: None,
             updated_at: None,
-        }].into())
+        }]
+        .into())
     }
 
     async fn get_merge_request(&self, _key: &str) -> Result<MergeRequest> {
         Err(devboy_core::Error::NotFound("not implemented".into()))
     }
 
-    async fn get_discussions(&self, _mr_key: &str) -> Result<devboy_core::ProviderResult<Discussion>> {
+    async fn get_discussions(
+        &self,
+        _mr_key: &str,
+    ) -> Result<devboy_core::ProviderResult<Discussion>> {
         Ok(vec![].into())
     }
 

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -3,7 +3,8 @@
 use async_trait::async_trait;
 use devboy_core::{
     Comment, CreateIssueInput, Error, Issue, IssueFilter, IssueProvider, IssueStatus,
-    MergeRequestProvider, PipelineProvider, Provider, Result, UpdateIssueInput, User,
+    MergeRequestProvider, PipelineProvider, Provider, ProviderResult, Result, UpdateIssueInput,
+    User,
 };
 use tracing::{debug, warn};
 
@@ -365,10 +366,10 @@ fn priority_to_clickup(priority: &str) -> Option<u8> {
 
 #[async_trait]
 impl IssueProvider for ClickUpClient {
-    async fn get_issues(&self, filter: IssueFilter) -> Result<Vec<Issue>> {
+    async fn get_issues(&self, filter: IssueFilter) -> Result<ProviderResult<Issue>> {
         let limit = filter.limit.unwrap_or(20) as usize;
         if limit == 0 {
-            return Ok(vec![]);
+            return Ok(vec![].into());
         }
         let offset = filter.offset.unwrap_or(0) as usize;
 
@@ -464,7 +465,7 @@ impl IssueProvider for ClickUpClient {
 
         issues.truncate(limit);
 
-        Ok(issues)
+        Ok(issues.into())
     }
 
     async fn get_issue(&self, key: &str) -> Result<Issue> {
@@ -544,7 +545,7 @@ impl IssueProvider for ClickUpClient {
         Ok(map_task(&task))
     }
 
-    async fn get_comments(&self, issue_key: &str) -> Result<Vec<Comment>> {
+    async fn get_comments(&self, issue_key: &str) -> Result<ProviderResult<Comment>> {
         let base_url = self.task_url(issue_key)?;
         // Append /comment — handle both raw URL and URL with query params
         let url = if base_url.contains('?') {
@@ -554,7 +555,7 @@ impl IssueProvider for ClickUpClient {
             format!("{}/comment", base_url)
         };
         let response: ClickUpCommentList = self.get(&url).await?;
-        Ok(response.comments.iter().map(map_comment).collect())
+        Ok(response.comments.iter().map(map_comment).collect::<Vec<_>>().into())
     }
 
     async fn add_comment(&self, issue_key: &str, body: &str) -> Result<Comment> {
@@ -581,11 +582,11 @@ impl IssueProvider for ClickUpClient {
         })
     }
 
-    async fn get_statuses(&self) -> Result<Vec<IssueStatus>> {
+    async fn get_statuses(&self) -> Result<ProviderResult<IssueStatus>> {
         let url = format!("{}/list/{}", self.base_url, self.list_id);
         let list_info: ClickUpListInfo = self.get(&url).await?;
 
-        let statuses = list_info
+        let statuses: Vec<IssueStatus> = list_info
             .statuses
             .iter()
             .enumerate()
@@ -606,7 +607,7 @@ impl IssueProvider for ClickUpClient {
             })
             .collect();
 
-        Ok(statuses)
+        Ok(statuses.into())
     }
 
     async fn link_issues(&self, source_key: &str, target_key: &str, link_type: &str) -> Result<()> {
@@ -1136,7 +1137,7 @@ mod tests {
             });
 
             let client = create_test_client(&server);
-            let issues = client.get_issues(IssueFilter::default()).await.unwrap();
+            let issues = client.get_issues(IssueFilter::default()).await.unwrap().items;
 
             assert_eq!(issues.len(), 1);
             assert_eq!(issues[0].key, "CU-abc123");
@@ -1173,7 +1174,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 2);
         }
@@ -1196,7 +1198,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 1);
             assert_eq!(issues[0].state, "open");
@@ -1222,7 +1225,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 1);
             assert_eq!(issues[0].state, "closed");
@@ -1264,7 +1268,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 2);
             assert_eq!(issues[0].key, "CU-task1");
@@ -1281,7 +1286,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert!(issues.is_empty());
         }
@@ -1348,7 +1354,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 120);
             assert_eq!(issues[0].key, "CU-task0");
@@ -1666,7 +1673,7 @@ mod tests {
             });
 
             let client = create_test_client(&server);
-            let comments = client.get_comments("CU-abc123").await.unwrap();
+            let comments = client.get_comments("CU-abc123").await.unwrap().items;
 
             assert_eq!(comments.len(), 1);
             assert_eq!(comments[0].body, "Looks good!");

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -612,7 +612,12 @@ impl IssueProvider for ClickUpClient {
             format!("{}/comment", base_url)
         };
         let response: ClickUpCommentList = self.get(&url).await?;
-        Ok(response.comments.iter().map(map_comment).collect::<Vec<_>>().into())
+        Ok(response
+            .comments
+            .iter()
+            .map(map_comment)
+            .collect::<Vec<_>>()
+            .into())
     }
 
     async fn add_comment(&self, issue_key: &str, body: &str) -> Result<Comment> {
@@ -1389,7 +1394,11 @@ mod tests {
             });
 
             let client = create_test_client(&server);
-            let issues = client.get_issues(IssueFilter::default()).await.unwrap().items;
+            let issues = client
+                .get_issues(IssueFilter::default())
+                .await
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 1);
             assert_eq!(issues[0].key, "CU-abc123");

--- a/crates/plugins/api/fireflies/src/client.rs
+++ b/crates/plugins/api/fireflies/src/client.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use devboy_core::{
     Error, MeetingFilter, MeetingNote, MeetingNotesProvider, MeetingSpeaker, MeetingTranscript,
-    Result, TranscriptSentence,
+    ProviderResult, Result, TranscriptSentence,
 };
 use serde_json::{Value, json};
 use tracing::debug;
@@ -149,14 +149,15 @@ impl MeetingNotesProvider for FirefliesClient {
         "fireflies"
     }
 
-    async fn get_meetings(&self, filter: MeetingFilter) -> Result<Vec<MeetingNote>> {
+    async fn get_meetings(&self, filter: MeetingFilter) -> Result<ProviderResult<MeetingNote>> {
         let variables = build_filter_variables(&filter);
         let data: TranscriptsData = self.graphql(GET_TRANSCRIPTS_QUERY, variables).await?;
         Ok(data
             .transcripts
             .into_iter()
             .map(convert_transcript)
-            .collect())
+            .collect::<Vec<_>>()
+            .into())
     }
 
     async fn get_transcript(&self, meeting_id: &str) -> Result<MeetingTranscript> {
@@ -218,7 +219,7 @@ impl MeetingNotesProvider for FirefliesClient {
         &self,
         query: &str,
         filter: MeetingFilter,
-    ) -> Result<Vec<MeetingNote>> {
+    ) -> Result<ProviderResult<MeetingNote>> {
         let mut variables = build_filter_variables(&filter);
         if let Some(obj) = variables.as_object_mut() {
             obj.insert("keyword".into(), Value::String(query.to_string()));
@@ -228,7 +229,8 @@ impl MeetingNotesProvider for FirefliesClient {
             .transcripts
             .into_iter()
             .map(convert_transcript)
-            .collect())
+            .collect::<Vec<_>>()
+            .into())
     }
 }
 

--- a/crates/plugins/api/github/src/client.rs
+++ b/crates/plugins/api/github/src/client.rs
@@ -6,7 +6,7 @@ use devboy_core::{
     Discussion, Error, FailedJob, FileDiff, GetPipelineInput, Issue, IssueFilter, IssueProvider,
     JobLogMode, JobLogOptions, JobLogOutput, MergeRequest, MergeRequestProvider, MrFilter,
     PipelineInfo, PipelineJob, PipelineProvider, PipelineStage, PipelineStatus, PipelineSummary,
-    Provider, Result, UpdateIssueInput, User,
+    Provider, ProviderResult, Result, UpdateIssueInput, User,
 };
 use serde::Deserialize;
 use tracing::{debug, warn};
@@ -299,7 +299,7 @@ fn map_file(gh_file: &GitHubFile) -> FileDiff {
 
 #[async_trait]
 impl IssueProvider for GitHubClient {
-    async fn get_issues(&self, filter: IssueFilter) -> Result<Vec<Issue>> {
+    async fn get_issues(&self, filter: IssueFilter) -> Result<ProviderResult<Issue>> {
         let mut url = self.repo_url("/issues");
         let mut params = vec![];
 
@@ -361,7 +361,7 @@ impl IssueProvider for GitHubClient {
             .map(map_issue)
             .collect();
 
-        Ok(issues)
+        Ok(issues.into())
     }
 
     async fn get_issue(&self, key: &str) -> Result<Issue> {
@@ -416,11 +416,11 @@ impl IssueProvider for GitHubClient {
         Ok(map_issue(&gh_issue))
     }
 
-    async fn get_comments(&self, issue_key: &str) -> Result<Vec<Comment>> {
+    async fn get_comments(&self, issue_key: &str) -> Result<ProviderResult<Comment>> {
         let number = parse_issue_key(issue_key)?;
         let url = self.repo_url(&format!("/issues/{}/comments", number));
         let gh_comments: Vec<GitHubComment> = self.get(&url).await?;
-        Ok(gh_comments.iter().map(map_comment).collect())
+        Ok(gh_comments.iter().map(map_comment).collect::<Vec<_>>().into())
     }
 
     async fn add_comment(&self, issue_key: &str, body: &str) -> Result<Comment> {
@@ -441,7 +441,7 @@ impl IssueProvider for GitHubClient {
 
 #[async_trait]
 impl MergeRequestProvider for GitHubClient {
-    async fn get_merge_requests(&self, filter: MrFilter) -> Result<Vec<MergeRequest>> {
+    async fn get_merge_requests(&self, filter: MrFilter) -> Result<ProviderResult<MergeRequest>> {
         let mut url = self.repo_url("/pulls");
         let mut params = vec![];
 
@@ -485,7 +485,7 @@ impl MergeRequestProvider for GitHubClient {
             prs.retain(|pr| pr.state == "merged");
         }
 
-        Ok(prs)
+        Ok(prs.into())
     }
 
     async fn get_merge_request(&self, key: &str) -> Result<MergeRequest> {
@@ -495,7 +495,7 @@ impl MergeRequestProvider for GitHubClient {
         Ok(map_pull_request(&gh_pr))
     }
 
-    async fn get_discussions(&self, mr_key: &str) -> Result<Vec<Discussion>> {
+    async fn get_discussions(&self, mr_key: &str) -> Result<ProviderResult<Discussion>> {
         let number = parse_pr_key(mr_key)?;
 
         // Fetch reviews, review comments, and general comments
@@ -571,14 +571,14 @@ impl MergeRequestProvider for GitHubClient {
             });
         }
 
-        Ok(discussions)
+        Ok(discussions.into())
     }
 
-    async fn get_diffs(&self, mr_key: &str) -> Result<Vec<FileDiff>> {
+    async fn get_diffs(&self, mr_key: &str) -> Result<ProviderResult<FileDiff>> {
         let number = parse_pr_key(mr_key)?;
         let url = self.repo_url(&format!("/pulls/{}/files", number));
         let gh_files: Vec<GitHubFile> = self.get(&url).await?;
-        Ok(gh_files.iter().map(map_file).collect())
+        Ok(gh_files.iter().map(map_file).collect::<Vec<_>>().into())
     }
 
     async fn add_comment(&self, mr_key: &str, input: CreateCommentInput) -> Result<Comment> {
@@ -1742,7 +1742,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 1);
             assert_eq!(issues[0].key, "gh#42");
@@ -1764,7 +1765,7 @@ mod tests {
             });
 
             let client = create_test_client(&server);
-            let issues = client.get_issues(IssueFilter::default()).await.unwrap();
+            let issues = client.get_issues(IssueFilter::default()).await.unwrap().items;
 
             // Only the real issue, not the PR
             assert_eq!(issues.len(), 1);
@@ -1801,7 +1802,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert!(issues.is_empty());
         }
@@ -1932,7 +1934,7 @@ mod tests {
             });
 
             let client = create_test_client(&server);
-            let comments = client.get_comments("gh#42").await.unwrap();
+            let comments = client.get_comments("gh#42").await.unwrap().items;
 
             assert_eq!(comments.len(), 1);
             assert_eq!(comments[0].body, "Comment text");
@@ -1994,7 +1996,8 @@ mod tests {
             let mrs = client
                 .get_merge_requests(MrFilter::default())
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(mrs.len(), 1);
             assert_eq!(mrs[0].key, "pr#10");
@@ -2024,7 +2027,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert!(mrs.is_empty());
         }
@@ -2054,7 +2058,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             // Only merged PRs returned
             assert_eq!(mrs.len(), 1);
@@ -2104,7 +2109,7 @@ mod tests {
             });
 
             let client = create_test_client(&server);
-            let discussions = client.get_discussions("pr#10").await.unwrap();
+            let discussions = client.get_discussions("pr#10").await.unwrap().items;
 
             // 1 review comment thread + 1 review + 1 general comment = 3
             assert_eq!(discussions.len(), 3);
@@ -2128,7 +2133,7 @@ mod tests {
             });
 
             let client = create_test_client(&server);
-            let diffs = client.get_diffs("pr#10").await.unwrap();
+            let diffs = client.get_diffs("pr#10").await.unwrap().items;
 
             assert_eq!(diffs.len(), 1);
             assert_eq!(diffs[0].file_path, "src/main.rs");

--- a/crates/plugins/api/github/src/client.rs
+++ b/crates/plugins/api/github/src/client.rs
@@ -422,7 +422,11 @@ impl IssueProvider for GitHubClient {
         let number = parse_issue_key(issue_key)?;
         let url = self.repo_url(&format!("/issues/{}/comments", number));
         let gh_comments: Vec<GitHubComment> = self.get(&url).await?;
-        Ok(gh_comments.iter().map(map_comment).collect::<Vec<_>>().into())
+        Ok(gh_comments
+            .iter()
+            .map(map_comment)
+            .collect::<Vec<_>>()
+            .into())
     }
 
     async fn add_comment(&self, issue_key: &str, body: &str) -> Result<Comment> {
@@ -1767,7 +1771,11 @@ mod tests {
             });
 
             let client = create_test_client(&server);
-            let issues = client.get_issues(IssueFilter::default()).await.unwrap().items;
+            let issues = client
+                .get_issues(IssueFilter::default())
+                .await
+                .unwrap()
+                .items;
 
             // Only the real issue, not the PR
             assert_eq!(issues.len(), 1);

--- a/crates/plugins/api/gitlab/src/client.rs
+++ b/crates/plugins/api/gitlab/src/client.rs
@@ -541,7 +541,11 @@ impl MergeRequestProvider for GitLabClient {
         }
 
         let gl_mrs: Vec<GitLabMergeRequest> = self.get(&url).await?;
-        Ok(gl_mrs.iter().map(map_merge_request).collect::<Vec<_>>().into())
+        Ok(gl_mrs
+            .iter()
+            .map(map_merge_request)
+            .collect::<Vec<_>>()
+            .into())
     }
 
     async fn get_merge_request(&self, key: &str) -> Result<MergeRequest> {
@@ -570,7 +574,12 @@ impl MergeRequestProvider for GitLabClient {
         // Use the changes endpoint which returns diffs with content
         let url = self.project_url(&format!("/merge_requests/{}/changes", iid));
         let gl_changes: GitLabMergeRequestChanges = self.get(&url).await?;
-        Ok(gl_changes.changes.iter().map(map_diff).collect::<Vec<_>>().into())
+        Ok(gl_changes
+            .changes
+            .iter()
+            .map(map_diff)
+            .collect::<Vec<_>>()
+            .into())
     }
 
     async fn add_comment(&self, mr_key: &str, input: CreateCommentInput) -> Result<Comment> {

--- a/crates/plugins/api/gitlab/src/client.rs
+++ b/crates/plugins/api/gitlab/src/client.rs
@@ -133,6 +133,83 @@ impl GitLabClient {
         self.handle_response(response).await
     }
 
+    /// Make an authenticated GET request and extract pagination from headers.
+    async fn get_with_pagination<T: serde::de::DeserializeOwned>(
+        &self,
+        url: &str,
+        filter_offset: Option<u32>,
+        filter_limit: Option<u32>,
+    ) -> Result<(T, Option<devboy_core::Pagination>)> {
+        debug!(url = url, "GitLab GET request (with pagination)");
+
+        let response = self
+            .request(reqwest::Method::GET, url)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let status_code = status.as_u16();
+            let message = response.text().await.unwrap_or_default();
+            warn!(
+                status = status_code,
+                message = message,
+                "GitLab API error response"
+            );
+            return Err(Error::from_status(status_code, message));
+        }
+
+        // Extract pagination from GitLab headers
+        let pagination = Self::extract_pagination(&response, filter_offset, filter_limit);
+
+        let data: T = response
+            .json()
+            .await
+            .map_err(|e| Error::InvalidData(format!("Failed to parse response: {}", e)))?;
+
+        Ok((data, pagination))
+    }
+
+    /// Extract pagination metadata from GitLab response headers.
+    fn extract_pagination(
+        response: &reqwest::Response,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> Option<devboy_core::Pagination> {
+        let headers = response.headers();
+
+        let x_total = headers
+            .get("x-total")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u32>().ok());
+
+        let x_page = headers
+            .get("x-page")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u32>().ok());
+
+        let x_total_pages = headers
+            .get("x-total-pages")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u32>().ok());
+
+        let limit = limit.unwrap_or(20);
+        let offset = offset.unwrap_or(0);
+
+        let has_more = match (x_page, x_total_pages) {
+            (Some(page), Some(total_pages)) => page < total_pages,
+            _ => false,
+        };
+
+        Some(devboy_core::Pagination {
+            offset,
+            limit,
+            total: x_total,
+            has_more,
+        })
+    }
+
     /// Handle response and map errors.
     async fn handle_response<T: serde::de::DeserializeOwned>(
         &self,
@@ -409,8 +486,21 @@ impl IssueProvider for GitLabClient {
             url.push_str(&format!("?{}", params.join("&")));
         }
 
-        let gl_issues: Vec<GitLabIssue> = self.get(&url).await?;
-        Ok(gl_issues.iter().map(map_issue).collect::<Vec<_>>().into())
+        let (gl_issues, pagination): (Vec<GitLabIssue>, _) = self
+            .get_with_pagination(&url, filter.offset, filter.limit)
+            .await?;
+        let issues: Vec<Issue> = gl_issues.iter().map(map_issue).collect();
+        let mut result = ProviderResult::new(issues);
+        result.pagination = pagination;
+        result.sort_info = Some(devboy_core::SortInfo {
+            current_sort: Some(format!(
+                "{}:{}",
+                filter.sort_by.as_deref().unwrap_or("updated_at"),
+                filter.sort_order.as_deref().unwrap_or("desc")
+            )),
+            available_sorts: vec!["created_at".into(), "updated_at".into()],
+        });
+        Ok(result)
     }
 
     async fn get_issue(&self, key: &str) -> Result<Issue> {
@@ -540,12 +630,17 @@ impl MergeRequestProvider for GitLabClient {
             url.push_str(&format!("?{}", params.join("&")));
         }
 
-        let gl_mrs: Vec<GitLabMergeRequest> = self.get(&url).await?;
-        Ok(gl_mrs
-            .iter()
-            .map(map_merge_request)
-            .collect::<Vec<_>>()
-            .into())
+        let (gl_mrs, pagination): (Vec<GitLabMergeRequest>, _) = self
+            .get_with_pagination(&url, filter.offset, filter.limit)
+            .await?;
+        let mrs: Vec<MergeRequest> = gl_mrs.iter().map(map_merge_request).collect();
+        let mut result = ProviderResult::new(mrs);
+        result.pagination = pagination;
+        result.sort_info = Some(devboy_core::SortInfo {
+            current_sort: Some("updated_at:desc".into()),
+            available_sorts: vec!["created_at".into(), "updated_at".into()],
+        });
+        Ok(result)
     }
 
     async fn get_merge_request(&self, key: &str) -> Result<MergeRequest> {

--- a/crates/plugins/api/gitlab/src/client.rs
+++ b/crates/plugins/api/gitlab/src/client.rs
@@ -493,11 +493,11 @@ impl IssueProvider for GitLabClient {
         let mut result = ProviderResult::new(issues);
         result.pagination = pagination;
         result.sort_info = Some(devboy_core::SortInfo {
-            current_sort: Some(format!(
-                "{}:{}",
-                filter.sort_by.as_deref().unwrap_or("updated_at"),
-                filter.sort_order.as_deref().unwrap_or("desc")
-            )),
+            sort_by: Some(filter.sort_by.as_deref().unwrap_or("updated_at").into()),
+            sort_order: match filter.sort_order.as_deref() {
+                Some("asc") => devboy_core::SortOrder::Asc,
+                _ => devboy_core::SortOrder::Desc,
+            },
             available_sorts: vec!["created_at".into(), "updated_at".into()],
         });
         Ok(result)
@@ -623,8 +623,15 @@ impl MergeRequestProvider for GitLabClient {
             params.push(format!("per_page={}", limit.min(100)));
         }
 
-        params.push("order_by=updated_at".to_string());
-        params.push("sort=desc".to_string());
+        let order_by = filter.sort_by.as_deref().unwrap_or("updated_at");
+        let sort_order = filter.sort_order.as_deref().unwrap_or("desc");
+        params.push(format!("order_by={}", order_by));
+        params.push(format!("sort={}", sort_order));
+
+        if let Some(offset) = filter.offset {
+            let page = (offset / filter.limit.unwrap_or(20)) + 1;
+            params.push(format!("page={}", page));
+        }
 
         if !params.is_empty() {
             url.push_str(&format!("?{}", params.join("&")));
@@ -637,7 +644,11 @@ impl MergeRequestProvider for GitLabClient {
         let mut result = ProviderResult::new(mrs);
         result.pagination = pagination;
         result.sort_info = Some(devboy_core::SortInfo {
-            current_sort: Some("updated_at:desc".into()),
+            sort_by: Some(order_by.into()),
+            sort_order: match sort_order {
+                "asc" => devboy_core::SortOrder::Asc,
+                _ => devboy_core::SortOrder::Desc,
+            },
             available_sorts: vec!["created_at".into(), "updated_at".into()],
         });
         Ok(result)

--- a/crates/plugins/api/gitlab/src/client.rs
+++ b/crates/plugins/api/gitlab/src/client.rs
@@ -6,7 +6,7 @@ use devboy_core::{
     Discussion, Error, FailedJob, FileDiff, GetPipelineInput, Issue, IssueFilter, IssueProvider,
     JobLogMode, JobLogOptions, JobLogOutput, MergeRequest, MergeRequestProvider, MrFilter,
     PipelineInfo, PipelineJob, PipelineProvider, PipelineStage, PipelineStatus, PipelineSummary,
-    Provider, Result, UpdateIssueInput, User,
+    Provider, ProviderResult, Result, UpdateIssueInput, User,
 };
 use tracing::{debug, warn};
 
@@ -352,7 +352,7 @@ fn parse_mr_key(key: &str) -> Result<u64> {
 
 #[async_trait]
 impl IssueProvider for GitLabClient {
-    async fn get_issues(&self, filter: IssueFilter) -> Result<Vec<Issue>> {
+    async fn get_issues(&self, filter: IssueFilter) -> Result<ProviderResult<Issue>> {
         let mut url = self.project_url("/issues");
         let mut params = vec![];
 
@@ -408,7 +408,7 @@ impl IssueProvider for GitLabClient {
         }
 
         let gl_issues: Vec<GitLabIssue> = self.get(&url).await?;
-        Ok(gl_issues.iter().map(map_issue).collect())
+        Ok(gl_issues.iter().map(map_issue).collect::<Vec<_>>().into())
     }
 
     async fn get_issue(&self, key: &str) -> Result<Issue> {
@@ -462,17 +462,18 @@ impl IssueProvider for GitLabClient {
         Ok(map_issue(&gl_issue))
     }
 
-    async fn get_comments(&self, issue_key: &str) -> Result<Vec<Comment>> {
+    async fn get_comments(&self, issue_key: &str) -> Result<ProviderResult<Comment>> {
         let iid = parse_issue_key(issue_key)?;
         let url = self.project_url(&format!("/issues/{}/notes", iid));
         let gl_notes: Vec<GitLabNote> = self.get(&url).await?;
 
         // Filter out system notes
-        Ok(gl_notes
+        let comments: Vec<Comment> = gl_notes
             .iter()
             .filter(|n| !n.system)
             .map(map_note)
-            .collect())
+            .collect();
+        Ok(comments.into())
     }
 
     async fn add_comment(&self, issue_key: &str, body: &str) -> Result<Comment> {
@@ -493,7 +494,7 @@ impl IssueProvider for GitLabClient {
 
 #[async_trait]
 impl MergeRequestProvider for GitLabClient {
-    async fn get_merge_requests(&self, filter: MrFilter) -> Result<Vec<MergeRequest>> {
+    async fn get_merge_requests(&self, filter: MrFilter) -> Result<ProviderResult<MergeRequest>> {
         let mut url = self.project_url("/merge_requests");
         let mut params = vec![];
 
@@ -538,7 +539,7 @@ impl MergeRequestProvider for GitLabClient {
         }
 
         let gl_mrs: Vec<GitLabMergeRequest> = self.get(&url).await?;
-        Ok(gl_mrs.iter().map(map_merge_request).collect())
+        Ok(gl_mrs.iter().map(map_merge_request).collect::<Vec<_>>().into())
     }
 
     async fn get_merge_request(&self, key: &str) -> Result<MergeRequest> {
@@ -548,25 +549,26 @@ impl MergeRequestProvider for GitLabClient {
         Ok(map_merge_request(&gl_mr))
     }
 
-    async fn get_discussions(&self, mr_key: &str) -> Result<Vec<Discussion>> {
+    async fn get_discussions(&self, mr_key: &str) -> Result<ProviderResult<Discussion>> {
         let iid = parse_mr_key(mr_key)?;
         let url = self.project_url(&format!("/merge_requests/{}/discussions", iid));
         let gl_discussions: Vec<GitLabDiscussion> = self.get(&url).await?;
 
         // Map and filter out empty discussions (all system notes)
-        Ok(gl_discussions
+        let discussions: Vec<Discussion> = gl_discussions
             .iter()
             .map(map_discussion)
             .filter(|d| !d.comments.is_empty())
-            .collect())
+            .collect();
+        Ok(discussions.into())
     }
 
-    async fn get_diffs(&self, mr_key: &str) -> Result<Vec<FileDiff>> {
+    async fn get_diffs(&self, mr_key: &str) -> Result<ProviderResult<FileDiff>> {
         let iid = parse_mr_key(mr_key)?;
         // Use the changes endpoint which returns diffs with content
         let url = self.project_url(&format!("/merge_requests/{}/changes", iid));
         let gl_changes: GitLabMergeRequestChanges = self.get(&url).await?;
-        Ok(gl_changes.changes.iter().map(map_diff).collect())
+        Ok(gl_changes.changes.iter().map(map_diff).collect::<Vec<_>>().into())
     }
 
     async fn add_comment(&self, mr_key: &str, input: CreateCommentInput) -> Result<Comment> {
@@ -1498,7 +1500,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 1);
             assert_eq!(issues[0].key, "gitlab#42");
@@ -1659,7 +1662,8 @@ mod tests {
             let mrs = client
                 .get_merge_requests(MrFilter::default())
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(mrs.len(), 1);
             assert_eq!(mrs[0].key, "mr#50");
@@ -1725,7 +1729,7 @@ mod tests {
             });
 
             let client = create_test_client(&server);
-            let discussions = client.get_discussions("mr#50").await.unwrap();
+            let discussions = client.get_discussions("mr#50").await.unwrap().items;
 
             // System-only discussion should be filtered out
             assert_eq!(discussions.len(), 1);
@@ -1766,7 +1770,7 @@ mod tests {
             });
 
             let client = create_test_client(&server);
-            let diffs = client.get_diffs("mr#50").await.unwrap();
+            let diffs = client.get_diffs("mr#50").await.unwrap().items;
 
             assert_eq!(diffs.len(), 2);
             assert_eq!(diffs[0].file_path, "src/main.rs");

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -6,7 +6,8 @@
 use async_trait::async_trait;
 use devboy_core::{
     Comment, CreateIssueInput, Error, GetUsersOptions, Issue, IssueFilter, IssueProvider,
-    IssueStatus, MergeRequestProvider, PipelineProvider, Provider, Result, UpdateIssueInput, User,
+    IssueStatus, MergeRequestProvider, PipelineProvider, Provider, ProviderResult, Result,
+    UpdateIssueInput, User,
 };
 use tracing::{debug, warn};
 
@@ -814,10 +815,10 @@ fn instance_url_from_base(base_url: &str) -> String {
 
 #[async_trait]
 impl IssueProvider for JiraClient {
-    async fn get_issues(&self, filter: IssueFilter) -> Result<Vec<Issue>> {
+    async fn get_issues(&self, filter: IssueFilter) -> Result<ProviderResult<Issue>> {
         let limit = filter.limit.unwrap_or(20);
         if limit == 0 {
-            return Ok(vec![]);
+            return Ok(vec![].into());
         }
         let offset = filter.offset.unwrap_or(0);
 
@@ -926,7 +927,7 @@ impl IssueProvider for JiraClient {
                     }
                 }
 
-                Ok(all_issues)
+                Ok(all_issues.into())
             }
             JiraFlavor::SelfHosted => {
                 // Self-Hosted: GET /search?jql=...&startAt=...&maxResults=...
@@ -952,13 +953,13 @@ impl IssueProvider for JiraClient {
 
                 let search_resp: JiraSearchResponse = self.handle_response(response).await?;
 
-                let issues = search_resp
+                let issues: Vec<Issue> = search_resp
                     .issues
                     .iter()
                     .map(|i| map_issue(i, self.flavor, instance_url))
                     .collect();
 
-                Ok(issues)
+                Ok(issues.into())
             }
         }
     }
@@ -1077,7 +1078,7 @@ impl IssueProvider for JiraClient {
         self.get_issue(jira_key).await
     }
 
-    async fn get_comments(&self, issue_key: &str) -> Result<Vec<Comment>> {
+    async fn get_comments(&self, issue_key: &str) -> Result<ProviderResult<Comment>> {
         let jira_key = parse_jira_key(issue_key);
         let url = format!("{}/issue/{}/comment", self.base_url, jira_key);
         let response: JiraCommentsResponse = self.get(&url).await?;
@@ -1085,7 +1086,8 @@ impl IssueProvider for JiraClient {
             .comments
             .iter()
             .map(|c| map_comment(c, self.flavor))
-            .collect())
+            .collect::<Vec<_>>()
+            .into())
     }
 
     async fn add_comment(&self, issue_key: &str, body: &str) -> Result<Comment> {
@@ -1103,10 +1105,10 @@ impl IssueProvider for JiraClient {
         Ok(map_comment(&jira_comment, self.flavor))
     }
 
-    async fn get_statuses(&self) -> Result<Vec<IssueStatus>> {
+    async fn get_statuses(&self) -> Result<ProviderResult<IssueStatus>> {
         let project_statuses = self.get_project_statuses().await?;
 
-        let statuses = project_statuses
+        let statuses: Vec<IssueStatus> = project_statuses
             .iter()
             .enumerate()
             .map(|(idx, s)| {
@@ -1131,10 +1133,10 @@ impl IssueProvider for JiraClient {
             })
             .collect();
 
-        Ok(statuses)
+        Ok(statuses.into())
     }
 
-    async fn get_users(&self, options: GetUsersOptions) -> Result<Vec<User>> {
+    async fn get_users(&self, options: GetUsersOptions) -> Result<ProviderResult<User>> {
         let start_at = options.start_at.unwrap_or(0);
         let max_results = options.max_results.unwrap_or(50);
 
@@ -1163,12 +1165,12 @@ impl IssueProvider for JiraClient {
 
         let jira_users: Vec<JiraUser> = self.get(&url).await?;
 
-        let users = jira_users
+        let users: Vec<User> = jira_users
             .iter()
             .map(|u| map_user(Some(u)).unwrap_or_default())
             .collect();
 
-        Ok(users)
+        Ok(users.into())
     }
 
     async fn link_issues(&self, source_key: &str, target_key: &str, link_type: &str) -> Result<()> {
@@ -1939,7 +1941,7 @@ mod tests {
             });
 
             let client = create_self_hosted_client(&server);
-            let issues = client.get_issues(IssueFilter::default()).await.unwrap();
+            let issues = client.get_issues(IssueFilter::default()).await.unwrap().items;
 
             assert_eq!(issues.len(), 1);
             assert_eq!(issues[0].key, "jira#PROJ-1");
@@ -1977,7 +1979,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 1);
         }
@@ -2007,7 +2010,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 1);
         }
@@ -2535,7 +2539,7 @@ mod tests {
             });
 
             let client = create_self_hosted_client(&server);
-            let comments = client.get_comments("PROJ-1").await.unwrap();
+            let comments = client.get_comments("PROJ-1").await.unwrap().items;
 
             assert_eq!(comments.len(), 1);
             assert_eq!(comments[0].id, "100");
@@ -2589,7 +2593,7 @@ mod tests {
             });
 
             let client = create_cloud_client(&server);
-            let issues = client.get_issues(IssueFilter::default()).await.unwrap();
+            let issues = client.get_issues(IssueFilter::default()).await.unwrap().items;
 
             assert_eq!(issues.len(), 1);
             assert_eq!(issues[0].key, "jira#PROJ-1");
@@ -2956,7 +2960,8 @@ mod tests {
                     ..Default::default()
                 })
                 .await
-                .unwrap();
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 3);
             assert_eq!(issues[0].key, "jira#PROJ-1");

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -2017,7 +2017,11 @@ mod tests {
             });
 
             let client = create_self_hosted_client(&server);
-            let issues = client.get_issues(IssueFilter::default()).await.unwrap().items;
+            let issues = client
+                .get_issues(IssueFilter::default())
+                .await
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 1);
             assert_eq!(issues[0].key, "jira#PROJ-1");
@@ -2667,7 +2671,11 @@ mod tests {
             });
 
             let client = create_cloud_client(&server);
-            let issues = client.get_issues(IssueFilter::default()).await.unwrap().items;
+            let issues = client
+                .get_issues(IssueFilter::default())
+                .await
+                .unwrap()
+                .items;
 
             assert_eq!(issues.len(), 1);
             assert_eq!(issues[0].key, "jira#PROJ-1");

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -984,7 +984,18 @@ impl IssueProvider for JiraClient {
                     }
                 }
 
-                Ok(all_issues.into())
+                let mut result = ProviderResult::new(all_issues);
+                result.pagination = Some(devboy_core::Pagination {
+                    offset,
+                    limit,
+                    total: None, // Jira Cloud cursor-based, no total
+                    has_more: next_page_token.is_some(),
+                });
+                result.sort_info = Some(devboy_core::SortInfo {
+                    current_sort: Some(format!("{}:{}", order_by, order.to_lowercase())),
+                    available_sorts: vec!["created".into(), "updated".into(), "priority".into()],
+                });
+                Ok(result)
             }
             JiraFlavor::SelfHosted => {
                 // Self-Hosted: GET /search?jql=...&startAt=...&maxResults=...
@@ -1010,13 +1021,30 @@ impl IssueProvider for JiraClient {
 
                 let search_resp: JiraSearchResponse = self.handle_response(response).await?;
 
+                let total = search_resp.total;
+                let has_more = match (total, search_resp.start_at, search_resp.max_results) {
+                    (Some(t), Some(s), Some(m)) => s + m < t,
+                    _ => false,
+                };
+
                 let issues: Vec<Issue> = search_resp
                     .issues
                     .iter()
                     .map(|i| map_issue(i, self.flavor, instance_url))
                     .collect();
 
-                Ok(issues.into())
+                let mut result = ProviderResult::new(issues);
+                result.pagination = Some(devboy_core::Pagination {
+                    offset,
+                    limit,
+                    total,
+                    has_more,
+                });
+                result.sort_info = Some(devboy_core::SortInfo {
+                    current_sort: Some(format!("{}:{}", order_by, order.to_lowercase())),
+                    available_sorts: vec!["created".into(), "updated".into(), "priority".into()],
+                });
+                Ok(result)
             }
         }
     }

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -992,7 +992,11 @@ impl IssueProvider for JiraClient {
                     has_more: next_page_token.is_some(),
                 });
                 result.sort_info = Some(devboy_core::SortInfo {
-                    current_sort: Some(format!("{}:{}", order_by, order.to_lowercase())),
+                    sort_by: Some(order_by.into()),
+                    sort_order: match order {
+                        "ASC" => devboy_core::SortOrder::Asc,
+                        _ => devboy_core::SortOrder::Desc,
+                    },
                     available_sorts: vec!["created".into(), "updated".into(), "priority".into()],
                 });
                 Ok(result)
@@ -1041,7 +1045,11 @@ impl IssueProvider for JiraClient {
                     has_more,
                 });
                 result.sort_info = Some(devboy_core::SortInfo {
-                    current_sort: Some(format!("{}:{}", order_by, order.to_lowercase())),
+                    sort_by: Some(order_by.into()),
+                    sort_order: match order {
+                        "ASC" => devboy_core::SortOrder::Asc,
+                        _ => devboy_core::SortOrder::Desc,
+                    },
                     available_sorts: vec!["created".into(), "updated".into(), "priority".into()],
                 });
                 Ok(result)

--- a/crates/plugins/format-pipeline/benches/format_comparison.rs
+++ b/crates/plugins/format-pipeline/benches/format_comparison.rs
@@ -201,7 +201,7 @@ fn bench_pipeline_transform(c: &mut Criterion) {
             |b, issues| {
                 let pipeline = Pipeline::with_config(PipelineConfig {
                     format: OutputFormat::Json,
-                    max_items: 100,
+
                     max_chars: 1_000_000,
                     ..Default::default()
                 });
@@ -219,7 +219,7 @@ fn bench_pipeline_transform(c: &mut Criterion) {
             |b, issues| {
                 let pipeline = Pipeline::with_config(PipelineConfig {
                     format: OutputFormat::Toon,
-                    max_items: 100,
+
                     max_chars: 1_000_000,
                     ..Default::default()
                 });

--- a/crates/plugins/format-pipeline/benches/format_comparison.rs
+++ b/crates/plugins/format-pipeline/benches/format_comparison.rs
@@ -203,7 +203,6 @@ fn bench_pipeline_transform(c: &mut Criterion) {
             |b, issues| {
                 let pipeline = Pipeline::with_config(PipelineConfig {
                     format: OutputFormat::Json,
-
                     max_chars: 1_000_000,
                     ..Default::default()
                 });
@@ -221,7 +220,6 @@ fn bench_pipeline_transform(c: &mut Criterion) {
             |b, issues| {
                 let pipeline = Pipeline::with_config(PipelineConfig {
                     format: OutputFormat::Toon,
-
                     max_chars: 1_000_000,
                     ..Default::default()
                 });

--- a/crates/plugins/format-pipeline/src/budget.rs
+++ b/crates/plugins/format-pipeline/src/budget.rs
@@ -230,10 +230,8 @@ pub fn process_merge_requests(
 
     if result.trimmed {
         let included_indices = tree.included_item_indices();
-        let included_mrs: Vec<devboy_core::MergeRequest> = included_indices
-            .iter()
-            .map(|&i| mrs[i].clone())
-            .collect();
+        let included_mrs: Vec<devboy_core::MergeRequest> =
+            included_indices.iter().map(|&i| mrs[i].clone()).collect();
 
         for level in [TrimLevel::Full, TrimLevel::Standard, TrimLevel::Minimal] {
             let encoded = toon::encode_merge_requests(&included_mrs, level)?;
@@ -282,10 +280,8 @@ pub fn process_diffs(
 
     if result.trimmed {
         let included_indices = tree.included_item_indices();
-        let included_diffs: Vec<devboy_core::FileDiff> = included_indices
-            .iter()
-            .map(|&i| diffs[i].clone())
-            .collect();
+        let included_diffs: Vec<devboy_core::FileDiff> =
+            included_indices.iter().map(|&i| diffs[i].clone()).collect();
 
         let encoded = toon::encode_diffs(&included_diffs)?;
         let tokens = estimate_tokens(&encoded);

--- a/crates/plugins/format-pipeline/src/budget.rs
+++ b/crates/plugins/format-pipeline/src/budget.rs
@@ -202,6 +202,202 @@ pub fn process_issues(
     Ok(result)
 }
 
+/// High-level: apply strategy and run budget pipeline on merge requests.
+pub fn process_merge_requests(
+    mrs: &[devboy_core::MergeRequest],
+    strategy_kind: TrimStrategyKind,
+    config: &BudgetConfig,
+) -> devboy_core::Result<BudgetResult> {
+    let full_encoded = toon::encode_merge_requests(mrs, TrimLevel::Full)?;
+    let full_tokens = estimate_tokens(&full_encoded);
+
+    if full_tokens <= config.budget_tokens {
+        return Ok(BudgetResult {
+            content: full_encoded,
+            tokens: full_tokens,
+            trimmed: false,
+            overflow_indices: vec![],
+            total_items: mrs.len(),
+            included_items: mrs.len(),
+        });
+    }
+
+    let mut tree = crate::tree::build_merge_requests_tree(mrs);
+    let strategy = create_strategy(strategy_kind);
+    strategy.assign_values(&mut tree);
+
+    let mut result = run(&mut tree, &full_encoded, config);
+
+    if result.trimmed {
+        let included_indices = tree.included_item_indices();
+        let included_mrs: Vec<devboy_core::MergeRequest> = included_indices
+            .iter()
+            .map(|&i| mrs[i].clone())
+            .collect();
+
+        for level in [TrimLevel::Full, TrimLevel::Standard, TrimLevel::Minimal] {
+            let encoded = toon::encode_merge_requests(&included_mrs, level)?;
+            let tokens = estimate_tokens(&encoded);
+            if tokens <= config.budget_tokens {
+                result.content = encoded;
+                result.tokens = tokens;
+                return Ok(result);
+            }
+        }
+
+        let encoded = toon::encode_merge_requests(&included_mrs, TrimLevel::Minimal)?;
+        let max_chars = crate::token_counter::tokens_to_chars(config.budget_tokens);
+        result.content = truncation::truncate_string(&encoded, max_chars);
+        result.tokens = estimate_tokens(&result.content);
+    }
+
+    Ok(result)
+}
+
+/// High-level: apply strategy and run budget pipeline on diffs.
+pub fn process_diffs(
+    diffs: &[devboy_core::FileDiff],
+    strategy_kind: TrimStrategyKind,
+    config: &BudgetConfig,
+) -> devboy_core::Result<BudgetResult> {
+    let full_encoded = toon::encode_diffs(diffs)?;
+    let full_tokens = estimate_tokens(&full_encoded);
+
+    if full_tokens <= config.budget_tokens {
+        return Ok(BudgetResult {
+            content: full_encoded,
+            tokens: full_tokens,
+            trimmed: false,
+            overflow_indices: vec![],
+            total_items: diffs.len(),
+            included_items: diffs.len(),
+        });
+    }
+
+    let mut tree = crate::tree::build_diffs_tree(diffs);
+    let strategy = create_strategy(strategy_kind);
+    strategy.assign_values(&mut tree);
+
+    let mut result = run(&mut tree, &full_encoded, config);
+
+    if result.trimmed {
+        let included_indices = tree.included_item_indices();
+        let included_diffs: Vec<devboy_core::FileDiff> = included_indices
+            .iter()
+            .map(|&i| diffs[i].clone())
+            .collect();
+
+        let encoded = toon::encode_diffs(&included_diffs)?;
+        let tokens = estimate_tokens(&encoded);
+        if tokens <= config.budget_tokens {
+            result.content = encoded;
+            result.tokens = tokens;
+        } else {
+            let max_chars = crate::token_counter::tokens_to_chars(config.budget_tokens);
+            result.content = truncation::truncate_string(&encoded, max_chars);
+            result.tokens = estimate_tokens(&result.content);
+        }
+    }
+
+    Ok(result)
+}
+
+/// High-level: apply strategy and run budget pipeline on discussions.
+pub fn process_discussions(
+    discussions: &[devboy_core::Discussion],
+    strategy_kind: TrimStrategyKind,
+    config: &BudgetConfig,
+) -> devboy_core::Result<BudgetResult> {
+    let full_encoded = toon::encode_discussions(discussions)?;
+    let full_tokens = estimate_tokens(&full_encoded);
+
+    if full_tokens <= config.budget_tokens {
+        return Ok(BudgetResult {
+            content: full_encoded,
+            tokens: full_tokens,
+            trimmed: false,
+            overflow_indices: vec![],
+            total_items: discussions.len(),
+            included_items: discussions.len(),
+        });
+    }
+
+    let mut tree = crate::tree::build_discussions_tree(discussions);
+    let strategy = create_strategy(strategy_kind);
+    strategy.assign_values(&mut tree);
+
+    let mut result = run(&mut tree, &full_encoded, config);
+
+    if result.trimmed {
+        let included_indices = tree.included_item_indices();
+        let included_discussions: Vec<devboy_core::Discussion> = included_indices
+            .iter()
+            .map(|&i| discussions[i].clone())
+            .collect();
+
+        let encoded = toon::encode_discussions(&included_discussions)?;
+        let tokens = estimate_tokens(&encoded);
+        if tokens <= config.budget_tokens {
+            result.content = encoded;
+            result.tokens = tokens;
+        } else {
+            let max_chars = crate::token_counter::tokens_to_chars(config.budget_tokens);
+            result.content = truncation::truncate_string(&encoded, max_chars);
+            result.tokens = estimate_tokens(&result.content);
+        }
+    }
+
+    Ok(result)
+}
+
+/// High-level: apply strategy and run budget pipeline on comments.
+pub fn process_comments(
+    comments: &[devboy_core::Comment],
+    strategy_kind: TrimStrategyKind,
+    config: &BudgetConfig,
+) -> devboy_core::Result<BudgetResult> {
+    let full_encoded = toon::encode_comments(comments)?;
+    let full_tokens = estimate_tokens(&full_encoded);
+
+    if full_tokens <= config.budget_tokens {
+        return Ok(BudgetResult {
+            content: full_encoded,
+            tokens: full_tokens,
+            trimmed: false,
+            overflow_indices: vec![],
+            total_items: comments.len(),
+            included_items: comments.len(),
+        });
+    }
+
+    let mut tree = crate::tree::build_comments_tree(comments);
+    let strategy = create_strategy(strategy_kind);
+    strategy.assign_values(&mut tree);
+
+    let mut result = run(&mut tree, &full_encoded, config);
+
+    if result.trimmed {
+        let included_indices = tree.included_item_indices();
+        let included_comments: Vec<devboy_core::Comment> = included_indices
+            .iter()
+            .map(|&i| comments[i].clone())
+            .collect();
+
+        let encoded = toon::encode_comments(&included_comments)?;
+        let tokens = estimate_tokens(&encoded);
+        if tokens <= config.budget_tokens {
+            result.content = encoded;
+            result.tokens = tokens;
+        } else {
+            let max_chars = crate::token_counter::tokens_to_chars(config.budget_tokens);
+            result.content = truncation::truncate_string(&encoded, max_chars);
+            result.tokens = estimate_tokens(&result.content);
+        }
+    }
+
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/plugins/format-pipeline/src/budget.rs
+++ b/crates/plugins/format-pipeline/src/budget.rs
@@ -563,4 +563,258 @@ mod tests {
         assert!(!result.trimmed);
         assert_eq!(result.total_items, 0);
     }
+
+    // --- process_merge_requests tests ---
+
+    fn sample_merge_requests(n: usize) -> Vec<devboy_core::MergeRequest> {
+        (0..n)
+            .map(|i| devboy_core::MergeRequest {
+                key: format!("mr#{}", i + 1),
+                title: format!("Merge Request {}", i + 1),
+                description: Some(format!(
+                    "Description for MR {} with enough text to make it non-trivial for token counting purposes",
+                    i + 1
+                )),
+                state: "opened".into(),
+                source: "gitlab".into(),
+                source_branch: format!("feature-{}", i + 1),
+                target_branch: "main".into(),
+                author: Some(devboy_core::User {
+                    id: format!("{}", i),
+                    username: format!("user{}", i),
+                    name: None,
+                    email: None,
+                    avatar_url: None,
+                }),
+                assignees: vec![],
+                reviewers: vec![],
+                labels: vec!["enhancement".into()],
+                draft: false,
+                url: Some(format!("https://gitlab.com/test/repo/-/merge_requests/{}", i + 1)),
+                created_at: Some("2024-01-01T00:00:00Z".into()),
+                updated_at: Some("2024-01-02T00:00:00Z".into()),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_process_merge_requests_fast_path() {
+        let mrs = sample_merge_requests(2);
+        let config = BudgetConfig {
+            budget_tokens: 50000,
+            ..Default::default()
+        };
+        let result = process_merge_requests(&mrs, TrimStrategyKind::ElementCount, &config).unwrap();
+        assert!(!result.trimmed);
+        assert!(!result.content.is_empty());
+        assert_eq!(result.total_items, 2);
+        assert_eq!(result.included_items, 2);
+    }
+
+    #[test]
+    fn test_process_merge_requests_with_trimming() {
+        let mrs = sample_merge_requests(20);
+        let config = BudgetConfig {
+            budget_tokens: 500,
+            margin: 0.20,
+            max_iterations: 3,
+        };
+        let result = process_merge_requests(&mrs, TrimStrategyKind::ElementCount, &config).unwrap();
+        assert!(result.trimmed);
+        assert!(result.included_items < 20);
+        assert!(!result.content.is_empty());
+        assert!(result.tokens <= config.budget_tokens);
+    }
+
+    #[test]
+    fn test_process_merge_requests_empty() {
+        let config = BudgetConfig::default();
+        let result = process_merge_requests(&[], TrimStrategyKind::Default, &config).unwrap();
+        assert!(!result.trimmed);
+        assert_eq!(result.total_items, 0);
+    }
+
+    // --- process_diffs tests ---
+
+    fn sample_diffs(n: usize) -> Vec<devboy_core::FileDiff> {
+        (0..n)
+            .map(|i| devboy_core::FileDiff {
+                file_path: format!("src/module_{}/file_{}.rs", i / 3, i + 1),
+                old_path: None,
+                new_file: i == 0,
+                deleted_file: false,
+                renamed_file: false,
+                diff: format!(
+                    "@@ -1,10 +1,15 @@\n-old line {i}\n+new line {i}\n+added context for file {i} with enough diff content to be meaningful",
+                    i = i + 1
+                ),
+                additions: Some(2),
+                deletions: Some(1),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_process_diffs_fast_path() {
+        let diffs = sample_diffs(2);
+        let config = BudgetConfig {
+            budget_tokens: 50000,
+            ..Default::default()
+        };
+        let result = process_diffs(&diffs, TrimStrategyKind::ElementCount, &config).unwrap();
+        assert!(!result.trimmed);
+        assert!(!result.content.is_empty());
+        assert_eq!(result.total_items, 2);
+        assert_eq!(result.included_items, 2);
+    }
+
+    #[test]
+    fn test_process_diffs_with_trimming() {
+        let diffs = sample_diffs(20);
+        let config = BudgetConfig {
+            budget_tokens: 200,
+            margin: 0.20,
+            max_iterations: 3,
+        };
+        let result = process_diffs(&diffs, TrimStrategyKind::ElementCount, &config).unwrap();
+        assert!(result.trimmed);
+        assert!(result.included_items < 20);
+        assert!(!result.content.is_empty());
+    }
+
+    #[test]
+    fn test_process_diffs_empty() {
+        let config = BudgetConfig::default();
+        let result = process_diffs(&[], TrimStrategyKind::Default, &config).unwrap();
+        assert!(!result.trimmed);
+        assert_eq!(result.total_items, 0);
+    }
+
+    // --- process_discussions tests ---
+
+    fn sample_discussions(n: usize) -> Vec<devboy_core::Discussion> {
+        (0..n)
+            .map(|i| devboy_core::Discussion {
+                id: format!("disc-{}", i + 1),
+                resolved: i % 3 == 0,
+                resolved_by: None,
+                comments: vec![devboy_core::Comment {
+                    id: format!("comment-{}", i + 1),
+                    body: format!(
+                        "Discussion comment {} with enough body text for token counting purposes in the budget pipeline",
+                        i + 1
+                    ),
+                    author: Some(devboy_core::User {
+                        id: format!("{}", i),
+                        username: format!("reviewer{}", i),
+                        name: None,
+                        email: None,
+                        avatar_url: None,
+                    }),
+                    created_at: Some("2024-01-01T00:00:00Z".into()),
+                    updated_at: None,
+                    position: None,
+                }],
+                position: None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_process_discussions_fast_path() {
+        let discussions = sample_discussions(2);
+        let config = BudgetConfig {
+            budget_tokens: 50000,
+            ..Default::default()
+        };
+        let result =
+            process_discussions(&discussions, TrimStrategyKind::ElementCount, &config).unwrap();
+        assert!(!result.trimmed);
+        assert!(!result.content.is_empty());
+        assert_eq!(result.total_items, 2);
+        assert_eq!(result.included_items, 2);
+    }
+
+    #[test]
+    fn test_process_discussions_with_trimming() {
+        let discussions = sample_discussions(20);
+        let config = BudgetConfig {
+            budget_tokens: 300,
+            margin: 0.20,
+            max_iterations: 3,
+        };
+        let result =
+            process_discussions(&discussions, TrimStrategyKind::ElementCount, &config).unwrap();
+        assert!(result.trimmed);
+        assert!(result.included_items < 20);
+        assert!(!result.content.is_empty());
+    }
+
+    #[test]
+    fn test_process_discussions_empty() {
+        let config = BudgetConfig::default();
+        let result = process_discussions(&[], TrimStrategyKind::Default, &config).unwrap();
+        assert!(!result.trimmed);
+        assert_eq!(result.total_items, 0);
+    }
+
+    // --- process_comments tests ---
+
+    fn sample_comments(n: usize) -> Vec<devboy_core::Comment> {
+        (0..n)
+            .map(|i| devboy_core::Comment {
+                id: format!("c-{}", i + 1),
+                body: format!(
+                    "Comment {} with enough body text to make it non-trivial for budget pipeline token counting",
+                    i + 1
+                ),
+                author: Some(devboy_core::User {
+                    id: format!("{}", i),
+                    username: format!("commenter{}", i),
+                    name: None,
+                    email: None,
+                    avatar_url: None,
+                }),
+                created_at: Some("2024-01-01T00:00:00Z".into()),
+                updated_at: Some("2024-01-02T00:00:00Z".into()),
+                position: None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_process_comments_fast_path() {
+        let comments = sample_comments(2);
+        let config = BudgetConfig {
+            budget_tokens: 50000,
+            ..Default::default()
+        };
+        let result = process_comments(&comments, TrimStrategyKind::ElementCount, &config).unwrap();
+        assert!(!result.trimmed);
+        assert!(!result.content.is_empty());
+        assert_eq!(result.total_items, 2);
+        assert_eq!(result.included_items, 2);
+    }
+
+    #[test]
+    fn test_process_comments_with_trimming() {
+        let comments = sample_comments(20);
+        let config = BudgetConfig {
+            budget_tokens: 300,
+            margin: 0.20,
+            max_iterations: 3,
+        };
+        let result = process_comments(&comments, TrimStrategyKind::ElementCount, &config).unwrap();
+        assert!(result.trimmed);
+        assert!(result.included_items < 20);
+        assert!(!result.content.is_empty());
+    }
+
+    #[test]
+    fn test_process_comments_empty() {
+        let config = BudgetConfig::default();
+        let result = process_comments(&[], TrimStrategyKind::Default, &config).unwrap();
+        assert!(!result.trimmed);
+        assert_eq!(result.total_items, 0);
+    }
 }

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -532,7 +532,7 @@ impl Pipeline {
                     if idx.total_pages > 1 {
                         let hint = format!(
                             "Chunk 1/{}: {} most relevant {} (by priority). {} total items across {} chunks. \
-                            Request specific chunks with `offset` and `limit` params, or request all remaining data.",
+                            Use `chunk: N` parameter to fetch a specific chunk, or request all remaining data.",
                             idx.total_pages,
                             result.included_items,
                             item_type,
@@ -551,7 +551,7 @@ impl Pipeline {
                 } else {
                     let remaining = total.saturating_sub(result.included_items);
                     output.agent_hint = Some(format!(
-                        "Showing {}/{} {}. {} items trimmed by budget. Use `offset` and `limit` for pagination.",
+                        "Showing {}/{} {}. {} items trimmed by budget. Use `chunk: N` parameter to fetch a specific chunk.",
                         result.included_items, total, item_type, remaining
                     ));
                 }

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -437,7 +437,7 @@ impl Pipeline {
                 if let Some(idx) = index {
                     if idx.total_pages > 1 {
                         let hint = format!(
-                            "Showing {}/{} {} (page 1 of {}). Use `offset` and `limit` parameters for pagination.",
+                            "Showing {}/{} {} selected by priority ({} pages available). Use `offset` and `limit` for sequential access.",
                             result.included_items, total, item_type, idx.total_pages
                         );
                         output.page_index = Some(idx);

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -216,7 +216,8 @@ impl Pipeline {
         let strategy_kind = self.resolve_strategy("get_issues");
         let result = budget::process_issues(&issues, strategy_kind, &budget_config)?;
 
-        let index = page_index::build_issues_index(&issues, result.included_items, self.config.max_chars);
+        let index =
+            page_index::build_issues_index(&issues, result.included_items, self.config.max_chars);
         self.build_budget_output(result, raw_chars, total, "issues", Some(index))
     }
 
@@ -241,7 +242,11 @@ impl Pipeline {
         let strategy_kind = self.resolve_strategy("get_merge_requests");
         let result = budget::process_merge_requests(&mrs, strategy_kind, &budget_config)?;
 
-        let index = page_index::build_merge_requests_index(&mrs, result.included_items, self.config.max_chars);
+        let index = page_index::build_merge_requests_index(
+            &mrs,
+            result.included_items,
+            self.config.max_chars,
+        );
         self.build_budget_output(result, raw_chars, total, "merge_requests", Some(index))
     }
 
@@ -279,7 +284,8 @@ impl Pipeline {
         let strategy_kind = self.resolve_strategy("get_merge_request_diffs");
         let result = budget::process_diffs(&diffs, strategy_kind, &budget_config)?;
 
-        let index = page_index::build_diffs_index(&diffs, result.included_items, self.config.max_chars);
+        let index =
+            page_index::build_diffs_index(&diffs, result.included_items, self.config.max_chars);
         self.build_budget_output(result, raw_chars, total, "diffs", Some(index))
     }
 
@@ -304,7 +310,11 @@ impl Pipeline {
         let strategy_kind = self.resolve_strategy("get_issue_comments");
         let result = budget::process_comments(&comments, strategy_kind, &budget_config)?;
 
-        let index = page_index::build_comments_index(&comments, result.included_items, self.config.max_chars);
+        let index = page_index::build_comments_index(
+            &comments,
+            result.included_items,
+            self.config.max_chars,
+        );
         self.build_budget_output(result, raw_chars, total, "comments", Some(index))
     }
 
@@ -329,7 +339,11 @@ impl Pipeline {
         let strategy_kind = self.resolve_strategy("get_merge_request_discussions");
         let result = budget::process_discussions(&discussions, strategy_kind, &budget_config)?;
 
-        let index = page_index::build_discussions_index(&discussions, result.included_items, self.config.max_chars);
+        let index = page_index::build_discussions_index(
+            &discussions,
+            result.included_items,
+            self.config.max_chars,
+        );
         self.build_budget_output(result, raw_chars, total, "discussions", Some(index))
     }
 

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! - **TOON** (default): Token-Oriented Object Notation -- saves 39-90% of tokens
 //! - **JSON**: for programmatic processing
-//! - **Truncation**: size limiting with pagination hints
+//! - **Budget trimming**: smart strategy-based trimming when output exceeds budget
 //!
 //! # Example
 //!
@@ -14,7 +14,7 @@
 //!
 //! let pipeline = Pipeline::with_config(PipelineConfig {
 //!     format: OutputFormat::Toon,
-//!     max_items: 20,
+//!     max_chars: 100_000,
 //!     ..Default::default()
 //! });
 //!
@@ -34,6 +34,14 @@ pub mod truncation;
 pub use truncation::TruncationPlugin;
 
 use devboy_core::{Comment, Discussion, FileDiff, Issue, MergeRequest, Result};
+
+use budget::BudgetConfig;
+use strategy::StrategyResolver;
+
+/// Convert character budget to token estimate (chars / 3.5).
+fn estimate_tokens_from_chars(chars: usize) -> usize {
+    (chars as f64 / 3.5).ceil() as usize
+}
 
 /// Output from a pipeline transformation.
 ///
@@ -106,9 +114,8 @@ impl TransformOutput {
 /// Configuration for pipeline transformations.
 #[derive(Debug, Clone)]
 pub struct PipelineConfig {
-    /// Maximum number of items to include in output
-    pub max_items: usize,
-    /// Maximum characters for the entire output (0 = no limit)
+    /// Maximum characters for the entire output (0 = no limit).
+    /// Used as budget ceiling — converted to tokens via `max_chars / 3.5`.
     pub max_chars: usize,
     /// Maximum characters per item (e.g., diff content)
     pub max_chars_per_item: usize,
@@ -120,18 +127,20 @@ pub struct PipelineConfig {
     pub include_hints: bool,
     /// Page cursor from a previous request (for pagination)
     pub page_cursor: Option<String>,
+    /// Tool name for strategy resolution (e.g., "get_issues", "get_merge_request_diffs")
+    pub tool_name: Option<String>,
 }
 
 impl Default for PipelineConfig {
     fn default() -> Self {
         Self {
-            max_items: 20,
             max_chars: 100_000,
             max_chars_per_item: 10_000,
             max_description_len: 10_000,
             format: OutputFormat::Toon,
             include_hints: true,
             page_cursor: None,
+            tool_name: None,
         }
     }
 }
@@ -163,184 +172,177 @@ impl Pipeline {
         Self { config }
     }
 
-    /// Transform a list of issues.
+    /// Transform a list of issues using budget pipeline.
     pub fn transform_issues(&self, issues: Vec<Issue>) -> Result<TransformOutput> {
         let total = issues.len();
-        let truncated_issues = self.truncate_items(issues);
-        let included = truncated_issues.len();
-
-        let raw_json = serde_json::to_string(&truncated_issues)?;
+        let raw_json = serde_json::to_string(&issues)?;
         let raw_chars = raw_json.len();
 
         let content = match self.config.format {
-            OutputFormat::Json => serde_json::to_string_pretty(&truncated_issues)?,
-            OutputFormat::Toon => toon::encode_issues(&truncated_issues, toon::TrimLevel::Full)?,
+            OutputFormat::Json => serde_json::to_string_pretty(&issues)?,
+            OutputFormat::Toon => toon::encode_issues(&issues, toon::TrimLevel::Full)?,
         };
 
-        let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
-        output.included_count = included;
-
-        if included < total && self.config.include_hints {
-            let hint = self.create_pagination_hint("issues", total, included, None);
-            output = output.with_truncation(total, included, hint);
+        // Fast path: fits within budget
+        if self.config.max_chars == 0 || content.len() <= self.config.max_chars {
+            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+            output.included_count = total;
+            return Ok(output);
         }
 
-        Ok(self.apply_char_limit(output))
+        // Budget pipeline: smart trimming with strategy
+        let budget_config = self.budget_config();
+        let strategy_kind = self.resolve_strategy("get_issues");
+        let result = budget::process_issues(&issues, strategy_kind, &budget_config)?;
+
+        self.build_budget_output(result, raw_chars, total, "issues")
     }
 
-    /// Transform a list of merge requests.
+    /// Transform a list of merge requests using budget pipeline.
     pub fn transform_merge_requests(&self, mrs: Vec<MergeRequest>) -> Result<TransformOutput> {
         let total = mrs.len();
-        let truncated_mrs = self.truncate_items(mrs);
-        let included = truncated_mrs.len();
-
-        let raw_json = serde_json::to_string(&truncated_mrs)?;
+        let raw_json = serde_json::to_string(&mrs)?;
         let raw_chars = raw_json.len();
 
         let content = match self.config.format {
-            OutputFormat::Json => serde_json::to_string_pretty(&truncated_mrs)?,
-            OutputFormat::Toon => {
-                toon::encode_merge_requests(&truncated_mrs, toon::TrimLevel::Full)?
-            }
+            OutputFormat::Json => serde_json::to_string_pretty(&mrs)?,
+            OutputFormat::Toon => toon::encode_merge_requests(&mrs, toon::TrimLevel::Full)?,
         };
 
-        let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
-        output.included_count = included;
-
-        if included < total && self.config.include_hints {
-            let hint = self.create_pagination_hint("merge_requests", total, included, None);
-            output = output.with_truncation(total, included, hint);
+        if self.config.max_chars == 0 || content.len() <= self.config.max_chars {
+            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+            output.included_count = total;
+            return Ok(output);
         }
 
-        Ok(self.apply_char_limit(output))
+        let budget_config = self.budget_config();
+        let strategy_kind = self.resolve_strategy("get_merge_requests");
+        let result = budget::process_merge_requests(&mrs, strategy_kind, &budget_config)?;
+
+        self.build_budget_output(result, raw_chars, total, "merge_requests")
     }
 
-    /// Transform a list of file diffs.
+    /// Transform a list of file diffs using budget pipeline.
+    ///
+    /// Individual diff content is truncated per `max_chars_per_item` before
+    /// budget trimming to protect against giant lock/generated files.
     pub fn transform_diffs(&self, diffs: Vec<FileDiff>) -> Result<TransformOutput> {
         let total = diffs.len();
 
-        // Truncate diff content first
-        let truncated_diffs: Vec<FileDiff> = diffs
+        // Per-item truncation for individual diff content (protection against giant files)
+        let diffs: Vec<FileDiff> = diffs
             .into_iter()
-            .take(self.config.max_items)
             .map(|mut d| {
                 d.diff = truncation::truncate_string(&d.diff, self.config.max_chars_per_item);
                 d
             })
             .collect();
 
-        let included = truncated_diffs.len();
-
-        let raw_json = serde_json::to_string(&truncated_diffs)?;
+        let raw_json = serde_json::to_string(&diffs)?;
         let raw_chars = raw_json.len();
 
         let content = match self.config.format {
-            OutputFormat::Json => serde_json::to_string_pretty(&truncated_diffs)?,
-            OutputFormat::Toon => toon::encode_diffs(&truncated_diffs)?,
+            OutputFormat::Json => serde_json::to_string_pretty(&diffs)?,
+            OutputFormat::Toon => toon::encode_diffs(&diffs)?,
         };
 
-        let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
-        output.included_count = included;
-
-        if included < total && self.config.include_hints {
-            let hint = self.create_pagination_hint("diffs", total, included, Some("get_diffs"));
-            output = output.with_truncation(total, included, hint);
+        if self.config.max_chars == 0 || content.len() <= self.config.max_chars {
+            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+            output.included_count = total;
+            return Ok(output);
         }
 
-        Ok(self.apply_char_limit(output))
+        let budget_config = self.budget_config();
+        let strategy_kind = self.resolve_strategy("get_merge_request_diffs");
+        let result = budget::process_diffs(&diffs, strategy_kind, &budget_config)?;
+
+        self.build_budget_output(result, raw_chars, total, "diffs")
     }
 
-    /// Transform a list of comments.
+    /// Transform a list of comments using budget pipeline.
     pub fn transform_comments(&self, comments: Vec<Comment>) -> Result<TransformOutput> {
         let total = comments.len();
-        let truncated_comments = self.truncate_items(comments);
-        let included = truncated_comments.len();
-
-        let raw_json = serde_json::to_string(&truncated_comments)?;
+        let raw_json = serde_json::to_string(&comments)?;
         let raw_chars = raw_json.len();
 
         let content = match self.config.format {
-            OutputFormat::Json => serde_json::to_string_pretty(&truncated_comments)?,
-            OutputFormat::Toon => toon::encode_comments(&truncated_comments)?,
+            OutputFormat::Json => serde_json::to_string_pretty(&comments)?,
+            OutputFormat::Toon => toon::encode_comments(&comments)?,
         };
 
-        let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
-        output.included_count = included;
-
-        if included < total && self.config.include_hints {
-            let hint = self.create_pagination_hint("comments", total, included, None);
-            output = output.with_truncation(total, included, hint);
+        if self.config.max_chars == 0 || content.len() <= self.config.max_chars {
+            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+            output.included_count = total;
+            return Ok(output);
         }
 
-        Ok(self.apply_char_limit(output))
+        let budget_config = self.budget_config();
+        let strategy_kind = self.resolve_strategy("get_issue_comments");
+        let result = budget::process_comments(&comments, strategy_kind, &budget_config)?;
+
+        self.build_budget_output(result, raw_chars, total, "comments")
     }
 
-    /// Transform a list of discussions.
+    /// Transform a list of discussions using budget pipeline.
     pub fn transform_discussions(&self, discussions: Vec<Discussion>) -> Result<TransformOutput> {
         let total = discussions.len();
-        let truncated_discussions = self.truncate_items(discussions);
-        let included = truncated_discussions.len();
-
-        let raw_json = serde_json::to_string(&truncated_discussions)?;
+        let raw_json = serde_json::to_string(&discussions)?;
         let raw_chars = raw_json.len();
 
         let content = match self.config.format {
-            OutputFormat::Json => serde_json::to_string_pretty(&truncated_discussions)?,
-            OutputFormat::Toon => toon::encode_discussions(&truncated_discussions)?,
+            OutputFormat::Json => serde_json::to_string_pretty(&discussions)?,
+            OutputFormat::Toon => toon::encode_discussions(&discussions)?,
         };
 
-        let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
-        output.included_count = included;
-
-        if included < total && self.config.include_hints {
-            let hint = self.create_pagination_hint("discussions", total, included, None);
-            output = output.with_truncation(total, included, hint);
+        if self.config.max_chars == 0 || content.len() <= self.config.max_chars {
+            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+            output.included_count = total;
+            return Ok(output);
         }
 
-        Ok(self.apply_char_limit(output))
+        let budget_config = self.budget_config();
+        let strategy_kind = self.resolve_strategy("get_merge_request_discussions");
+        let result = budget::process_discussions(&discussions, strategy_kind, &budget_config)?;
+
+        self.build_budget_output(result, raw_chars, total, "discussions")
     }
 
-    /// Truncate a vector to max_items.
-    fn truncate_items<T>(&self, items: Vec<T>) -> Vec<T> {
-        items.into_iter().take(self.config.max_items).collect()
-    }
-
-    /// Apply character limit to output.
-    fn apply_char_limit(&self, mut output: TransformOutput) -> TransformOutput {
-        if output.content.len() > self.config.max_chars {
-            output.pre_trim_chars = output.output_chars; // save size before trimming
-            output.content = truncation::truncate_string(&output.content, self.config.max_chars);
-            output.output_chars = output.content.len();
-            if !output.truncated {
-                output.truncated = true;
-                output.agent_hint = Some(format!(
-                    "Output truncated to {} chars. Use pagination or filters to get more specific results.",
-                    self.config.max_chars
-                ));
-            }
+    /// Convert max_chars to budget pipeline config.
+    fn budget_config(&self) -> BudgetConfig {
+        BudgetConfig {
+            budget_tokens: estimate_tokens_from_chars(self.config.max_chars),
+            ..Default::default()
         }
-        output
     }
 
-    /// Create a pagination hint for the agent.
-    fn create_pagination_hint(
+    /// Resolve trimming strategy for tool name.
+    fn resolve_strategy(&self, default_tool: &str) -> strategy::TrimStrategyKind {
+        let resolver = StrategyResolver::new();
+        let tool = self.config.tool_name.as_deref().unwrap_or(default_tool);
+        resolver.resolve(tool)
+    }
+
+    /// Build TransformOutput from BudgetResult.
+    fn build_budget_output(
         &self,
-        item_type: &str,
+        result: budget::BudgetResult,
+        raw_chars: usize,
         total: usize,
-        included: usize,
-        tool_name: Option<&str>,
-    ) -> String {
-        let remaining = total - included;
-        let next_offset = included;
+        item_type: &str,
+    ) -> Result<TransformOutput> {
+        let mut output = TransformOutput::new(result.content).with_raw_chars(raw_chars);
+        output.included_count = result.included_items;
 
-        let tool_hint = tool_name
-            .map(|t| format!(" Use `{}` with offset={}", t, next_offset))
-            .unwrap_or_default();
+        if result.trimmed && self.config.include_hints {
+            let remaining = total.saturating_sub(result.included_items);
+            let hint = format!(
+                "Showing {}/{} {}. {} items trimmed by budget. Use `offset` and `limit` parameters for pagination.",
+                result.included_items, total, item_type, remaining
+            );
+            output = output.with_truncation(total, result.included_items, hint);
+        }
 
-        format!(
-            "Showing {}/{} {}. {} more available.{} You can use `offset` and `limit` parameters for pagination.",
-            included, total, item_type, remaining, tool_hint
-        )
+        Ok(output)
     }
 }
 
@@ -452,13 +454,13 @@ mod tests {
             .collect()
     }
 
-    // --- Pipeline truncation ---
+    // --- Pipeline truncation (budget-based) ---
 
     #[test]
     fn test_pipeline_truncates_items() {
+        // Use a small max_chars to force budget trimming
         let pipeline = Pipeline::with_config(PipelineConfig {
-            max_items: 5,
-            max_chars: 100_000,
+            max_chars: 200,
             ..Default::default()
         });
 
@@ -467,14 +469,13 @@ mod tests {
 
         assert!(output.truncated);
         assert_eq!(output.total_count, Some(25));
-        assert_eq!(output.included_count, 5);
+        assert!(output.included_count < 25);
         assert!(output.agent_hint.is_some());
     }
 
     #[test]
     fn test_pipeline_no_truncation_when_under_limit() {
         let pipeline = Pipeline::with_config(PipelineConfig {
-            max_items: 50,
             max_chars: 100_000,
             ..Default::default()
         });
@@ -492,7 +493,6 @@ mod tests {
     fn test_toon_format_issues() {
         let pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Toon,
-            max_items: 3,
             max_chars: 100_000,
             ..Default::default()
         });
@@ -506,10 +506,10 @@ mod tests {
 
     #[test]
     fn test_toon_format_merge_requests() {
+        // Use max_chars large enough to include some but not all MRs
         let pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Toon,
-            max_items: 3,
-            max_chars: 100_000,
+            max_chars: 500,
             ..Default::default()
         });
 
@@ -519,15 +519,15 @@ mod tests {
         assert!(output.content.contains("mr#1"));
         assert!(output.content.contains("MR 1"));
         assert!(output.truncated);
-        assert_eq!(output.included_count, 3);
+        assert!(output.included_count < 5);
     }
 
     #[test]
     fn test_toon_format_diffs() {
+        // Use max_chars small enough to force budget trimming of 5 diffs
         let pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Toon,
-            max_items: 3,
-            max_chars: 100_000,
+            max_chars: 200,
             ..Default::default()
         });
 
@@ -536,32 +536,34 @@ mod tests {
 
         assert!(output.content.contains("src/file_1.rs"));
         assert!(output.truncated);
-        assert_eq!(output.included_count, 3);
+        assert!(output.included_count < 5);
     }
 
     #[test]
     fn test_toon_format_comments() {
+        // Use max_chars small enough to force budget trimming of 5 comments
+        // but large enough to include at least one comment with body text
         let pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Toon,
-            max_items: 3,
-            max_chars: 100_000,
+            max_chars: 300,
             ..Default::default()
         });
 
         let comments = sample_comments();
         let output = pipeline.transform_comments(comments).unwrap();
 
-        assert!(output.content.contains("Comment body 1"));
+        // Budget trimming may drop early items; check that some comment body is present
+        assert!(output.content.contains("Comment body"));
         assert!(output.truncated);
-        assert_eq!(output.included_count, 3);
+        assert!(output.included_count < 5);
     }
 
     #[test]
     fn test_toon_format_discussions() {
+        // Use max_chars large enough to include some but not all discussions
         let pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Toon,
-            max_items: 3,
-            max_chars: 100_000,
+            max_chars: 500,
             ..Default::default()
         });
 
@@ -570,7 +572,7 @@ mod tests {
 
         assert!(output.content.contains("Discussion comment 1"));
         assert!(output.truncated);
-        assert_eq!(output.included_count, 3);
+        assert!(output.included_count < 5);
     }
 
     // --- JSON format ---
@@ -579,7 +581,6 @@ mod tests {
     fn test_json_format_issues() {
         let pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Json,
-            max_items: 2,
             max_chars: 100_000,
             ..Default::default()
         });
@@ -595,7 +596,6 @@ mod tests {
     fn test_json_format_merge_requests() {
         let pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Json,
-            max_items: 2,
             max_chars: 100_000,
             ..Default::default()
         });
@@ -611,7 +611,6 @@ mod tests {
     fn test_json_format_diffs() {
         let pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Json,
-            max_items: 2,
             max_chars: 100_000,
             ..Default::default()
         });
@@ -627,7 +626,6 @@ mod tests {
     fn test_json_format_comments() {
         let pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Json,
-            max_items: 2,
             max_chars: 100_000,
             ..Default::default()
         });
@@ -643,7 +641,6 @@ mod tests {
     fn test_json_format_discussions() {
         let pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Json,
-            max_items: 2,
             max_chars: 100_000,
             ..Default::default()
         });
@@ -686,7 +683,6 @@ mod tests {
     #[test]
     fn test_pipeline_config_default_values() {
         let config = PipelineConfig::default();
-        assert_eq!(config.max_items, 20);
         assert_eq!(config.max_chars, 100_000);
         assert_eq!(config.max_chars_per_item, 10_000);
         assert_eq!(config.max_description_len, 10_000);
@@ -704,9 +700,9 @@ mod tests {
 
     #[test]
     fn test_pipeline_hints_disabled() {
+        // Use small max_chars to trigger budget trimming, but with hints disabled
         let pipeline = Pipeline::with_config(PipelineConfig {
-            max_items: 2,
-            max_chars: 100_000,
+            max_chars: 200,
             include_hints: false,
             ..Default::default()
         });
@@ -714,17 +710,17 @@ mod tests {
         let issues = sample_issues();
         let output = pipeline.transform_issues(issues).unwrap();
 
-        assert_eq!(output.included_count, 2);
+        assert!(output.included_count < 25);
+        // hints are disabled, so even though trimming occurred, no hint is set
         assert!(!output.truncated);
         assert!(output.agent_hint.is_none());
     }
 
-    // --- Character limit ---
+    // --- Character limit (budget-based) ---
 
     #[test]
     fn test_char_limit_applied() {
         let pipeline = Pipeline::with_config(PipelineConfig {
-            max_items: 100,
             max_chars: 100,
             ..Default::default()
         });
@@ -732,58 +728,12 @@ mod tests {
         let issues = sample_issues();
         let output = pipeline.transform_issues(issues).unwrap();
 
-        assert!(output.content.len() <= 100);
         assert!(output.truncated);
     }
 
     #[test]
-    fn test_apply_char_limit_no_truncation() {
+    fn test_char_limit_triggers_trimming() {
         let pipeline = Pipeline::with_config(PipelineConfig {
-            max_chars: 1000,
-            max_items: 50,
-            ..Default::default()
-        });
-        let output = TransformOutput::new("short content".into());
-        let result = pipeline.apply_char_limit(output);
-        assert!(!result.truncated);
-        assert!(result.agent_hint.is_none());
-        assert_eq!(result.content, "short content");
-    }
-
-    #[test]
-    fn test_apply_char_limit_truncates_large_content() {
-        let pipeline = Pipeline::with_config(PipelineConfig {
-            max_chars: 20,
-            max_items: 50,
-            ..Default::default()
-        });
-        let long_content = "a".repeat(100);
-        let output = TransformOutput::new(long_content);
-        let result = pipeline.apply_char_limit(output);
-        assert!(result.truncated);
-        assert!(result.content.len() <= 20);
-        assert!(result.agent_hint.is_some());
-        assert!(result.agent_hint.unwrap().contains("truncated"));
-    }
-
-    #[test]
-    fn test_apply_char_limit_preserves_existing_truncation() {
-        let pipeline = Pipeline::with_config(PipelineConfig {
-            max_chars: 10,
-            max_items: 50,
-            ..Default::default()
-        });
-        let long_content = "x".repeat(100);
-        let output =
-            TransformOutput::new(long_content).with_truncation(50, 5, "existing hint".into());
-        let result = pipeline.apply_char_limit(output);
-        assert!(result.truncated);
-    }
-
-    #[test]
-    fn test_char_limit_triggers_before_item_limit() {
-        let pipeline = Pipeline::with_config(PipelineConfig {
-            max_items: 100,
             max_chars: 50,
             ..Default::default()
         });
@@ -791,29 +741,6 @@ mod tests {
         let issues: Vec<Issue> = sample_issues().into_iter().take(3).collect();
         let output = pipeline.transform_issues(issues).unwrap();
         assert!(output.truncated);
-        assert!(output.content.len() <= 50);
-    }
-
-    // --- Pagination hints ---
-
-    #[test]
-    fn test_create_pagination_hint_without_tool() {
-        let pipeline = Pipeline::new();
-        let hint = pipeline.create_pagination_hint("issues", 50, 20, None);
-        assert!(hint.contains("20/50"));
-        assert!(hint.contains("30 more"));
-        assert!(hint.contains("offset"));
-        assert!(hint.contains("limit"));
-    }
-
-    #[test]
-    fn test_create_pagination_hint_with_tool() {
-        let pipeline = Pipeline::new();
-        let hint = pipeline.create_pagination_hint("diffs", 30, 10, Some("get_diffs"));
-        assert!(hint.contains("10/30"));
-        assert!(hint.contains("20 more"));
-        assert!(hint.contains("get_diffs"));
-        assert!(hint.contains("offset=10"));
     }
 
     // --- Empty collections ---
@@ -864,7 +791,6 @@ mod tests {
     fn test_diff_content_truncated_per_item() {
         let pipeline = Pipeline::with_config(PipelineConfig {
             max_chars_per_item: 10,
-            max_items: 10,
             max_chars: 100_000,
             ..Default::default()
         });
@@ -892,13 +818,11 @@ mod tests {
 
         let json_pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Json,
-            max_items: 100,
             max_chars: 1_000_000,
             ..Default::default()
         });
         let toon_pipeline = Pipeline::with_config(PipelineConfig {
             format: OutputFormat::Toon,
-            max_items: 100,
             max_chars: 1_000_000,
             ..Default::default()
         });

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -216,9 +216,16 @@ impl Pipeline {
         let strategy_kind = self.resolve_strategy("get_issues");
         let result = budget::process_issues(&issues, strategy_kind, &budget_config)?;
 
-        let index =
-            page_index::build_issues_index(&issues, result.included_items, self.config.max_chars);
-        self.build_budget_output(result, raw_chars, total, "issues", Some(index))
+        let json_fallback = self.json_fallback(&content);
+        let index = page_index::build_issues_index(&issues, result.included_items);
+        self.build_budget_output(
+            result,
+            raw_chars,
+            total,
+            "issues",
+            Some(index),
+            json_fallback,
+        )
     }
 
     /// Transform a list of merge requests using budget pipeline.
@@ -238,16 +245,20 @@ impl Pipeline {
             return Ok(output);
         }
 
+        let json_fallback = self.json_fallback(&content);
         let budget_config = self.budget_config();
         let strategy_kind = self.resolve_strategy("get_merge_requests");
         let result = budget::process_merge_requests(&mrs, strategy_kind, &budget_config)?;
 
-        let index = page_index::build_merge_requests_index(
-            &mrs,
-            result.included_items,
-            self.config.max_chars,
-        );
-        self.build_budget_output(result, raw_chars, total, "merge_requests", Some(index))
+        let index = page_index::build_merge_requests_index(&mrs, result.included_items);
+        self.build_budget_output(
+            result,
+            raw_chars,
+            total,
+            "merge_requests",
+            Some(index),
+            json_fallback,
+        )
     }
 
     /// Transform a list of file diffs using budget pipeline.
@@ -280,13 +291,20 @@ impl Pipeline {
             return Ok(output);
         }
 
+        let json_fallback = self.json_fallback(&content);
         let budget_config = self.budget_config();
         let strategy_kind = self.resolve_strategy("get_merge_request_diffs");
         let result = budget::process_diffs(&diffs, strategy_kind, &budget_config)?;
 
-        let index =
-            page_index::build_diffs_index(&diffs, result.included_items, self.config.max_chars);
-        self.build_budget_output(result, raw_chars, total, "diffs", Some(index))
+        let index = page_index::build_diffs_index(&diffs, result.included_items);
+        self.build_budget_output(
+            result,
+            raw_chars,
+            total,
+            "diffs",
+            Some(index),
+            json_fallback,
+        )
     }
 
     /// Transform a list of comments using budget pipeline.
@@ -306,16 +324,20 @@ impl Pipeline {
             return Ok(output);
         }
 
+        let json_fallback = self.json_fallback(&content);
         let budget_config = self.budget_config();
         let strategy_kind = self.resolve_strategy("get_issue_comments");
         let result = budget::process_comments(&comments, strategy_kind, &budget_config)?;
 
-        let index = page_index::build_comments_index(
-            &comments,
-            result.included_items,
-            self.config.max_chars,
-        );
-        self.build_budget_output(result, raw_chars, total, "comments", Some(index))
+        let index = page_index::build_comments_index(&comments, result.included_items);
+        self.build_budget_output(
+            result,
+            raw_chars,
+            total,
+            "comments",
+            Some(index),
+            json_fallback,
+        )
     }
 
     /// Transform a list of discussions using budget pipeline.
@@ -335,16 +357,30 @@ impl Pipeline {
             return Ok(output);
         }
 
+        let json_fallback = self.json_fallback(&content);
         let budget_config = self.budget_config();
         let strategy_kind = self.resolve_strategy("get_merge_request_discussions");
         let result = budget::process_discussions(&discussions, strategy_kind, &budget_config)?;
 
-        let index = page_index::build_discussions_index(
-            &discussions,
-            result.included_items,
-            self.config.max_chars,
-        );
-        self.build_budget_output(result, raw_chars, total, "discussions", Some(index))
+        let index = page_index::build_discussions_index(&discussions, result.included_items);
+        self.build_budget_output(
+            result,
+            raw_chars,
+            total,
+            "discussions",
+            Some(index),
+            json_fallback,
+        )
+    }
+
+    /// When format is JSON, return the content for truncation fallback.
+    /// Budget pipeline always produces TOON, so for JSON we truncate the original JSON.
+    fn json_fallback(&self, content: &str) -> Option<String> {
+        if matches!(self.config.format, OutputFormat::Json) {
+            Some(content.to_string())
+        } else {
+            None
+        }
     }
 
     /// Convert max_chars to budget pipeline config.
@@ -363,6 +399,9 @@ impl Pipeline {
     }
 
     /// Build TransformOutput from BudgetResult with optional page index.
+    ///
+    /// Note: budget pipeline always produces TOON content. When format is JSON,
+    /// we fall back to simple character truncation of the JSON output instead.
     fn build_budget_output(
         &self,
         result: budget::BudgetResult,
@@ -370,35 +409,51 @@ impl Pipeline {
         total: usize,
         item_type: &str,
         index: Option<page_index::PageIndex>,
+        json_fallback: Option<String>,
     ) -> Result<TransformOutput> {
-        let mut output = TransformOutput::new(result.content).with_raw_chars(raw_chars);
+        // Budget pipeline produces TOON. For JSON format, use truncated JSON instead.
+        let content = if matches!(self.config.format, OutputFormat::Json) {
+            if let Some(json) = json_fallback {
+                truncation::truncate_string(&json, self.config.max_chars)
+            } else {
+                result.content
+            }
+        } else {
+            result.content
+        };
+
+        let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
         output.included_count = result.included_items;
 
-        if result.trimmed && self.config.include_hints {
-            let remaining = total.saturating_sub(result.included_items);
+        // Always set truncation metadata when trimmed, regardless of include_hints
+        if result.trimmed {
+            output.truncated = true;
+            output.total_count = Some(total);
 
-            // Generate page index for multi-page results
-            if let Some(idx) = index {
-                if idx.total_pages > 1 {
-                    let hint = format!(
-                        "Showing {}/{} {} (page 1 of {}). Use `offset` and `limit` parameters for pagination.",
-                        result.included_items, total, item_type, idx.total_pages
-                    );
-                    output.page_index = Some(idx);
-                    output = output.with_truncation(total, result.included_items, hint);
+            if self.config.include_hints {
+                let remaining = total.saturating_sub(result.included_items);
+
+                // Generate page index for multi-page results
+                if let Some(idx) = index {
+                    if idx.total_pages > 1 {
+                        let hint = format!(
+                            "Showing {}/{} {} (page 1 of {}). Use `offset` and `limit` parameters for pagination.",
+                            result.included_items, total, item_type, idx.total_pages
+                        );
+                        output.page_index = Some(idx);
+                        output.agent_hint = Some(hint);
+                    } else {
+                        output.agent_hint = Some(format!(
+                            "Showing {}/{} {}. {} items trimmed by budget.",
+                            result.included_items, total, item_type, remaining
+                        ));
+                    }
                 } else {
-                    let hint = format!(
-                        "Showing {}/{} {}. {} items trimmed by budget.",
+                    output.agent_hint = Some(format!(
+                        "Showing {}/{} {}. {} items trimmed by budget. Use `offset` and `limit` parameters for pagination.",
                         result.included_items, total, item_type, remaining
-                    );
-                    output = output.with_truncation(total, result.included_items, hint);
+                    ));
                 }
-            } else {
-                let hint = format!(
-                    "Showing {}/{} {}. {} items trimmed by budget. Use `offset` and `limit` parameters for pagination.",
-                    result.included_items, total, item_type, remaining
-                );
-                output = output.with_truncation(total, result.included_items, hint);
             }
         }
 
@@ -773,9 +828,11 @@ mod tests {
         let output = pipeline.transform_issues(issues).unwrap();
 
         assert!(output.included_count < 25);
-        // hints are disabled, so even though trimming occurred, no hint is set
-        assert!(!output.truncated);
+        // truncated flag is always set when trimming occurs (for metadata consumers)
+        assert!(output.truncated);
+        // but agent_hint and page_index are suppressed when include_hints is false
         assert!(output.agent_hint.is_none());
+        assert!(output.page_index.is_none());
     }
 
     // --- Character limit (budget-based) ---

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -938,6 +938,138 @@ mod tests {
 
     // --- TOON smaller than JSON ---
 
+    // --- JSON format with budget trimming (triggers json_fallback) ---
+
+    #[test]
+    fn test_json_format_with_budget_trimming_issues() {
+        let pipeline = Pipeline::with_config(PipelineConfig {
+            format: OutputFormat::Json,
+            max_chars: 200,
+            ..Default::default()
+        });
+
+        let issues = sample_issues();
+        let output = pipeline.transform_issues(issues).unwrap();
+
+        assert!(output.truncated);
+        assert!(output.included_count < 25);
+        // Content should be truncated JSON (not TOON)
+        assert!(!output.content.is_empty());
+    }
+
+    #[test]
+    fn test_json_format_with_budget_trimming_merge_requests() {
+        let pipeline = Pipeline::with_config(PipelineConfig {
+            format: OutputFormat::Json,
+            max_chars: 200,
+            ..Default::default()
+        });
+
+        let mrs = sample_merge_requests();
+        let output = pipeline.transform_merge_requests(mrs).unwrap();
+
+        assert!(output.truncated);
+        assert!(!output.content.is_empty());
+    }
+
+    #[test]
+    fn test_json_format_with_budget_trimming_diffs() {
+        let pipeline = Pipeline::with_config(PipelineConfig {
+            format: OutputFormat::Json,
+            max_chars: 100,
+            ..Default::default()
+        });
+
+        let diffs = sample_diffs();
+        let output = pipeline.transform_diffs(diffs).unwrap();
+
+        assert!(output.truncated);
+        assert!(!output.content.is_empty());
+    }
+
+    #[test]
+    fn test_json_format_with_budget_trimming_comments() {
+        let pipeline = Pipeline::with_config(PipelineConfig {
+            format: OutputFormat::Json,
+            max_chars: 100,
+            ..Default::default()
+        });
+
+        let comments = sample_comments();
+        let output = pipeline.transform_comments(comments).unwrap();
+
+        assert!(output.truncated);
+        assert!(!output.content.is_empty());
+    }
+
+    #[test]
+    fn test_json_format_with_budget_trimming_discussions() {
+        let pipeline = Pipeline::with_config(PipelineConfig {
+            format: OutputFormat::Json,
+            max_chars: 100,
+            ..Default::default()
+        });
+
+        let discussions = sample_discussions();
+        let output = pipeline.transform_discussions(discussions).unwrap();
+
+        assert!(output.truncated);
+        assert!(!output.content.is_empty());
+    }
+
+    // --- Chunk index hints (total_pages > 1) ---
+
+    #[test]
+    fn test_pipeline_chunk_index_with_many_issues() {
+        // Use enough issues and small budget to trigger multi-page chunk index
+        let issues: Vec<Issue> = (1..=50)
+            .map(|i| Issue {
+                key: format!("gh#{}", i),
+                title: format!("Issue {} with a moderately long title for sizing", i),
+                description: Some(format!(
+                    "Description for issue {} with substantial content to inflate token count significantly beyond budget",
+                    i
+                )),
+                state: "open".to_string(),
+                source: "github".to_string(),
+                priority: None,
+                labels: vec!["bug".to_string(), "critical".to_string()],
+                author: Some(User {
+                    id: "1".to_string(),
+                    username: "test".to_string(),
+                    name: None,
+                    email: None,
+                    avatar_url: None,
+                }),
+                assignees: vec![],
+                url: Some(format!("https://github.com/test/repo/issues/{}", i)),
+                created_at: Some("2024-01-01T00:00:00Z".to_string()),
+                updated_at: Some("2024-01-02T00:00:00Z".to_string()),
+                parent: None,
+                subtasks: vec![],
+            })
+            .collect();
+
+        let pipeline = Pipeline::with_config(PipelineConfig {
+            max_chars: 500,
+            include_hints: true,
+            ..Default::default()
+        });
+
+        let output = pipeline.transform_issues(issues).unwrap();
+
+        assert!(output.truncated);
+        assert!(output.included_count < 50);
+        // When many items are trimmed, we expect page_index and chunk hint
+        if let Some(ref hint) = output.agent_hint {
+            assert!(
+                hint.contains("Chunk") || hint.contains("Showing"),
+                "Expected chunk or showing hint, got: {}",
+                hint
+            );
+        }
+    }
+
     #[test]
     fn test_toon_smaller_than_json_for_issues() {
         let issues: Vec<Issue> = sample_issues().into_iter().take(10).collect();

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -23,6 +23,7 @@
 //! ```
 
 pub mod budget;
+pub mod page_index;
 pub mod pagination;
 pub mod strategy;
 pub mod token_counter;
@@ -60,6 +61,12 @@ pub struct TransformOutput {
     pub agent_hint: Option<String>,
     /// Cursor for fetching the next page (if overflow exists)
     pub page_cursor: Option<String>,
+    /// Page index for large results (when budget trimming is applied)
+    pub page_index: Option<page_index::PageIndex>,
+    /// Provider-level pagination metadata
+    pub provider_pagination: Option<devboy_core::Pagination>,
+    /// Provider-level sort metadata
+    pub provider_sort: Option<devboy_core::SortInfo>,
     /// Size of raw input data before formatting (UTF-8 bytes)
     pub raw_chars: usize,
     /// Size of formatted output (UTF-8 bytes) — updated after apply_char_limit
@@ -80,6 +87,9 @@ impl TransformOutput {
             included_count: 0,
             agent_hint: None,
             page_cursor: None,
+            page_index: None,
+            provider_pagination: None,
+            provider_sort: None,
             raw_chars: 0,
             output_chars,
             pre_trim_chars: 0,
@@ -101,13 +111,24 @@ impl TransformOutput {
         self
     }
 
-    /// Get the final output including any agent hints.
+    /// Get the final output including page index and agent hints.
     pub fn to_string_with_hints(&self) -> String {
-        if let Some(hint) = &self.agent_hint {
-            format!("{}\n\n{}", self.content, hint)
-        } else {
-            self.content.clone()
+        let mut parts = Vec::new();
+
+        // Page index header (when budget trimming produced pages)
+        if let Some(index) = &self.page_index {
+            parts.push(index.to_toon());
         }
+
+        // Main content
+        parts.push(self.content.clone());
+
+        // Agent hint footer
+        if let Some(hint) = &self.agent_hint {
+            parts.push(hint.clone());
+        }
+
+        parts.join("\n\n")
     }
 }
 
@@ -195,7 +216,8 @@ impl Pipeline {
         let strategy_kind = self.resolve_strategy("get_issues");
         let result = budget::process_issues(&issues, strategy_kind, &budget_config)?;
 
-        self.build_budget_output(result, raw_chars, total, "issues")
+        let index = page_index::build_issues_index(&issues, result.included_items, self.config.max_chars);
+        self.build_budget_output(result, raw_chars, total, "issues", Some(index))
     }
 
     /// Transform a list of merge requests using budget pipeline.
@@ -219,7 +241,8 @@ impl Pipeline {
         let strategy_kind = self.resolve_strategy("get_merge_requests");
         let result = budget::process_merge_requests(&mrs, strategy_kind, &budget_config)?;
 
-        self.build_budget_output(result, raw_chars, total, "merge_requests")
+        let index = page_index::build_merge_requests_index(&mrs, result.included_items, self.config.max_chars);
+        self.build_budget_output(result, raw_chars, total, "merge_requests", Some(index))
     }
 
     /// Transform a list of file diffs using budget pipeline.
@@ -256,7 +279,8 @@ impl Pipeline {
         let strategy_kind = self.resolve_strategy("get_merge_request_diffs");
         let result = budget::process_diffs(&diffs, strategy_kind, &budget_config)?;
 
-        self.build_budget_output(result, raw_chars, total, "diffs")
+        let index = page_index::build_diffs_index(&diffs, result.included_items, self.config.max_chars);
+        self.build_budget_output(result, raw_chars, total, "diffs", Some(index))
     }
 
     /// Transform a list of comments using budget pipeline.
@@ -280,7 +304,8 @@ impl Pipeline {
         let strategy_kind = self.resolve_strategy("get_issue_comments");
         let result = budget::process_comments(&comments, strategy_kind, &budget_config)?;
 
-        self.build_budget_output(result, raw_chars, total, "comments")
+        let index = page_index::build_comments_index(&comments, result.included_items, self.config.max_chars);
+        self.build_budget_output(result, raw_chars, total, "comments", Some(index))
     }
 
     /// Transform a list of discussions using budget pipeline.
@@ -304,7 +329,8 @@ impl Pipeline {
         let strategy_kind = self.resolve_strategy("get_merge_request_discussions");
         let result = budget::process_discussions(&discussions, strategy_kind, &budget_config)?;
 
-        self.build_budget_output(result, raw_chars, total, "discussions")
+        let index = page_index::build_discussions_index(&discussions, result.included_items, self.config.max_chars);
+        self.build_budget_output(result, raw_chars, total, "discussions", Some(index))
     }
 
     /// Convert max_chars to budget pipeline config.
@@ -322,24 +348,44 @@ impl Pipeline {
         resolver.resolve(tool)
     }
 
-    /// Build TransformOutput from BudgetResult.
+    /// Build TransformOutput from BudgetResult with optional page index.
     fn build_budget_output(
         &self,
         result: budget::BudgetResult,
         raw_chars: usize,
         total: usize,
         item_type: &str,
+        index: Option<page_index::PageIndex>,
     ) -> Result<TransformOutput> {
         let mut output = TransformOutput::new(result.content).with_raw_chars(raw_chars);
         output.included_count = result.included_items;
 
         if result.trimmed && self.config.include_hints {
             let remaining = total.saturating_sub(result.included_items);
-            let hint = format!(
-                "Showing {}/{} {}. {} items trimmed by budget. Use `offset` and `limit` parameters for pagination.",
-                result.included_items, total, item_type, remaining
-            );
-            output = output.with_truncation(total, result.included_items, hint);
+
+            // Generate page index for multi-page results
+            if let Some(idx) = index {
+                if idx.total_pages > 1 {
+                    let hint = format!(
+                        "Showing {}/{} {} (page 1 of {}). Use `offset` and `limit` parameters for pagination.",
+                        result.included_items, total, item_type, idx.total_pages
+                    );
+                    output.page_index = Some(idx);
+                    output = output.with_truncation(total, result.included_items, hint);
+                } else {
+                    let hint = format!(
+                        "Showing {}/{} {}. {} items trimmed by budget.",
+                        result.included_items, total, item_type, remaining
+                    );
+                    output = output.with_truncation(total, result.included_items, hint);
+                }
+            } else {
+                let hint = format!(
+                    "Showing {}/{} {}. {} items trimmed by budget. Use `offset` and `limit` parameters for pagination.",
+                    result.included_items, total, item_type, remaining
+                );
+                output = output.with_truncation(total, result.included_items, hint);
+            }
         }
 
         Ok(output)

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -150,6 +150,9 @@ pub struct PipelineConfig {
     pub page_cursor: Option<String>,
     /// Tool name for strategy resolution (e.g., "get_issues", "get_merge_request_diffs")
     pub tool_name: Option<String>,
+    /// Chunk number to return (1-based). When set, pipeline skips to that chunk
+    /// instead of returning chunk 1. Used for chunk index navigation.
+    pub chunk: Option<usize>,
 }
 
 impl Default for PipelineConfig {
@@ -162,6 +165,7 @@ impl Default for PipelineConfig {
             include_hints: true,
             page_cursor: None,
             tool_name: None,
+            chunk: None,
         }
     }
 }
@@ -199,24 +203,39 @@ impl Pipeline {
         let raw_json = serde_json::to_string(&issues)?;
         let raw_chars = raw_json.len();
 
-        let content = match self.config.format {
+        // First pass: check if all data fits in budget
+        let full_content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&issues)?,
             OutputFormat::Toon => toon::encode_issues(&issues, toon::TrimLevel::Full)?,
         };
 
-        // Fast path: fits within budget
-        if self.config.max_chars == 0 || content.len() <= self.config.max_chars {
-            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+        if self.config.max_chars == 0 || full_content.len() <= self.config.max_chars {
+            let mut output = TransformOutput::new(full_content).with_raw_chars(raw_chars);
             output.included_count = total;
             return Ok(output);
         }
 
-        // Budget pipeline: smart trimming with strategy
+        // Budget pipeline: find how many items fit
         let budget_config = self.budget_config();
         let strategy_kind = self.resolve_strategy("get_issues");
         let result = budget::process_issues(&issues, strategy_kind, &budget_config)?;
+        let chunk_size = result.included_items;
 
-        let json_fallback = self.json_fallback(&content);
+        // Chunk navigation: if chunk > 1, slice to that chunk
+        let (chunk_items, is_chunk_request) = self.slice_for_chunk(&issues, chunk_size);
+        if is_chunk_request {
+            let content = match self.config.format {
+                OutputFormat::Json => serde_json::to_string_pretty(chunk_items)?,
+                OutputFormat::Toon => toon::encode_issues(chunk_items, toon::TrimLevel::Full)?,
+            };
+            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+            output.included_count = chunk_items.len();
+            output.total_count = Some(total);
+            return Ok(output);
+        }
+
+        // Chunk 1 (default): budget-trimmed best items + chunk index
+        let json_fallback = self.json_fallback(&full_content);
         let index = page_index::build_issues_index(&issues, result.included_items);
         self.build_budget_output(
             result,
@@ -234,22 +253,37 @@ impl Pipeline {
         let raw_json = serde_json::to_string(&mrs)?;
         let raw_chars = raw_json.len();
 
-        let content = match self.config.format {
+        let full_content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&mrs)?,
             OutputFormat::Toon => toon::encode_merge_requests(&mrs, toon::TrimLevel::Full)?,
         };
 
-        if self.config.max_chars == 0 || content.len() <= self.config.max_chars {
-            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+        if self.config.max_chars == 0 || full_content.len() <= self.config.max_chars {
+            let mut output = TransformOutput::new(full_content).with_raw_chars(raw_chars);
             output.included_count = total;
             return Ok(output);
         }
 
-        let json_fallback = self.json_fallback(&content);
         let budget_config = self.budget_config();
         let strategy_kind = self.resolve_strategy("get_merge_requests");
         let result = budget::process_merge_requests(&mrs, strategy_kind, &budget_config)?;
+        let chunk_size = result.included_items;
 
+        let (chunk_items, is_chunk_request) = self.slice_for_chunk(&mrs, chunk_size);
+        if is_chunk_request {
+            let content = match self.config.format {
+                OutputFormat::Json => serde_json::to_string_pretty(chunk_items)?,
+                OutputFormat::Toon => {
+                    toon::encode_merge_requests(chunk_items, toon::TrimLevel::Full)?
+                }
+            };
+            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+            output.included_count = chunk_items.len();
+            output.total_count = Some(total);
+            return Ok(output);
+        }
+
+        let json_fallback = self.json_fallback(&full_content);
         let index = page_index::build_merge_requests_index(&mrs, result.included_items);
         self.build_budget_output(
             result,
@@ -280,22 +314,35 @@ impl Pipeline {
         let raw_json = serde_json::to_string(&diffs)?;
         let raw_chars = raw_json.len();
 
-        let content = match self.config.format {
+        let full_content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&diffs)?,
             OutputFormat::Toon => toon::encode_diffs(&diffs)?,
         };
 
-        if self.config.max_chars == 0 || content.len() <= self.config.max_chars {
-            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+        if self.config.max_chars == 0 || full_content.len() <= self.config.max_chars {
+            let mut output = TransformOutput::new(full_content).with_raw_chars(raw_chars);
             output.included_count = total;
             return Ok(output);
         }
 
-        let json_fallback = self.json_fallback(&content);
         let budget_config = self.budget_config();
         let strategy_kind = self.resolve_strategy("get_merge_request_diffs");
         let result = budget::process_diffs(&diffs, strategy_kind, &budget_config)?;
+        let chunk_size = result.included_items;
 
+        let (chunk_items, is_chunk_request) = self.slice_for_chunk(&diffs, chunk_size);
+        if is_chunk_request {
+            let content = match self.config.format {
+                OutputFormat::Json => serde_json::to_string_pretty(chunk_items)?,
+                OutputFormat::Toon => toon::encode_diffs(chunk_items)?,
+            };
+            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+            output.included_count = chunk_items.len();
+            output.total_count = Some(total);
+            return Ok(output);
+        }
+
+        let json_fallback = self.json_fallback(&full_content);
         let index = page_index::build_diffs_index(&diffs, result.included_items);
         self.build_budget_output(
             result,
@@ -313,22 +360,35 @@ impl Pipeline {
         let raw_json = serde_json::to_string(&comments)?;
         let raw_chars = raw_json.len();
 
-        let content = match self.config.format {
+        let full_content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&comments)?,
             OutputFormat::Toon => toon::encode_comments(&comments)?,
         };
 
-        if self.config.max_chars == 0 || content.len() <= self.config.max_chars {
-            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+        if self.config.max_chars == 0 || full_content.len() <= self.config.max_chars {
+            let mut output = TransformOutput::new(full_content).with_raw_chars(raw_chars);
             output.included_count = total;
             return Ok(output);
         }
 
-        let json_fallback = self.json_fallback(&content);
         let budget_config = self.budget_config();
         let strategy_kind = self.resolve_strategy("get_issue_comments");
         let result = budget::process_comments(&comments, strategy_kind, &budget_config)?;
+        let chunk_size = result.included_items;
 
+        let (chunk_items, is_chunk_request) = self.slice_for_chunk(&comments, chunk_size);
+        if is_chunk_request {
+            let content = match self.config.format {
+                OutputFormat::Json => serde_json::to_string_pretty(chunk_items)?,
+                OutputFormat::Toon => toon::encode_comments(chunk_items)?,
+            };
+            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+            output.included_count = chunk_items.len();
+            output.total_count = Some(total);
+            return Ok(output);
+        }
+
+        let json_fallback = self.json_fallback(&full_content);
         let index = page_index::build_comments_index(&comments, result.included_items);
         self.build_budget_output(
             result,
@@ -346,22 +406,35 @@ impl Pipeline {
         let raw_json = serde_json::to_string(&discussions)?;
         let raw_chars = raw_json.len();
 
-        let content = match self.config.format {
+        let full_content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&discussions)?,
             OutputFormat::Toon => toon::encode_discussions(&discussions)?,
         };
 
-        if self.config.max_chars == 0 || content.len() <= self.config.max_chars {
-            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+        if self.config.max_chars == 0 || full_content.len() <= self.config.max_chars {
+            let mut output = TransformOutput::new(full_content).with_raw_chars(raw_chars);
             output.included_count = total;
             return Ok(output);
         }
 
-        let json_fallback = self.json_fallback(&content);
         let budget_config = self.budget_config();
         let strategy_kind = self.resolve_strategy("get_merge_request_discussions");
         let result = budget::process_discussions(&discussions, strategy_kind, &budget_config)?;
+        let chunk_size = result.included_items;
 
+        let (chunk_items, is_chunk_request) = self.slice_for_chunk(&discussions, chunk_size);
+        if is_chunk_request {
+            let content = match self.config.format {
+                OutputFormat::Json => serde_json::to_string_pretty(chunk_items)?,
+                OutputFormat::Toon => toon::encode_discussions(chunk_items)?,
+            };
+            let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
+            output.included_count = chunk_items.len();
+            output.total_count = Some(total);
+            return Ok(output);
+        }
+
+        let json_fallback = self.json_fallback(&full_content);
         let index = page_index::build_discussions_index(&discussions, result.included_items);
         self.build_budget_output(
             result,
@@ -380,6 +453,27 @@ impl Pipeline {
             Some(content.to_string())
         } else {
             None
+        }
+    }
+
+    /// Slice items for a specific chunk number.
+    ///
+    /// When `config.chunk` is Some(n) with n > 1, we need to compute
+    /// the chunk boundaries and return only items for that chunk.
+    /// Returns (slice_items, is_chunk_request) — if not a chunk request,
+    /// returns all items.
+    fn slice_for_chunk<'a, T>(&self, items: &'a [T], chunk_size: usize) -> (&'a [T], bool) {
+        match self.config.chunk {
+            Some(n) if n > 1 && chunk_size > 0 => {
+                let offset = (n - 1) * chunk_size;
+                if offset >= items.len() {
+                    (&[], true) // chunk beyond data
+                } else {
+                    let end = (offset + chunk_size).min(items.len());
+                    (&items[offset..end], true)
+                }
+            }
+            _ => (items, false),
         }
     }
 

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -398,7 +398,10 @@ impl Pipeline {
         resolver.resolve(tool)
     }
 
-    /// Build TransformOutput from BudgetResult with optional page index.
+    /// Build TransformOutput from BudgetResult with chunk index.
+    ///
+    /// Returns: chunk 1 (best items by strategy) + index of ALL chunks.
+    /// Agent can fetch remaining chunks via offset/limit in subsequent tool calls.
     ///
     /// Note: budget pipeline always produces TOON content. When format is JSON,
     /// we fall back to simple character truncation of the JSON output instead.
@@ -431,26 +434,30 @@ impl Pipeline {
             output.total_count = Some(total);
 
             if self.config.include_hints {
-                let remaining = total.saturating_sub(result.included_items);
-
-                // Generate page index for multi-page results
                 if let Some(idx) = index {
                     if idx.total_pages > 1 {
                         let hint = format!(
-                            "Showing {}/{} {} selected by priority ({} pages available). Use `offset` and `limit` for sequential access.",
-                            result.included_items, total, item_type, idx.total_pages
+                            "Chunk 1/{}: {} most relevant {} (by priority). {} total items across {} chunks. \
+                            Request specific chunks with `offset` and `limit` params, or request all remaining data.",
+                            idx.total_pages,
+                            result.included_items,
+                            item_type,
+                            total,
+                            idx.total_pages
                         );
                         output.page_index = Some(idx);
                         output.agent_hint = Some(hint);
                     } else {
+                        let remaining = total.saturating_sub(result.included_items);
                         output.agent_hint = Some(format!(
                             "Showing {}/{} {}. {} items trimmed by budget.",
                             result.included_items, total, item_type, remaining
                         ));
                     }
                 } else {
+                    let remaining = total.saturating_sub(result.included_items);
                     output.agent_hint = Some(format!(
-                        "Showing {}/{} {}. {} items trimmed by budget. Use `offset` and `limit` parameters for pagination.",
+                        "Showing {}/{} {}. {} items trimmed by budget. Use `offset` and `limit` for pagination.",
                         result.included_items, total, item_type, remaining
                     ));
                 }

--- a/crates/plugins/format-pipeline/src/page_index.rs
+++ b/crates/plugins/format-pipeline/src/page_index.rs
@@ -1,0 +1,419 @@
+//! Page index generation for large results.
+//!
+//! When budget trimming drops items, generates a structured index
+//! describing what's on each page so the LLM can request specific pages.
+
+use devboy_core::{Comment, Discussion, FileDiff, Issue, MergeRequest};
+use std::collections::BTreeMap;
+
+/// A single page descriptor in the index.
+#[derive(Debug, Clone)]
+pub struct PageDescriptor {
+    /// Page number (1-based)
+    pub page: usize,
+    /// Whether this is the current page
+    pub current: bool,
+    /// Human-readable summary of page contents
+    pub summary: String,
+    /// Number of items on this page
+    pub item_count: usize,
+    /// Offset to request this page
+    pub offset: usize,
+}
+
+/// Full page index for a result set.
+#[derive(Debug, Clone)]
+pub struct PageIndex {
+    /// Total items across all pages
+    pub total_items: usize,
+    /// Items shown on current page
+    pub shown_items: usize,
+    /// Current page number (1-based)
+    pub current_page: usize,
+    /// Total number of pages
+    pub total_pages: usize,
+    /// Page descriptors
+    pub pages: Vec<PageDescriptor>,
+    /// Data type (e.g., "issues", "diffs", "discussions")
+    pub data_type: String,
+}
+
+impl PageIndex {
+    /// Render page index as a TOON-compatible block.
+    pub fn to_toon(&self) -> String {
+        let mut lines = Vec::new();
+        lines.push(format!(
+            "[meta]{{total:{},shown:{},pages:{},page:{}}}",
+            self.total_items, self.shown_items, self.total_pages, self.current_page
+        ));
+        lines.push("[page_index]".to_string());
+        for p in &self.pages {
+            let marker = if p.current { " (current)" } else { "" };
+            lines.push(format!(
+                "  p{}{}: {}",
+                p.page, marker, p.summary
+            ));
+        }
+        lines.push("[/page_index]".to_string());
+        lines.join("\n")
+    }
+}
+
+/// Default page size for chunking.
+const DEFAULT_PAGE_SIZE: usize = 20;
+
+/// Compute page size based on budget and average item size.
+fn compute_page_size(total_items: usize, included_items: usize, _budget_chars: usize) -> usize {
+    // Use the number of items that fit in budget as page size
+    if included_items > 0 {
+        included_items
+    } else {
+        DEFAULT_PAGE_SIZE.min(total_items)
+    }
+}
+
+// =============================================================================
+// Type-specific page index builders
+// =============================================================================
+
+/// Build page index for issues.
+pub fn build_issues_index(
+    issues: &[Issue],
+    included_count: usize,
+    budget_chars: usize,
+) -> PageIndex {
+    let total = issues.len();
+    let page_size = compute_page_size(total, included_count, budget_chars);
+    let total_pages = (total + page_size - 1) / page_size;
+
+    let pages: Vec<PageDescriptor> = (0..total_pages)
+        .map(|page_idx| {
+            let offset = page_idx * page_size;
+            let end = (offset + page_size).min(total);
+            let page_issues = &issues[offset..end];
+            let item_count = page_issues.len();
+
+            // Summarize: count by state
+            let mut states: BTreeMap<&str, usize> = BTreeMap::new();
+            for issue in page_issues {
+                *states.entry(issue.state.as_str()).or_default() += 1;
+            }
+            let state_parts: Vec<String> = states
+                .iter()
+                .map(|(s, c)| format!("{} {}", c, s))
+                .collect();
+            let summary = format!(
+                "issues #{}-{} ({})",
+                offset + 1,
+                end,
+                state_parts.join(", ")
+            );
+
+            PageDescriptor {
+                page: page_idx + 1,
+                current: page_idx == 0,
+                summary,
+                item_count,
+                offset,
+            }
+        })
+        .collect();
+
+    PageIndex {
+        total_items: total,
+        shown_items: included_count,
+        current_page: 1,
+        total_pages,
+        pages,
+        data_type: "issues".to_string(),
+    }
+}
+
+/// Build page index for merge requests.
+pub fn build_merge_requests_index(
+    mrs: &[MergeRequest],
+    included_count: usize,
+    budget_chars: usize,
+) -> PageIndex {
+    let total = mrs.len();
+    let page_size = compute_page_size(total, included_count, budget_chars);
+    let total_pages = (total + page_size - 1) / page_size;
+
+    let pages: Vec<PageDescriptor> = (0..total_pages)
+        .map(|page_idx| {
+            let offset = page_idx * page_size;
+            let end = (offset + page_size).min(total);
+            let page_mrs = &mrs[offset..end];
+
+            let mut states: BTreeMap<&str, usize> = BTreeMap::new();
+            for mr in page_mrs {
+                *states.entry(mr.state.as_str()).or_default() += 1;
+            }
+            let state_parts: Vec<String> = states
+                .iter()
+                .map(|(s, c)| format!("{} {}", c, s))
+                .collect();
+            let summary = format!(
+                "MRs #{}-{} ({})",
+                offset + 1,
+                end,
+                state_parts.join(", ")
+            );
+
+            PageDescriptor {
+                page: page_idx + 1,
+                current: page_idx == 0,
+                summary,
+                item_count: page_mrs.len(),
+                offset,
+            }
+        })
+        .collect();
+
+    PageIndex {
+        total_items: total,
+        shown_items: included_count,
+        current_page: 1,
+        total_pages,
+        pages,
+        data_type: "merge_requests".to_string(),
+    }
+}
+
+/// Build page index for diffs — grouped by directory.
+pub fn build_diffs_index(
+    diffs: &[FileDiff],
+    included_count: usize,
+    budget_chars: usize,
+) -> PageIndex {
+    let total = diffs.len();
+    let page_size = compute_page_size(total, included_count, budget_chars);
+    let total_pages = (total + page_size - 1) / page_size;
+
+    let pages: Vec<PageDescriptor> = (0..total_pages)
+        .map(|page_idx| {
+            let offset = page_idx * page_size;
+            let end = (offset + page_size).min(total);
+            let page_diffs = &diffs[offset..end];
+
+            // Group by top-level directory for summary
+            let mut dirs: BTreeMap<String, usize> = BTreeMap::new();
+            let mut total_additions: u32 = 0;
+            let mut total_deletions: u32 = 0;
+            for d in page_diffs {
+                let dir = extract_top_dir(&d.file_path);
+                *dirs.entry(dir).or_default() += 1;
+                total_additions += d.additions.unwrap_or(0);
+                total_deletions += d.deletions.unwrap_or(0);
+            }
+
+            let dir_parts: Vec<String> = dirs
+                .iter()
+                .map(|(d, c)| {
+                    if *c == 1 {
+                        format!("{d}/*")
+                    } else {
+                        format!("{d}/* ({c} files)")
+                    }
+                })
+                .collect();
+
+            let summary = format!(
+                "{} — +{}/-{}",
+                dir_parts.join(", "),
+                total_additions,
+                total_deletions
+            );
+
+            PageDescriptor {
+                page: page_idx + 1,
+                current: page_idx == 0,
+                summary,
+                item_count: page_diffs.len(),
+                offset,
+            }
+        })
+        .collect();
+
+    PageIndex {
+        total_items: total,
+        shown_items: included_count,
+        current_page: 1,
+        total_pages,
+        pages,
+        data_type: "diffs".to_string(),
+    }
+}
+
+/// Build page index for discussions — grouped by resolved status.
+pub fn build_discussions_index(
+    discussions: &[Discussion],
+    included_count: usize,
+    budget_chars: usize,
+) -> PageIndex {
+    let total = discussions.len();
+    let page_size = compute_page_size(total, included_count, budget_chars);
+    let total_pages = (total + page_size - 1) / page_size;
+
+    let pages: Vec<PageDescriptor> = (0..total_pages)
+        .map(|page_idx| {
+            let offset = page_idx * page_size;
+            let end = (offset + page_size).min(total);
+            let page_disc = &discussions[offset..end];
+
+            let resolved = page_disc.iter().filter(|d| d.resolved).count();
+            let unresolved = page_disc.len() - resolved;
+
+            let summary = format!(
+                "{} discussions ({} unresolved, {} resolved)",
+                page_disc.len(),
+                unresolved,
+                resolved
+            );
+
+            PageDescriptor {
+                page: page_idx + 1,
+                current: page_idx == 0,
+                summary,
+                item_count: page_disc.len(),
+                offset,
+            }
+        })
+        .collect();
+
+    PageIndex {
+        total_items: total,
+        shown_items: included_count,
+        current_page: 1,
+        total_pages,
+        pages,
+        data_type: "discussions".to_string(),
+    }
+}
+
+/// Build page index for comments — chronological.
+pub fn build_comments_index(
+    comments: &[Comment],
+    included_count: usize,
+    budget_chars: usize,
+) -> PageIndex {
+    let total = comments.len();
+    let page_size = compute_page_size(total, included_count, budget_chars);
+    let total_pages = (total + page_size - 1) / page_size;
+
+    let pages: Vec<PageDescriptor> = (0..total_pages)
+        .map(|page_idx| {
+            let offset = page_idx * page_size;
+            let end = (offset + page_size).min(total);
+            let page_comments = &comments[offset..end];
+
+            let summary = format!("comments {}-{}", offset + 1, end);
+
+            PageDescriptor {
+                page: page_idx + 1,
+                current: page_idx == 0,
+                summary,
+                item_count: page_comments.len(),
+                offset,
+            }
+        })
+        .collect();
+
+    PageIndex {
+        total_items: total,
+        shown_items: included_count,
+        current_page: 1,
+        total_pages,
+        pages,
+        data_type: "comments".to_string(),
+    }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Extract top-level directory from a file path.
+/// "src/app/modules/mcp/tools/foo.ts" → "src/app/modules/mcp"
+fn extract_top_dir(path: &str) -> String {
+    let parts: Vec<&str> = path.split('/').collect();
+    if parts.len() <= 2 {
+        // Short path: return parent dir or file itself
+        if parts.len() == 2 {
+            parts[0].to_string()
+        } else {
+            ".".to_string()
+        }
+    } else {
+        // Take first 3 levels for meaningful grouping
+        let depth = 3.min(parts.len() - 1);
+        parts[..depth].join("/")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_top_dir() {
+        assert_eq!(extract_top_dir("src/app/modules/mcp/tools/foo.ts"), "src/app/modules");
+        assert_eq!(extract_top_dir("README.md"), ".");
+        assert_eq!(extract_top_dir("src/main.rs"), "src");
+        assert_eq!(extract_top_dir("a/b/c/d/e.rs"), "a/b/c");
+    }
+
+    #[test]
+    fn test_page_index_toon_output() {
+        let index = PageIndex {
+            total_items: 52,
+            shown_items: 15,
+            current_page: 1,
+            total_pages: 4,
+            pages: vec![
+                PageDescriptor {
+                    page: 1,
+                    current: true,
+                    summary: "src/app/modules/* (8 files) — +120/-45".to_string(),
+                    item_count: 15,
+                    offset: 0,
+                },
+                PageDescriptor {
+                    page: 2,
+                    current: false,
+                    summary: "apps/dev-boy-e2e/* (17 files) — +340/-12".to_string(),
+                    item_count: 15,
+                    offset: 15,
+                },
+            ],
+            data_type: "diffs".to_string(),
+        };
+
+        let toon = index.to_toon();
+        assert!(toon.contains("[meta]{total:52,shown:15,pages:4,page:1}"));
+        assert!(toon.contains("[page_index]"));
+        assert!(toon.contains("p1 (current):"));
+        assert!(toon.contains("p2:"));
+        assert!(toon.contains("[/page_index]"));
+    }
+
+    #[test]
+    fn test_build_diffs_index() {
+        let diffs: Vec<FileDiff> = (0..10)
+            .map(|i| FileDiff {
+                file_path: format!("src/app/file_{}.ts", i),
+                diff: format!("diff content {}", i),
+                additions: Some(10),
+                deletions: Some(5),
+                ..Default::default()
+            })
+            .collect();
+
+        let index = build_diffs_index(&diffs, 5, 1000);
+        assert_eq!(index.total_items, 10);
+        assert_eq!(index.total_pages, 2);
+        assert_eq!(index.pages[0].item_count, 5);
+        assert!(index.pages[0].current);
+        assert!(!index.pages[1].current);
+    }
+}

--- a/crates/plugins/format-pipeline/src/page_index.rs
+++ b/crates/plugins/format-pipeline/src/page_index.rs
@@ -51,7 +51,7 @@ impl PageIndex {
         ));
         for p in &self.pages {
             let marker = if p.page == 1 {
-                " << included above"
+                " << returned in this response"
             } else {
                 ""
             };
@@ -61,7 +61,7 @@ impl PageIndex {
             ));
         }
         lines.push(
-            "[/chunks] Use offset and limit to fetch any chunk. You may not need all chunks."
+            "[/chunks] Use `chunk: N` parameter to fetch a specific chunk. You may not need all chunks."
                 .to_string(),
         );
         lines.join("\n")
@@ -364,16 +364,16 @@ mod tests {
         let toon = index.to_toon();
         assert!(toon.contains("[chunks] 15/52 diffs in 4 chunks:"));
         assert!(toon.contains("chunk 1 (offset=0, limit=15):"));
-        assert!(toon.contains("<< included above"));
+        assert!(toon.contains("<< returned in this response"));
         assert!(toon.contains("chunk 2 (offset=15, limit=15):"));
         assert!(toon.contains("[/chunks]"));
         assert!(toon.contains("You may not need all chunks"));
-        // Only chunk 1 is marked as included
+        // Only chunk 1 is marked as returned
         let lines: Vec<&str> = toon
             .lines()
-            .filter(|l| l.contains("included above"))
+            .filter(|l| l.contains("returned in this response"))
             .collect();
-        assert_eq!(lines.len(), 1, "Only chunk 1 should be marked as included");
+        assert_eq!(lines.len(), 1, "Only chunk 1 should be marked as returned");
     }
 
     #[test]

--- a/crates/plugins/format-pipeline/src/page_index.rs
+++ b/crates/plugins/format-pipeline/src/page_index.rs
@@ -39,21 +39,31 @@ pub struct PageIndex {
 }
 
 impl PageIndex {
-    /// Render page index as a TOON-compatible block.
+    /// Render chunk index as a structured block.
+    ///
+    /// The output is designed to be read by an LLM agent that can decide
+    /// which chunks to fetch based on the descriptions.
     pub fn to_toon(&self) -> String {
         let mut lines = Vec::new();
         lines.push(format!(
-            "[meta]{{total:{},shown:{},pages:{}}}",
-            self.total_items, self.shown_items, self.total_pages
+            "[chunks] {}/{} {} in {} chunks:",
+            self.shown_items, self.total_items, self.data_type, self.total_pages
         ));
-        lines.push("[page_index]".to_string());
         for p in &self.pages {
+            let marker = if p.page == 1 {
+                " << included above"
+            } else {
+                ""
+            };
             lines.push(format!(
-                "  p{} (offset={},limit={}): {}",
-                p.page, p.offset, p.item_count, p.summary
+                "  chunk {} (offset={}, limit={}): {}{}",
+                p.page, p.offset, p.item_count, p.summary, marker
             ));
         }
-        lines.push("[/page_index]".to_string());
+        lines.push(
+            "[/chunks] Use offset and limit to fetch any chunk. You may not need all chunks."
+                .to_string(),
+        );
         lines.join("\n")
     }
 }
@@ -352,11 +362,18 @@ mod tests {
         };
 
         let toon = index.to_toon();
-        assert!(toon.contains("[meta]{total:52,shown:15,pages:4}"));
-        assert!(toon.contains("[page_index]"));
-        assert!(toon.contains("p1 (offset=0,limit=15):"));
-        assert!(toon.contains("p2 (offset=15,limit=15):"));
-        assert!(toon.contains("[/page_index]"));
+        assert!(toon.contains("[chunks] 15/52 diffs in 4 chunks:"));
+        assert!(toon.contains("chunk 1 (offset=0, limit=15):"));
+        assert!(toon.contains("<< included above"));
+        assert!(toon.contains("chunk 2 (offset=15, limit=15):"));
+        assert!(toon.contains("[/chunks]"));
+        assert!(toon.contains("You may not need all chunks"));
+        // Only chunk 1 is marked as included
+        let lines: Vec<&str> = toon
+            .lines()
+            .filter(|l| l.contains("included above"))
+            .collect();
+        assert_eq!(lines.len(), 1, "Only chunk 1 should be marked as included");
     }
 
     #[test]

--- a/crates/plugins/format-pipeline/src/page_index.rs
+++ b/crates/plugins/format-pipeline/src/page_index.rs
@@ -11,8 +11,6 @@ use std::collections::BTreeMap;
 pub struct PageDescriptor {
     /// Page number (1-based)
     pub page: usize,
-    /// Whether this is the current page
-    pub current: bool,
     /// Human-readable summary of page contents
     pub summary: String,
     /// Number of items on this page
@@ -22,14 +20,16 @@ pub struct PageDescriptor {
 }
 
 /// Full page index for a result set.
+///
+/// Note: there is no "current page" concept because budget trimming may
+/// select non-contiguous items by priority. The shown items are selected
+/// by the trim strategy, not by sequential page boundaries.
 #[derive(Debug, Clone)]
 pub struct PageIndex {
     /// Total items across all pages
     pub total_items: usize,
-    /// Items shown on current page
+    /// Items shown (selected by budget trimming, may span multiple pages)
     pub shown_items: usize,
-    /// Current page number (1-based)
-    pub current_page: usize,
     /// Total number of pages
     pub total_pages: usize,
     /// Page descriptors
@@ -43,13 +43,15 @@ impl PageIndex {
     pub fn to_toon(&self) -> String {
         let mut lines = Vec::new();
         lines.push(format!(
-            "[meta]{{total:{},shown:{},pages:{},page:{}}}",
-            self.total_items, self.shown_items, self.total_pages, self.current_page
+            "[meta]{{total:{},shown:{},pages:{}}}",
+            self.total_items, self.shown_items, self.total_pages
         ));
         lines.push("[page_index]".to_string());
         for p in &self.pages {
-            let marker = if p.current { " (current)" } else { "" };
-            lines.push(format!("  p{}{}: {}", p.page, marker, p.summary));
+            lines.push(format!(
+                "  p{} (offset={},limit={}): {}",
+                p.page, p.offset, p.item_count, p.summary
+            ));
         }
         lines.push("[/page_index]".to_string());
         lines.join("\n")
@@ -104,7 +106,6 @@ pub fn build_issues_index(issues: &[Issue], included_count: usize) -> PageIndex 
 
             PageDescriptor {
                 page: page_idx + 1,
-                current: page_idx == 0,
                 summary,
                 item_count,
                 offset,
@@ -115,7 +116,6 @@ pub fn build_issues_index(issues: &[Issue], included_count: usize) -> PageIndex 
     PageIndex {
         total_items: total,
         shown_items: included_count,
-        current_page: 1,
         total_pages,
         pages,
         data_type: "issues".to_string(),
@@ -144,7 +144,6 @@ pub fn build_merge_requests_index(mrs: &[MergeRequest], included_count: usize) -
 
             PageDescriptor {
                 page: page_idx + 1,
-                current: page_idx == 0,
                 summary,
                 item_count: page_mrs.len(),
                 offset,
@@ -155,7 +154,6 @@ pub fn build_merge_requests_index(mrs: &[MergeRequest], included_count: usize) -
     PageIndex {
         total_items: total,
         shown_items: included_count,
-        current_page: 1,
         total_pages,
         pages,
         data_type: "merge_requests".to_string(),
@@ -205,7 +203,6 @@ pub fn build_diffs_index(diffs: &[FileDiff], included_count: usize) -> PageIndex
 
             PageDescriptor {
                 page: page_idx + 1,
-                current: page_idx == 0,
                 summary,
                 item_count: page_diffs.len(),
                 offset,
@@ -216,7 +213,6 @@ pub fn build_diffs_index(diffs: &[FileDiff], included_count: usize) -> PageIndex
     PageIndex {
         total_items: total,
         shown_items: included_count,
-        current_page: 1,
         total_pages,
         pages,
         data_type: "diffs".to_string(),
@@ -247,7 +243,6 @@ pub fn build_discussions_index(discussions: &[Discussion], included_count: usize
 
             PageDescriptor {
                 page: page_idx + 1,
-                current: page_idx == 0,
                 summary,
                 item_count: page_disc.len(),
                 offset,
@@ -258,7 +253,6 @@ pub fn build_discussions_index(discussions: &[Discussion], included_count: usize
     PageIndex {
         total_items: total,
         shown_items: included_count,
-        current_page: 1,
         total_pages,
         pages,
         data_type: "discussions".to_string(),
@@ -281,7 +275,6 @@ pub fn build_comments_index(comments: &[Comment], included_count: usize) -> Page
 
             PageDescriptor {
                 page: page_idx + 1,
-                current: page_idx == 0,
                 summary,
                 item_count: page_comments.len(),
                 offset,
@@ -292,7 +285,6 @@ pub fn build_comments_index(comments: &[Comment], included_count: usize) -> Page
     PageIndex {
         total_items: total,
         shown_items: included_count,
-        current_page: 1,
         total_pages,
         pages,
         data_type: "comments".to_string(),
@@ -341,19 +333,16 @@ mod tests {
         let index = PageIndex {
             total_items: 52,
             shown_items: 15,
-            current_page: 1,
             total_pages: 4,
             pages: vec![
                 PageDescriptor {
                     page: 1,
-                    current: true,
                     summary: "src/app/modules/* (8 files) — +120/-45".to_string(),
                     item_count: 15,
                     offset: 0,
                 },
                 PageDescriptor {
                     page: 2,
-                    current: false,
                     summary: "apps/dev-boy-e2e/* (17 files) — +340/-12".to_string(),
                     item_count: 15,
                     offset: 15,
@@ -363,10 +352,10 @@ mod tests {
         };
 
         let toon = index.to_toon();
-        assert!(toon.contains("[meta]{total:52,shown:15,pages:4,page:1}"));
+        assert!(toon.contains("[meta]{total:52,shown:15,pages:4}"));
         assert!(toon.contains("[page_index]"));
-        assert!(toon.contains("p1 (current):"));
-        assert!(toon.contains("p2:"));
+        assert!(toon.contains("p1 (offset=0,limit=15):"));
+        assert!(toon.contains("p2 (offset=15,limit=15):"));
         assert!(toon.contains("[/page_index]"));
     }
 
@@ -386,7 +375,7 @@ mod tests {
         assert_eq!(index.total_items, 10);
         assert_eq!(index.total_pages, 2);
         assert_eq!(index.pages[0].item_count, 5);
-        assert!(index.pages[0].current);
-        assert!(!index.pages[1].current);
+        assert_eq!(index.pages[0].offset, 0);
+        assert_eq!(index.pages[1].offset, 5);
     }
 }

--- a/crates/plugins/format-pipeline/src/page_index.rs
+++ b/crates/plugins/format-pipeline/src/page_index.rs
@@ -59,9 +59,11 @@ impl PageIndex {
 /// Default page size for chunking.
 const DEFAULT_PAGE_SIZE: usize = 20;
 
-/// Compute page size based on budget and average item size.
-fn compute_page_size(total_items: usize, included_items: usize, _budget_chars: usize) -> usize {
-    // Use the number of items that fit in budget as page size
+/// Compute page size from the number of items that fit in budget.
+///
+/// Uses `included_items` (items that fit in one budget window) as page size.
+/// Falls back to `DEFAULT_PAGE_SIZE` when included_items is 0.
+fn compute_page_size(total_items: usize, included_items: usize) -> usize {
     if included_items > 0 {
         included_items
     } else {
@@ -74,13 +76,9 @@ fn compute_page_size(total_items: usize, included_items: usize, _budget_chars: u
 // =============================================================================
 
 /// Build page index for issues.
-pub fn build_issues_index(
-    issues: &[Issue],
-    included_count: usize,
-    budget_chars: usize,
-) -> PageIndex {
+pub fn build_issues_index(issues: &[Issue], included_count: usize) -> PageIndex {
     let total = issues.len();
-    let page_size = compute_page_size(total, included_count, budget_chars);
+    let page_size = compute_page_size(total, included_count);
     let total_pages = total.div_ceil(page_size);
 
     let pages: Vec<PageDescriptor> = (0..total_pages)
@@ -125,13 +123,9 @@ pub fn build_issues_index(
 }
 
 /// Build page index for merge requests.
-pub fn build_merge_requests_index(
-    mrs: &[MergeRequest],
-    included_count: usize,
-    budget_chars: usize,
-) -> PageIndex {
+pub fn build_merge_requests_index(mrs: &[MergeRequest], included_count: usize) -> PageIndex {
     let total = mrs.len();
-    let page_size = compute_page_size(total, included_count, budget_chars);
+    let page_size = compute_page_size(total, included_count);
     let total_pages = total.div_ceil(page_size);
 
     let pages: Vec<PageDescriptor> = (0..total_pages)
@@ -169,13 +163,9 @@ pub fn build_merge_requests_index(
 }
 
 /// Build page index for diffs — grouped by directory.
-pub fn build_diffs_index(
-    diffs: &[FileDiff],
-    included_count: usize,
-    budget_chars: usize,
-) -> PageIndex {
+pub fn build_diffs_index(diffs: &[FileDiff], included_count: usize) -> PageIndex {
     let total = diffs.len();
-    let page_size = compute_page_size(total, included_count, budget_chars);
+    let page_size = compute_page_size(total, included_count);
     let total_pages = total.div_ceil(page_size);
 
     let pages: Vec<PageDescriptor> = (0..total_pages)
@@ -234,13 +224,9 @@ pub fn build_diffs_index(
 }
 
 /// Build page index for discussions — grouped by resolved status.
-pub fn build_discussions_index(
-    discussions: &[Discussion],
-    included_count: usize,
-    budget_chars: usize,
-) -> PageIndex {
+pub fn build_discussions_index(discussions: &[Discussion], included_count: usize) -> PageIndex {
     let total = discussions.len();
-    let page_size = compute_page_size(total, included_count, budget_chars);
+    let page_size = compute_page_size(total, included_count);
     let total_pages = total.div_ceil(page_size);
 
     let pages: Vec<PageDescriptor> = (0..total_pages)
@@ -280,13 +266,9 @@ pub fn build_discussions_index(
 }
 
 /// Build page index for comments — chronological.
-pub fn build_comments_index(
-    comments: &[Comment],
-    included_count: usize,
-    budget_chars: usize,
-) -> PageIndex {
+pub fn build_comments_index(comments: &[Comment], included_count: usize) -> PageIndex {
     let total = comments.len();
-    let page_size = compute_page_size(total, included_count, budget_chars);
+    let page_size = compute_page_size(total, included_count);
     let total_pages = total.div_ceil(page_size);
 
     let pages: Vec<PageDescriptor> = (0..total_pages)
@@ -321,8 +303,8 @@ pub fn build_comments_index(
 // Helpers
 // =============================================================================
 
-/// Extract top-level directory from a file path.
-/// "src/app/modules/mcp/tools/foo.ts" → "src/app/modules/mcp"
+/// Extract top-level directory from a file path (first 3 segments).
+/// "src/app/modules/mcp/tools/foo.ts" → "src/app/modules"
 fn extract_top_dir(path: &str) -> String {
     let parts: Vec<&str> = path.split('/').collect();
     if parts.len() <= 2 {
@@ -400,7 +382,7 @@ mod tests {
             })
             .collect();
 
-        let index = build_diffs_index(&diffs, 5, 1000);
+        let index = build_diffs_index(&diffs, 5);
         assert_eq!(index.total_items, 10);
         assert_eq!(index.total_pages, 2);
         assert_eq!(index.pages[0].item_count, 5);

--- a/crates/plugins/format-pipeline/src/page_index.rs
+++ b/crates/plugins/format-pipeline/src/page_index.rs
@@ -49,10 +49,7 @@ impl PageIndex {
         lines.push("[page_index]".to_string());
         for p in &self.pages {
             let marker = if p.current { " (current)" } else { "" };
-            lines.push(format!(
-                "  p{}{}: {}",
-                p.page, marker, p.summary
-            ));
+            lines.push(format!("  p{}{}: {}", p.page, marker, p.summary));
         }
         lines.push("[/page_index]".to_string());
         lines.join("\n")
@@ -84,7 +81,7 @@ pub fn build_issues_index(
 ) -> PageIndex {
     let total = issues.len();
     let page_size = compute_page_size(total, included_count, budget_chars);
-    let total_pages = (total + page_size - 1) / page_size;
+    let total_pages = total.div_ceil(page_size);
 
     let pages: Vec<PageDescriptor> = (0..total_pages)
         .map(|page_idx| {
@@ -98,10 +95,8 @@ pub fn build_issues_index(
             for issue in page_issues {
                 *states.entry(issue.state.as_str()).or_default() += 1;
             }
-            let state_parts: Vec<String> = states
-                .iter()
-                .map(|(s, c)| format!("{} {}", c, s))
-                .collect();
+            let state_parts: Vec<String> =
+                states.iter().map(|(s, c)| format!("{} {}", c, s)).collect();
             let summary = format!(
                 "issues #{}-{} ({})",
                 offset + 1,
@@ -137,7 +132,7 @@ pub fn build_merge_requests_index(
 ) -> PageIndex {
     let total = mrs.len();
     let page_size = compute_page_size(total, included_count, budget_chars);
-    let total_pages = (total + page_size - 1) / page_size;
+    let total_pages = total.div_ceil(page_size);
 
     let pages: Vec<PageDescriptor> = (0..total_pages)
         .map(|page_idx| {
@@ -149,16 +144,9 @@ pub fn build_merge_requests_index(
             for mr in page_mrs {
                 *states.entry(mr.state.as_str()).or_default() += 1;
             }
-            let state_parts: Vec<String> = states
-                .iter()
-                .map(|(s, c)| format!("{} {}", c, s))
-                .collect();
-            let summary = format!(
-                "MRs #{}-{} ({})",
-                offset + 1,
-                end,
-                state_parts.join(", ")
-            );
+            let state_parts: Vec<String> =
+                states.iter().map(|(s, c)| format!("{} {}", c, s)).collect();
+            let summary = format!("MRs #{}-{} ({})", offset + 1, end, state_parts.join(", "));
 
             PageDescriptor {
                 page: page_idx + 1,
@@ -188,7 +176,7 @@ pub fn build_diffs_index(
 ) -> PageIndex {
     let total = diffs.len();
     let page_size = compute_page_size(total, included_count, budget_chars);
-    let total_pages = (total + page_size - 1) / page_size;
+    let total_pages = total.div_ceil(page_size);
 
     let pages: Vec<PageDescriptor> = (0..total_pages)
         .map(|page_idx| {
@@ -253,7 +241,7 @@ pub fn build_discussions_index(
 ) -> PageIndex {
     let total = discussions.len();
     let page_size = compute_page_size(total, included_count, budget_chars);
-    let total_pages = (total + page_size - 1) / page_size;
+    let total_pages = total.div_ceil(page_size);
 
     let pages: Vec<PageDescriptor> = (0..total_pages)
         .map(|page_idx| {
@@ -299,7 +287,7 @@ pub fn build_comments_index(
 ) -> PageIndex {
     let total = comments.len();
     let page_size = compute_page_size(total, included_count, budget_chars);
-    let total_pages = (total + page_size - 1) / page_size;
+    let total_pages = total.div_ceil(page_size);
 
     let pages: Vec<PageDescriptor> = (0..total_pages)
         .map(|page_idx| {
@@ -357,7 +345,10 @@ mod tests {
 
     #[test]
     fn test_extract_top_dir() {
-        assert_eq!(extract_top_dir("src/app/modules/mcp/tools/foo.ts"), "src/app/modules");
+        assert_eq!(
+            extract_top_dir("src/app/modules/mcp/tools/foo.ts"),
+            "src/app/modules"
+        );
         assert_eq!(extract_top_dir("README.md"), ".");
         assert_eq!(extract_top_dir("src/main.rs"), "src");
         assert_eq!(extract_top_dir("a/b/c/d/e.rs"), "a/b/c");

--- a/docs/guide/architecture/format-pipeline.md
+++ b/docs/guide/architecture/format-pipeline.md
@@ -26,7 +26,6 @@ TransformOutput {
     content: String,            // TOON or JSON
     raw_chars: usize,           // input size (JSON)
     output_chars: usize,        // output size (TOON/JSON)
-    page_cursor: Option,        // for next page
     agent_hint: Option,         // pagination hint
     page_index: Option<String>, // chunk index for lazy loading
     provider_pagination: Option,// upstream pagination metadata
@@ -202,21 +201,21 @@ When data exceeds the token budget, the pipeline splits output into sequential c
 1. Budget pipeline determines which items fit in the budget (chunk 1)
 2. Remaining items are grouped into sequential chunks with content summaries
 3. The chunk index is appended to the response, describing each chunk
-4. The agent uses `offset` and `limit` parameters in subsequent tool calls to fetch specific chunks
+4. The agent uses the `chunk: N` parameter in subsequent tool calls to fetch specific chunks
 5. The agent can stop early if it finds the needed information without reading all chunks
 
 ### Chunk Index Format
 
 ```
 [chunks] 15/52 diffs in 4 chunks:
-  chunk 1 (offset=0, limit=15): src/app/* — 8 files, +120/-45 << included above
+  chunk 1 (offset=0, limit=15): src/app/* — 8 files, +120/-45 << returned in this response
   chunk 2 (offset=15, limit=15): apps/e2e/features/* — 15 files, +340/-12
   chunk 3 (offset=30, limit=12): apps/e2e/steps/* — 12 files, +280/-0
   chunk 4 (offset=42, limit=10): libs/*, docs/* — 10 files, +95/-30
-[/chunks] Use offset and limit to fetch any chunk. You may not need all chunks.
+[/chunks] Use `chunk: N` parameter to fetch a specific chunk. You may not need all chunks.
 ```
 
-Each chunk entry shows the `offset`/`limit` parameters needed to fetch it, a content summary (file paths, counts, line changes), and which chunk is already included in the current response.
+Each chunk entry shows the `offset`/`limit` boundaries, a content summary (file paths, counts, line changes), and which chunk is already included in the current response. Use `chunk: N` to fetch a specific chunk.
 
 ## Provider Metadata
 
@@ -241,7 +240,8 @@ Provider (API call)
 
 `SortInfo` describes the current ordering and available sort options:
 
-- `current_sort` — the sort field and direction applied to the current response
+- `sort_by` — the sort field applied to the current response (e.g., `updated_at`, `created_at`)
+- `sort_order` — the sort direction (`asc` or `desc`)
 - `available_sorts` — list of sort fields the provider supports (e.g., `created_at`, `updated_at`, `priority`)
 
 This metadata is passed through to `FormatMetadata` so agents can make informed decisions about re-querying with different sort orders or fetching additional pages.
@@ -314,7 +314,7 @@ This replaces the earlier cursor-based approach with a simpler, stateless model:
 
 1. First request returns chunk 1 + chunk index
 2. Agent reads the chunk index to understand available data
-3. Agent calls the tool again with `offset` and `limit` for the desired chunk
+3. Agent calls the tool again with `chunk: N` for the desired chunk
 4. Agent can stop early — no need to consume all chunks sequentially
 
 ## Token Estimation

--- a/docs/guide/architecture/format-pipeline.md
+++ b/docs/guide/architecture/format-pipeline.md
@@ -1,6 +1,6 @@
 # Format Pipeline
 
-The format pipeline transforms tool responses into token-efficient output for LLMs using **TOON** (Token-Oriented Object Notation) with intelligent budget trimming and cursor-based pagination.
+The format pipeline transforms tool responses into token-efficient output for LLMs using **TOON** (Token-Oriented Object Notation) with intelligent budget trimming and chunk-based lazy loading.
 
 ## Overview
 
@@ -18,16 +18,19 @@ ToolOutput (typed data)
 │     ├─ Check budget             │
 │     ├─ Trim tree                │
 │     └─ Re-encode + verify       │
-│  4. Pagination cursor           │
+│  4. Chunk index + pagination     │
 └─────────────────────────────────┘
     │
     ▼
 TransformOutput {
-    content: String,        // TOON or JSON
-    raw_chars: usize,       // input size (JSON)
-    output_chars: usize,    // output size (TOON/JSON)
-    page_cursor: Option,    // for next page
-    agent_hint: Option,     // pagination hint
+    content: String,            // TOON or JSON
+    raw_chars: usize,           // input size (JSON)
+    output_chars: usize,        // output size (TOON/JSON)
+    page_cursor: Option,        // for next page
+    agent_hint: Option,         // pagination hint
+    page_index: Option<String>, // chunk index for lazy loading
+    provider_pagination: Option,// upstream pagination metadata
+    provider_sort: Option,      // upstream sort metadata
 }
     │
     ▼
@@ -40,6 +43,8 @@ FormatResult {
         compression_ratio,      // output / raw (< 1.0 = savings)
         format,                 // "toon" | "json" | "text"
         truncated,              // budget trimming applied?
+        provider_pagination,    // upstream pagination metadata
+        provider_sort,          // upstream sort metadata
     }
 }
 ```
@@ -157,6 +162,8 @@ The pipeline processes and releases memory synchronously within a single tool ca
 
 ## Budget Trimming
 
+The `Pipeline::transform_*()` methods use the budget pipeline internally for ALL output size control. The flow is: format all items → if fits budget, return → else run budget pipeline with strategy → produce chunk 1 + chunk index.
+
 The trimming problem is modeled as a **Tree Knapsack Problem** (Cho & Shaw, 1997):
 
 > **maximize** Σ p(v) for v ∈ S
@@ -173,7 +180,8 @@ The trimming problem is modeled as a **Tree Knapsack Problem** (Cho & Shaw, 1997
    b. Re-encode → check tokens
    c. If fits → done
    d. Adjust B_trim based on actual compression ratio
-5. Fallback: hard truncate + overflow
+5. If overflow → generate chunk index + return chunk 1
+6. Fallback: hard truncate
 ```
 
 ### Algorithm Selection
@@ -184,6 +192,59 @@ The trimming problem is modeled as a **Tree Knapsack Problem** (Cho & Shaw, 1997
 | 100-999 | Greedy fractional | O(n log n) | ≥ 63% optimum |
 | 1,000-9,999 | Hierarchical WFQ | O(n log n) | Proportionally fair |
 | ≥ 10,000 | Head+Tail linear | O(n) | Heuristic |
+
+## Chunk-Based Lazy Loading
+
+When data exceeds the token budget, the pipeline splits output into sequential chunks. The first response returns **chunk 1** (the highest-value items according to the active strategy) plus a **chunk index** describing all available chunks.
+
+### How It Works
+
+1. Budget pipeline determines which items fit in the budget (chunk 1)
+2. Remaining items are grouped into sequential chunks with content summaries
+3. The chunk index is appended to the response, describing each chunk
+4. The agent uses `offset` and `limit` parameters in subsequent tool calls to fetch specific chunks
+5. The agent can stop early if it finds the needed information without reading all chunks
+
+### Chunk Index Format
+
+```
+[chunks] 15/52 diffs in 4 chunks:
+  chunk 1 (offset=0, limit=15): src/app/* — 8 files, +120/-45 << included above
+  chunk 2 (offset=15, limit=15): apps/e2e/features/* — 15 files, +340/-12
+  chunk 3 (offset=30, limit=12): apps/e2e/steps/* — 12 files, +280/-0
+  chunk 4 (offset=42, limit=10): libs/*, docs/* — 10 files, +95/-30
+[/chunks] Use offset and limit to fetch any chunk. You may not need all chunks.
+```
+
+Each chunk entry shows the `offset`/`limit` parameters needed to fetch it, a content summary (file paths, counts, line changes), and which chunk is already included in the current response.
+
+## Provider Metadata
+
+List-type provider responses are wrapped in `ProviderResult<T>`, which captures upstream pagination and sort metadata alongside the data items.
+
+### Metadata Sources
+
+- **GitLab**: Extracts `X-Total` and `X-Total-Pages` from response headers
+- **Jira**: Extracts `total`, `startAt`, `maxResults` from JQL response body
+
+### Data Flow
+
+```
+Provider (API call)
+    → ProviderResult<T> { items, pagination, sort }
+        → ToolOutput { items, ResultMeta { pagination, sort } }
+            → format.rs
+                → FormatMetadata { provider_pagination, provider_sort }
+```
+
+### SortInfo
+
+`SortInfo` describes the current ordering and available sort options:
+
+- `current_sort` — the sort field and direction applied to the current response
+- `available_sorts` — list of sort fields the provider supports (e.g., `created_at`, `updated_at`, `priority`)
+
+This metadata is passed through to `FormatMetadata` so agents can make informed decisions about re-querying with different sort orders or fetching additional pages.
 
 ## Trimming Strategies
 
@@ -245,30 +306,16 @@ The `StrategyResolver` maps tool names to strategies:
 3. **Strip proxy prefix** (`cloud__get_issues` → `get_issues`) and retry 1-2
 4. **Fallback** to `default` strategy
 
-## Cursor-Based Pagination
+## Pagination via Offset/Limit
 
-Since the MCP spec does not support pagination in tool responses, we implement it at the middleware level through a `_page_cursor` parameter.
+The primary pagination mechanism is `offset`/`limit` parameters on tool calls. When the pipeline produces a chunk index (see [Chunk-Based Lazy Loading](#chunk-based-lazy-loading)), agents use the `offset` and `limit` values from the chunk index to fetch specific chunks of data.
 
-### How It Works
+This replaces the earlier cursor-based approach with a simpler, stateless model:
 
-1. First request returns trimmed data + cursor in the response hint
-2. Agent includes `_page_cursor` in the next request
-3. Pipeline decodes cursor, serves the next page of overflow data
-4. Repeat until all data is consumed
-
-### Cursor Format
-
-Base64-encoded JSON:
-```json
-{
-  "v": 1,
-  "data_type": "issues",
-  "offset": 20,
-  "total": 50,
-  "strategy": "element_count",
-  "budget": 8000
-}
-```
+1. First request returns chunk 1 + chunk index
+2. Agent reads the chunk index to understand available data
+3. Agent calls the tool again with `offset` and `limit` for the desired chunk
+4. Agent can stop early — no need to consume all chunks sequentially
 
 ## Token Estimation
 
@@ -290,7 +337,8 @@ crates/plugins/format-pipeline/src/
 │   └── head_tail.rs    # Head+Tail linear (≥ 10000)
 ├── strategy.rs         # 6 strategies + StrategyResolver
 ├── budget.rs           # Iterative budget pipeline
-├── pagination.rs       # Cursor-based pagination
+├── page_index.rs       # Chunk index generation for lazy loading
+├── pagination.rs       # Offset/limit pagination
 └── truncation.rs       # String/diff truncation utilities
 ```
 

--- a/docs/guide/configuration/format-pipeline.md
+++ b/docs/guide/configuration/format-pipeline.md
@@ -139,3 +139,15 @@ Set a very high budget to effectively disable trimming:
 [format_pipeline]
 budget_tokens = 1000000
 ```
+
+## Chunk-Based Behavior
+
+When tool output exceeds the budget, the pipeline automatically splits the response into chunks. The first response includes chunk 1 (highest-value items based on the active trimming strategy) and a chunk index describing all available chunks. Agents use `offset` and `limit` parameters in subsequent tool calls to fetch specific chunks on demand, without needing to read all data sequentially.
+
+See [Format Pipeline Architecture — Chunk-Based Lazy Loading](/guide/architecture/format-pipeline#chunk-based-lazy-loading) for details on the chunk index format and data flow.
+
+## Provider Result Metadata
+
+When providers return list data, pagination and sort metadata from the upstream API (e.g., GitLab `X-Total` headers, Jira `total`/`startAt`/`maxResults`) is captured in `ProviderResult<T>` and flows through to `FormatMetadata`. This allows agents to understand the total dataset size and available sort options without additional API calls.
+
+See [Format Pipeline Architecture — Provider Metadata](/guide/architecture/format-pipeline#provider-metadata) for details.


### PR DESCRIPTION
## Summary

- **Remove `max_items` from `PipelineConfig`** — model controls pagination via `limit`/`offset`, pipeline no longer silently truncates items
- **Integrate budget pipeline** into `Pipeline::transform_*()` — smart trimming with strategies (ElementCount, Cascading, SizeProportional, ThreadLevel, HeadTail) replaces simple item-count truncation
- **Add `ProviderResult<T>`** wrapper to all list-returning provider methods — enables pagination and sort metadata to flow from providers through the pipeline
- **Structured page index** for large results — when budget trimming drops items, generates type-aware page descriptions so LLM can request specific pages

### Breaking Changes

- `PipelineConfig.max_items` field removed
- 10 provider trait methods now return `Result<ProviderResult<T>>` instead of `Result<Vec<T>>`
- `Pipeline::truncate_items()` and `create_pipeline_with_max_items()` removed

### New Types

- `ProviderResult<T>` — wrapper with pagination + sort metadata
- `SortInfo` — sorting metadata from provider API
- `PageIndex` / `PageDescriptor` — structured page descriptions for large results
- `MrFilter` extended with `offset`, `sort_by`, `sort_order`

### Budget Pipeline Integration

Before: `items → truncate_items(max_items=20) → format → apply_char_limit`
After: `items → format all → if fits budget return → else smart trim via tree+strategy+algorithm`

Algorithm selection by node count: <100 knapsack, 100-999 greedy, 1000-9999 WFQ, ≥10000 head+tail.

### Page Index Output Format

```
[meta]{total:52,shown:15,pages:4,page:1}
[page_index]
  p1 (current): src/app/modules/* (8 files) — +120/-45
  p2: apps/dev-boy-e2e/features/* (17 files) — +340/-12
  p3: apps/dev-boy-e2e/step-definitions/* (15 files) — +280/-0
  p4: libs/*, docs/* (12 files) — +95/-30
[/page_index]
```

## Test plan

- [x] All 1000+ existing tests pass (`cargo test`)
- [x] New page_index tests (extract_top_dir, toon output, build_diffs_index)
- [x] Budget pipeline process_* tests for all 5 data types
- [ ] Manual verification with real MR diffs (large result set)
- [ ] Benchmark comparison (`cargo bench -p devboy-format-pipeline`)

Closes #95
Related: #99, #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)