### PR TITLE
fix(clickup): restore regressions from migration (#113)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "multipart"], default-features = false }
 
 # Async traits
 async-trait = "0.1"

--- a/crates/devboy-core/src/provider.rs
+++ b/crates/devboy-core/src/provider.rs
@@ -93,6 +93,16 @@ pub trait IssueProvider: Send + Sync {
         })
     }
 
+    /// Set custom fields on an issue. Each entry: {"id": "field_id", "value": <value>}.
+    /// Default is no-op — override in providers that support custom fields (e.g., ClickUp).
+    async fn set_custom_fields(
+        &self,
+        _issue_key: &str,
+        _fields: &[serde_json::Value],
+    ) -> Result<()> {
+        Ok(()) // No-op by default
+    }
+
     /// Get issue relations (parent, subtasks, linked issues).
     async fn get_issue_relations(&self, _issue_key: &str) -> Result<IssueRelations> {
         Err(Error::ProviderUnsupported {

--- a/crates/devboy-core/src/provider.rs
+++ b/crates/devboy-core/src/provider.rs
@@ -79,6 +79,20 @@ pub trait IssueProvider: Send + Sync {
         })
     }
 
+    /// Upload a file attachment to an issue. Returns the download URL.
+    /// Default returns ProviderUnsupported — override in providers that support attachments.
+    async fn upload_attachment(
+        &self,
+        _issue_key: &str,
+        _filename: &str,
+        _data: &[u8],
+    ) -> Result<String> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "upload_attachment".to_string(),
+        })
+    }
+
     /// Get issue relations (parent, subtasks, linked issues).
     async fn get_issue_relations(&self, _issue_key: &str) -> Result<IssueRelations> {
         Err(Error::ProviderUnsupported {

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -102,10 +102,15 @@ pub struct IssueRelations {
 pub struct IssueFilter {
     /// Filter by state (e.g., "opened", "closed", "all")
     pub state: Option<String>,
+    /// Filter by semantic state category (e.g., "backlog", "todo", "in_progress", "done", "cancelled").
+    /// Maps to provider-specific statuses using name heuristics.
+    pub state_category: Option<String>,
     /// Search query for title and description
     pub search: Option<String>,
     /// Filter by labels
     pub labels: Option<Vec<String>>,
+    /// Label matching logic: "and" requires all labels, "or" requires any (default: "or")
+    pub labels_operator: Option<String>,
     /// Filter by assignee username
     pub assignee: Option<String>,
     /// Maximum number of results

--- a/crates/devboy-executor/Cargo.toml
+++ b/crates/devboy-executor/Cargo.toml
@@ -21,6 +21,7 @@ serde.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+base64 = "0.22"
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -13,6 +13,22 @@ use crate::factory;
 use crate::output::{ResultMeta, ToolOutput};
 use devboy_core::ToolEnricher;
 
+/// Deserialize a value that can be either a string or a number into Option<String>.
+/// Enricher may transform priority "high" → 2 (number), but executor needs String.
+fn deserialize_string_or_number<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Option<Value> = Option::deserialize(deserializer)?;
+    Ok(value.map(|v| match v {
+        Value::String(s) => s,
+        Value::Number(n) => n.to_string(),
+        other => other.to_string(),
+    }))
+}
+
 /// Tool execution engine.
 ///
 /// Manages enrichers and dispatches tool calls to providers.
@@ -416,6 +432,7 @@ struct CreateIssueParams {
     labels: Vec<String>,
     #[serde(default)]
     assignees: Vec<String>,
+    #[serde(default, deserialize_with = "deserialize_string_or_number")]
     priority: Option<String>,
     parent: Option<String>,
     markdown: Option<bool>,
@@ -457,6 +474,7 @@ struct UpdateIssueParams {
     state: Option<String>,
     labels: Option<Vec<String>>,
     assignees: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "deserialize_string_or_number")]
     priority: Option<String>,
     #[serde(rename = "parentId")]
     parent_id: Option<String>,
@@ -974,6 +992,7 @@ struct CreateEpicParams {
     labels: Vec<String>,
     #[serde(default)]
     assignees: Vec<String>,
+    #[serde(default, deserialize_with = "deserialize_string_or_number")]
     priority: Option<String>,
     markdown: Option<bool>,
 }
@@ -1032,6 +1051,7 @@ struct UpdateEpicParams {
     goal_id: Option<String>,
     labels: Option<Vec<String>>,
     assignees: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "deserialize_string_or_number")]
     priority: Option<String>,
     markdown: Option<bool>,
 }

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -354,24 +354,24 @@ async fn execute_get_issue(
     let mut result = serde_json::to_value(&issue).unwrap_or_default();
     let mut has_extras = false;
 
-    if params.include_comments {
-        if let Ok(comments_result) = provider.get_comments(&params.key).await {
-            result["comments"] = serde_json::to_value(&comments_result.items).unwrap_or_default();
-            result["comments_count"] = serde_json::json!(comments_result.items.len());
-            has_extras = true;
-        }
+    if params.include_comments
+        && let Ok(comments_result) = provider.get_comments(&params.key).await
+    {
+        result["comments"] = serde_json::to_value(&comments_result.items).unwrap_or_default();
+        result["comments_count"] = serde_json::json!(comments_result.items.len());
+        has_extras = true;
     }
 
-    if params.include_relations {
-        if let Ok(relations) = provider.get_issue_relations(&params.key).await {
-            result["relations"] = serde_json::to_value(&relations).unwrap_or_default();
-            if issue.subtasks.is_empty() && !relations.subtasks.is_empty() {
-                result["subtasks"] = serde_json::to_value(&relations.subtasks).unwrap_or_default();
-            }
-            result["subtasks_count"] =
-                serde_json::json!(issue.subtasks.len().max(relations.subtasks.len()));
-            has_extras = true;
+    if params.include_relations
+        && let Ok(relations) = provider.get_issue_relations(&params.key).await
+    {
+        result["relations"] = serde_json::to_value(&relations).unwrap_or_default();
+        if issue.subtasks.is_empty() && !relations.subtasks.is_empty() {
+            result["subtasks"] = serde_json::to_value(&relations.subtasks).unwrap_or_default();
         }
+        result["subtasks_count"] =
+            serde_json::json!(issue.subtasks.len().max(relations.subtasks.len()));
+        has_extras = true;
     }
 
     // If no extras were actually fetched, return simple issue
@@ -437,6 +437,15 @@ async fn execute_create_issue(
         markdown: params.markdown.unwrap_or(true),
     };
     let issue = provider.create_issue(input).await?;
+
+    // Set custom fields injected by enricher (e.g., cf_goals → customFields)
+    if let Some(cf) = args.get("customFields").and_then(|v| v.as_array())
+        && !cf.is_empty()
+        && let Err(e) = provider.set_custom_fields(&issue.key, cf).await
+    {
+        tracing::warn!(error = %e, "Failed to set custom fields on created issue");
+    }
+
     Ok(ToolOutput::SingleIssue(Box::new(issue)))
 }
 
@@ -471,6 +480,14 @@ async fn execute_update_issue(
         markdown: params.markdown.unwrap_or(true),
     };
     let issue = provider.update_issue(&params.key, input).await?;
+
+    // Set custom fields injected by enricher (e.g., cf_goals → customFields)
+    if let Some(cf) = args.get("customFields").and_then(|v| v.as_array())
+        && !cf.is_empty()
+        && let Err(e) = provider.set_custom_fields(&params.key, cf).await
+    {
+        tracing::warn!(error = %e, "Failed to set custom fields on updated issue");
+    }
     Ok(ToolOutput::SingleIssue(Box::new(issue)))
 }
 
@@ -992,11 +1009,21 @@ async fn execute_create_epic(
         markdown: params.markdown.unwrap_or(true),
     };
     let issue = provider.create_issue(input).await?;
+
+    // Set custom fields (e.g., Goals) injected by enricher via goalId → cf_goals → customFields
+    if let Some(cf) = args.get("customFields").and_then(|v| v.as_array())
+        && !cf.is_empty()
+        && let Err(e) = provider.set_custom_fields(&issue.key, cf).await
+    {
+        tracing::warn!(error = %e, "Failed to set custom fields on created epic");
+    }
+
     Ok(ToolOutput::SingleIssue(Box::new(issue)))
 }
 
 #[derive(Deserialize)]
 struct UpdateEpicParams {
+    #[serde(alias = "epicKey")]
     key: String,
     title: Option<String>,
     description: Option<String>,
@@ -1066,6 +1093,15 @@ async fn execute_update_epic(
         markdown: params.markdown.unwrap_or(true),
     };
     let issue = provider.update_issue(&params.key, input).await?;
+
+    // Set custom fields (e.g., Goals) injected by enricher via goalId → cf_goals → customFields
+    if let Some(cf) = args.get("customFields").and_then(|v| v.as_array())
+        && !cf.is_empty()
+        && let Err(e) = provider.set_custom_fields(&params.key, cf).await
+    {
+        tracing::warn!(error = %e, "Failed to set custom fields on updated epic");
+    }
+
     Ok(ToolOutput::SingleIssue(Box::new(issue)))
 }
 
@@ -1341,7 +1377,8 @@ mod tests {
         assert!(matches!(result, ToolOutput::Text(_)));
 
         // Without extras, returns SingleIssue
-        let args = serde_json::json!({"key": "gh#1", "includeComments": false, "includeRelations": false});
+        let args =
+            serde_json::json!({"key": "gh#1", "includeComments": false, "includeRelations": false});
         let result = dispatch_tool("get_issue", &args, &provider).await.unwrap();
         assert!(matches!(result, ToolOutput::SingleIssue(_)));
     }

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -271,8 +271,12 @@ async fn execute_search_meeting_notes(
 #[derive(Deserialize, Default)]
 struct GetIssuesParams {
     state: Option<String>,
+    #[serde(rename = "stateCategory")]
+    state_category: Option<String>,
     search: Option<String>,
     labels: Option<Vec<String>>,
+    #[serde(rename = "labelsOperator")]
+    labels_operator: Option<String>,
     assignee: Option<String>,
     limit: Option<u32>,
     offset: Option<u32>,
@@ -290,8 +294,10 @@ async fn execute_get_issues(
     let params: GetIssuesParams = serde_json::from_value(args.clone()).unwrap_or_default();
     let filter = IssueFilter {
         state: params.state,
+        state_category: params.state_category,
         search: params.search,
         labels: params.labels,
+        labels_operator: params.labels_operator,
         assignee: params.assignee,
         limit: params.limit.or(Some(20)),
         offset: params.offset,
@@ -315,14 +321,67 @@ struct KeyParam {
     budget: Option<usize>,
 }
 
+#[derive(Deserialize)]
+struct GetIssueParams {
+    key: String,
+    #[serde(default = "default_true", rename = "includeComments")]
+    include_comments: bool,
+    #[serde(default = "default_true", rename = "includeRelations")]
+    include_relations: bool,
+    #[serde(default)]
+    #[allow(dead_code)]
+    budget: Option<usize>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
 async fn execute_get_issue(
     provider: &dyn devboy_core::Provider,
     args: &Value,
 ) -> Result<ToolOutput> {
-    let params: KeyParam = serde_json::from_value(args.clone())
+    let params: GetIssueParams = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("missing 'key' parameter: {e}")))?;
     let issue = provider.get_issue(&params.key).await?;
-    Ok(ToolOutput::SingleIssue(Box::new(issue)))
+
+    // If no extras requested, return just the issue
+    if !params.include_comments && !params.include_relations {
+        return Ok(ToolOutput::SingleIssue(Box::new(issue)));
+    }
+
+    // Build a composite JSON with issue + optional comments/relations
+    let mut result = serde_json::to_value(&issue).unwrap_or_default();
+    let mut has_extras = false;
+
+    if params.include_comments {
+        if let Ok(comments_result) = provider.get_comments(&params.key).await {
+            result["comments"] = serde_json::to_value(&comments_result.items).unwrap_or_default();
+            result["comments_count"] = serde_json::json!(comments_result.items.len());
+            has_extras = true;
+        }
+    }
+
+    if params.include_relations {
+        if let Ok(relations) = provider.get_issue_relations(&params.key).await {
+            result["relations"] = serde_json::to_value(&relations).unwrap_or_default();
+            if issue.subtasks.is_empty() && !relations.subtasks.is_empty() {
+                result["subtasks"] = serde_json::to_value(&relations.subtasks).unwrap_or_default();
+            }
+            result["subtasks_count"] =
+                serde_json::json!(issue.subtasks.len().max(relations.subtasks.len()));
+            has_extras = true;
+        }
+    }
+
+    // If no extras were actually fetched, return simple issue
+    if !has_extras {
+        return Ok(ToolOutput::SingleIssue(Box::new(issue)));
+    }
+
+    Ok(ToolOutput::Text(
+        serde_json::to_string_pretty(&result).unwrap_or_default(),
+    ))
 }
 
 async fn execute_get_issue_comments(
@@ -419,6 +478,17 @@ async fn execute_update_issue(
 struct AddCommentParams {
     key: String,
     body: String,
+    #[serde(default)]
+    attachments: Vec<AttachmentParam>,
+}
+
+#[derive(Deserialize)]
+struct AttachmentParam {
+    /// Base64-encoded file content
+    #[serde(rename = "fileData")]
+    file_data: String,
+    /// Filename (e.g., "screenshot.png")
+    filename: String,
 }
 
 async fn execute_add_issue_comment(
@@ -427,12 +497,52 @@ async fn execute_add_issue_comment(
 ) -> Result<ToolOutput> {
     let params: AddCommentParams = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("invalid add_issue_comment params: {e}")))?;
-    let comment =
-        devboy_core::IssueProvider::add_comment(provider, &params.key, &params.body).await?;
-    Ok(ToolOutput::Text(format!(
-        "Comment added to {} (id: {})",
-        params.key, comment.id
-    )))
+
+    let mut body = params.body.clone();
+    let mut uploaded = 0;
+    let mut upload_errors = Vec::new();
+
+    // Upload attachments and append links to comment body
+    for att in &params.attachments {
+        use base64::Engine;
+        let data = match base64::engine::general_purpose::STANDARD.decode(&att.file_data) {
+            Ok(d) => d,
+            Err(e) => {
+                upload_errors.push(format!("{}: decode error: {}", att.filename, e));
+                continue;
+            }
+        };
+
+        match provider
+            .upload_attachment(&params.key, &att.filename, &data)
+            .await
+        {
+            Ok(url) => {
+                if !url.is_empty() {
+                    body.push_str(&format!("\n\n[{}]({})", att.filename, url));
+                }
+                uploaded += 1;
+            }
+            Err(e) => {
+                upload_errors.push(format!("{}: {}", att.filename, e));
+            }
+        }
+    }
+
+    let comment = devboy_core::IssueProvider::add_comment(provider, &params.key, &body).await?;
+
+    let mut msg = format!("Comment added to {} (id: {})", params.key, comment.id);
+    if uploaded > 0 {
+        msg.push_str(&format!(", {} attachment(s) uploaded", uploaded));
+    }
+    if !upload_errors.is_empty() {
+        msg.push_str(&format!(
+            ", {} attachment error(s): {}",
+            upload_errors.len(),
+            upload_errors.join("; ")
+        ));
+    }
+    Ok(ToolOutput::Text(msg))
 }
 
 // --- Merge request tool handlers ---
@@ -758,8 +868,41 @@ struct GetEpicsParams {
     state: Option<String>,
     search: Option<String>,
     assignee: Option<String>,
+    #[serde(rename = "goalId")]
+    goal_id: Option<String>,
     limit: Option<u32>,
     offset: Option<u32>,
+}
+
+/// Extract goal ID (G1-G9) from issue labels/tags.
+fn extract_goal_id(labels: &[String]) -> Option<String> {
+    labels.iter().find_map(|l| {
+        let lower = l.to_lowercase();
+        if lower.len() == 2
+            && lower.starts_with('g')
+            && lower.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
+        {
+            Some(lower.to_uppercase())
+        } else {
+            None
+        }
+    })
+}
+
+/// Calculate epic progress from subtasks.
+fn epic_progress(subtasks: &[devboy_core::Issue]) -> serde_json::Value {
+    let total = subtasks.len();
+    let completed = subtasks.iter().filter(|s| s.state == "closed").count();
+    let percentage = if total > 0 {
+        (completed as f64 / total as f64 * 100.0).round() as u32
+    } else {
+        0
+    };
+    serde_json::json!({
+        "total_subtasks": total,
+        "completed_subtasks": completed,
+        "percentage": percentage,
+    })
 }
 
 async fn execute_get_epics(
@@ -769,26 +912,47 @@ async fn execute_get_epics(
     let params: GetEpicsParams = serde_json::from_value(args.clone()).unwrap_or_default();
     let filter = IssueFilter {
         state: params.state,
+        state_category: None,
         search: params.search,
         labels: Some(vec!["epic".to_string()]),
+        labels_operator: None,
         assignee: params.assignee,
-        limit: params.limit.or(Some(20)),
+        limit: params.limit.or(Some(50)),
         offset: params.offset,
         sort_by: None,
         sort_order: None,
     };
     let result = provider.get_issues(filter).await?;
-    let meta = ResultMeta {
-        pagination: result.pagination,
-        sort_info: result.sort_info,
-    };
-    Ok(ToolOutput::Issues(result.items, Some(meta)))
+    let mut epics = result.items;
+
+    // Filter by goalId if provided
+    if let Some(ref goal) = params.goal_id {
+        let goal_lower = goal.to_lowercase();
+        epics.retain(|e| e.labels.iter().any(|l| l.to_lowercase() == goal_lower));
+    }
+
+    // Enrich each epic with goal ID and progress
+    let enriched: Vec<serde_json::Value> = epics
+        .iter()
+        .map(|epic| {
+            let mut v = serde_json::to_value(epic).unwrap_or_default();
+            v["goal_id"] = serde_json::json!(extract_goal_id(&epic.labels));
+            v["progress"] = epic_progress(&epic.subtasks);
+            v
+        })
+        .collect();
+
+    Ok(ToolOutput::Text(
+        serde_json::to_string_pretty(&enriched).unwrap_or_default(),
+    ))
 }
 
 #[derive(Deserialize)]
 struct CreateEpicParams {
     title: String,
     description: Option<String>,
+    #[serde(rename = "goalId")]
+    goal_id: Option<String>,
     #[serde(default)]
     labels: Vec<String>,
     #[serde(default)]
@@ -810,6 +974,14 @@ async fn execute_create_epic(
         labels.push("epic".to_string());
     }
 
+    // Add goal tag if goalId provided (e.g., "G1" → tag "g1")
+    if let Some(ref goal) = params.goal_id {
+        let goal_tag = goal.to_lowercase();
+        if !labels.iter().any(|l| l.to_lowercase() == goal_tag) {
+            labels.push(goal_tag);
+        }
+    }
+
     let input = CreateIssueInput {
         title: params.title,
         description: params.description,
@@ -823,20 +995,74 @@ async fn execute_create_epic(
     Ok(ToolOutput::SingleIssue(Box::new(issue)))
 }
 
+#[derive(Deserialize)]
+struct UpdateEpicParams {
+    key: String,
+    title: Option<String>,
+    description: Option<String>,
+    state: Option<String>,
+    #[serde(rename = "goalId")]
+    goal_id: Option<String>,
+    labels: Option<Vec<String>>,
+    assignees: Option<Vec<String>>,
+    priority: Option<String>,
+    markdown: Option<bool>,
+}
+
 async fn execute_update_epic(
     provider: &dyn devboy_core::Provider,
     args: &Value,
 ) -> Result<ToolOutput> {
-    let params: UpdateIssueParams = serde_json::from_value(args.clone())
+    let params: UpdateEpicParams = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("invalid update_epic params: {e}")))?;
+
+    // Handle goal tag transition: if goalId is changing, update labels
+    let labels = if let Some(ref new_goal) = params.goal_id {
+        // Fetch current issue to get existing labels
+        let current = provider.get_issue(&params.key).await?;
+        let mut labels: Vec<String> = current
+            .labels
+            .iter()
+            // Remove old goal tags (g1-g9)
+            .filter(|l| {
+                let lower = l.to_lowercase();
+                !(lower.len() == 2
+                    && lower.starts_with('g')
+                    && lower.chars().nth(1).is_some_and(|c| c.is_ascii_digit()))
+            })
+            .cloned()
+            .collect();
+
+        // Add new goal tag
+        let goal_tag = new_goal.to_lowercase();
+        if !labels.iter().any(|l| l.to_lowercase() == goal_tag) {
+            labels.push(goal_tag);
+        }
+
+        // Merge with explicitly provided labels
+        if let Some(extra) = params.labels {
+            for l in extra {
+                if !labels
+                    .iter()
+                    .any(|existing| existing.eq_ignore_ascii_case(&l))
+                {
+                    labels.push(l);
+                }
+            }
+        }
+        Some(labels)
+    } else {
+        params.labels
+    };
+
     let input = UpdateIssueInput {
         title: params.title,
         description: params.description,
         state: params.state,
-        labels: params.labels,
+        labels,
         assignees: params.assignees,
         priority: params.priority,
-        parent_id: params.parent_id,
+        parent_id: None,
         markdown: params.markdown.unwrap_or(true),
     };
     let issue = provider.update_issue(&params.key, input).await?;
@@ -1109,7 +1335,13 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_get_issue() {
         let provider = MockProvider;
+        // With includeComments/includeRelations defaulting to true, returns composite Text
         let args = serde_json::json!({"key": "gh#1"});
+        let result = dispatch_tool("get_issue", &args, &provider).await.unwrap();
+        assert!(matches!(result, ToolOutput::Text(_)));
+
+        // Without extras, returns SingleIssue
+        let args = serde_json::json!({"key": "gh#1", "includeComments": false, "includeRelations": false});
         let result = dispatch_tool("get_issue", &args, &provider).await.unwrap();
         assert!(matches!(result, ToolOutput::SingleIssue(_)));
     }
@@ -1403,7 +1635,8 @@ mod tests {
         let provider = MockProvider;
         let args = serde_json::json!({"state": "open", "limit": 10});
         let result = dispatch_tool("get_epics", &args, &provider).await.unwrap();
-        assert!(matches!(result, ToolOutput::Issues(v, _) if v.len() == 1));
+        // Returns enriched JSON with goal_id and progress
+        assert!(matches!(result, ToolOutput::Text(_)));
     }
 
     #[tokio::test]
@@ -1412,7 +1645,7 @@ mod tests {
         let result = dispatch_tool("get_epics", &Value::Null, &provider)
             .await
             .unwrap();
-        assert!(matches!(result, ToolOutput::Issues(_, _)));
+        assert!(matches!(result, ToolOutput::Text(_)));
     }
 
     #[tokio::test]

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -537,6 +537,18 @@ async fn execute_add_issue_comment(
     let mut uploaded = 0;
     let mut upload_errors = Vec::new();
 
+    // Validate attachment limits
+    const MAX_ATTACHMENTS: usize = 10;
+    const MAX_FILE_SIZE: usize = 10 * 1024 * 1024; // 10MB
+
+    if params.attachments.len() > MAX_ATTACHMENTS {
+        return Err(Error::InvalidData(format!(
+            "Too many attachments: {} (max {})",
+            params.attachments.len(),
+            MAX_ATTACHMENTS
+        )));
+    }
+
     // Upload attachments and append links to comment body
     for att in &params.attachments {
         use base64::Engine;
@@ -547,6 +559,16 @@ async fn execute_add_issue_comment(
                 continue;
             }
         };
+
+        if data.len() > MAX_FILE_SIZE {
+            upload_errors.push(format!(
+                "{}: file too large ({} bytes, max {})",
+                att.filename,
+                data.len(),
+                MAX_FILE_SIZE
+            ));
+            continue;
+        }
 
         match provider
             .upload_attachment(&params.key, &att.filename, &data)
@@ -915,7 +937,7 @@ fn extract_goal_id(labels: &[String]) -> Option<String> {
         let lower = l.to_lowercase();
         if lower.len() == 2
             && lower.starts_with('g')
-            && lower.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
+            && lower.chars().nth(1).is_some_and(|c| matches!(c, '1'..='9'))
         {
             Some(lower.to_uppercase())
         } else {
@@ -1075,7 +1097,7 @@ async fn execute_update_epic(
                 let lower = l.to_lowercase();
                 !(lower.len() == 2
                     && lower.starts_with('g')
-                    && lower.chars().nth(1).is_some_and(|c| c.is_ascii_digit()))
+                    && lower.chars().nth(1).is_some_and(|c| matches!(c, '1'..='9')))
             })
             .cloned()
             .collect();

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -937,7 +937,7 @@ fn extract_goal_id(labels: &[String]) -> Option<String> {
         let lower = l.to_lowercase();
         if lower.len() == 2
             && lower.starts_with('g')
-            && lower.chars().nth(1).is_some_and(|c| matches!(c, '1'..='9'))
+            && lower.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
         {
             Some(lower.to_uppercase())
         } else {
@@ -1097,7 +1097,7 @@ async fn execute_update_epic(
                 let lower = l.to_lowercase();
                 !(lower.len() == 2
                     && lower.starts_with('g')
-                    && lower.chars().nth(1).is_some_and(|c| matches!(c, '1'..='9')))
+                    && lower.chars().nth(1).is_some_and(|c| c.is_ascii_digit()))
             })
             .cloned()
             .collect();

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -37,11 +37,13 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "get_issue".into(),
-            description: "Get a single issue by key (e.g., 'gh#123', 'gitlab#456', 'CU-abc', 'jira#PROJ-123').".into(),
+            description: "Get a single issue by key with optional comments and relations.".into(),
             category: ToolCategory::IssueTracker,
             input_schema: {
                 let mut s = ToolSchema::new();
-                s.add_property("key", PropertySchema::string("Issue key"));
+                s.add_property("key", PropertySchema::string("Issue key (e.g., 'gh#123', 'gitlab#456', 'CU-abc', 'DEV-42', 'jira#PROJ-123')"));
+                s.add_property("includeComments", PropertySchema::boolean("Include issue comments (default: true)"));
+                s.add_property("includeRelations", PropertySchema::boolean("Include issue relations — parent, subtasks, dependencies (default: true)"));
                 s.set_required("key", true);
                 s
             },
@@ -104,12 +106,16 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "add_issue_comment".into(),
-            description: "Add a comment to an issue.".into(),
+            description: "Add a comment to an issue with optional file attachments (ClickUp only).".into(),
             category: ToolCategory::IssueTracker,
             input_schema: {
                 let mut s = ToolSchema::new();
                 s.add_property("key", PropertySchema::string("Issue key"));
                 s.add_property("body", PropertySchema::string("Comment text"));
+                s.add_property("attachments", PropertySchema::array(
+                    PropertySchema::string("Attachment object with fileData (base64) and filename"),
+                    "File attachments (ClickUp only, max 10MB per file). Each: {fileData: base64, filename: string}",
+                ));
                 s.set_required("key", true);
                 s.set_required("body", true);
                 s
@@ -304,6 +310,11 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("epicKey", PropertySchema::string("Epic key (e.g., 'CU-abc', 'DEV-123')"));
                 s.add_property("title", PropertySchema::string("New title"));
                 s.add_property("description", PropertySchema::string("New description"));
+                s.add_property("state", PropertySchema::string("New epic state"));
+                s.add_property("goalId", PropertySchema::string("Goal ID (G1-G9) to associate with the epic"));
+                s.add_property("priority", PropertySchema::string("New priority (urgent/high/normal/low)"));
+                s.add_property("labels", PropertySchema::array(PropertySchema::string("label"), "Labels to set"));
+                s.add_property("assignees", PropertySchema::array(PropertySchema::string("assignee"), "Assignees to set"));
                 s.set_required("epicKey", true);
                 s
             },

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -301,10 +301,10 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
             category: ToolCategory::Epics,
             input_schema: {
                 let mut s = ToolSchema::new();
-                s.add_property("key", PropertySchema::string("Epic key"));
+                s.add_property("epicKey", PropertySchema::string("Epic key (e.g., 'CU-abc', 'DEV-123')"));
                 s.add_property("title", PropertySchema::string("New title"));
                 s.add_property("description", PropertySchema::string("New description"));
-                s.set_required("key", true);
+                s.set_required("epicKey", true);
                 s
             },
         },

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -145,7 +145,7 @@ define_tools! {
 
     "get_issue" => handle_get_issue {
         category: ToolCategory::Issues,
-        description: "Get a single issue by key (e.g., 'gh#123', 'gitlab#456', 'CU-abc', 'DEV-42', 'jira#PROJ-123'). Returns full issue details.",
+        description: "Get a single issue by key (e.g., 'gh#123', 'gitlab#456', 'CU-abc', 'DEV-42', 'jira#PROJ-123'). Returns full issue details with optional comments and relations.",
         schema: {
             "type": "object",
             "required": ["key"],
@@ -153,6 +153,16 @@ define_tools! {
                 "key": {
                     "type": "string",
                     "description": "Issue key (e.g., 'gh#123' for GitHub, 'gitlab#456' for GitLab, 'CU-abc' or custom ID like 'DEV-42' for ClickUp, 'jira#PROJ-123' for Jira)"
+                },
+                "includeComments": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include issue comments in the response (default: true)"
+                },
+                "includeRelations": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include issue relations (parent, subtasks, dependencies) in the response (default: true)"
                 }
             }
         }
@@ -753,8 +763,10 @@ impl ToolHandler {
 
         let filter = IssueFilter {
             state: params.state,
+            state_category: params.state_category,
             search: params.search,
             labels: params.labels,
+            labels_operator: params.labels_operator,
             assignee: params.assignee,
             limit: Some(params.limit.unwrap_or(20) as u32),
             offset: Some(params.offset.unwrap_or(0) as u32),
@@ -831,6 +843,40 @@ impl ToolHandler {
         for provider in &self.providers {
             match provider.get_issue(&params.key).await {
                 Ok(issue) => {
+                    // Optionally fetch comments and relations
+                    let comments = if params.include_comments {
+                        provider
+                            .get_comments(&params.key)
+                            .await
+                            .ok()
+                            .map(|r| r.items)
+                    } else {
+                        None
+                    };
+
+                    let relations = if params.include_relations {
+                        provider.get_issue_relations(&params.key).await.ok()
+                    } else {
+                        None
+                    };
+
+                    // If extras were requested, build composite JSON
+                    if comments.is_some() || relations.is_some() {
+                        let mut result = serde_json::to_value(&issue).unwrap_or_default();
+                        if let Some(ref c) = comments {
+                            result["comments"] = serde_json::to_value(c).unwrap_or_default();
+                            result["comments_count"] = serde_json::json!(c.len());
+                        }
+                        if let Some(ref rel) = relations {
+                            result["relations"] = serde_json::to_value(rel).unwrap_or_default();
+                            let subtask_count = issue.subtasks.len().max(rel.subtasks.len());
+                            result["subtasks_count"] = serde_json::json!(subtask_count);
+                        }
+                        return ToolCallResult::text(
+                            serde_json::to_string_pretty(&result).unwrap_or_default(),
+                        );
+                    }
+
                     let pipeline =
                         self.create_pipeline(&params.format, params.budget, params.chunk);
                     return match pipeline.transform_issues(vec![issue]) {
@@ -1828,8 +1874,12 @@ impl ToolHandler {
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct GetIssuesParams {
     state: Option<String>,
+    #[serde(rename = "stateCategory")]
+    state_category: Option<String>,
     search: Option<String>,
     labels: Option<Vec<String>>,
+    #[serde(rename = "labelsOperator")]
+    labels_operator: Option<String>,
     assignee: Option<String>,
     limit: Option<usize>,
     offset: Option<usize>,
@@ -1844,9 +1894,17 @@ struct GetIssuesParams {
 #[derive(Debug, Serialize, Deserialize)]
 struct GetIssueParams {
     key: String,
+    #[serde(default = "default_true_fn", rename = "includeComments")]
+    include_comments: bool,
+    #[serde(default = "default_true_fn", rename = "includeRelations")]
+    include_relations: bool,
     format: Option<String>,
     budget: Option<usize>,
     chunk: Option<usize>,
+}
+
+fn default_true_fn() -> bool {
+    true
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/plugins/api/clickup/Cargo.toml
+++ b/crates/plugins/api/clickup/Cargo.toml
@@ -15,6 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+urlencoding = "2"
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use devboy_core::{
     Comment, CreateIssueInput, Error, Issue, IssueFilter, IssueLink, IssueProvider, IssueRelations,
     IssueStatus, MergeRequestProvider, PipelineProvider, Provider, ProviderResult, Result,
-    UpdateIssueInput, User,
+    SortInfo, SortOrder, UpdateIssueInput, User,
 };
 use tracing::{debug, warn};
 
@@ -332,6 +332,56 @@ fn map_state(task: &ClickUpTask) -> String {
     }
 }
 
+/// Map a ClickUp status to a semantic category using both the status type field
+/// and name-based heuristics (for custom statuses where the type is always "custom").
+///
+/// Categories: "backlog", "todo", "in_progress", "done", "cancelled"
+fn map_status_category(status_type: Option<&str>, status_name: &str) -> String {
+    // First, use the explicit type from ClickUp
+    match status_type {
+        Some("closed") | Some("done") => return "done".to_string(),
+        // "open" type in ClickUp is the initial/default status — map via name heuristics below
+        // "custom" type covers most user-defined statuses — also use name heuristics
+        _ => {}
+    }
+
+    // Name-based heuristic matching (case-insensitive)
+    let name_lower = status_name.to_lowercase();
+
+    if name_lower.contains("backlog") {
+        "backlog".to_string()
+    } else if name_lower.contains("cancel")
+        || name_lower.contains("archived")
+        || name_lower.contains("rejected")
+    {
+        "cancelled".to_string()
+    } else if name_lower.contains("done")
+        || name_lower.contains("complete")
+        || name_lower.contains("closed")
+        || name_lower.contains("resolved")
+    {
+        "done".to_string()
+    } else if name_lower.contains("progress")
+        || name_lower.contains("doing")
+        || name_lower.contains("active")
+        || name_lower.contains("review")
+    {
+        "in_progress".to_string()
+    } else if name_lower.contains("todo")
+        || name_lower.contains("to do")
+        || name_lower.contains("open")
+        || name_lower.contains("new")
+    {
+        "todo".to_string()
+    } else {
+        // Unknown custom status — default based on type
+        match status_type {
+            Some("open") => "todo".to_string(),
+            _ => "in_progress".to_string(),
+        }
+    }
+}
+
 /// Build the unified issue key for a task.
 /// Uses `custom_id` when available (e.g., `DEV-42`), otherwise `CU-{id}`.
 fn map_task_key(task: &ClickUpTask) -> String {
@@ -426,6 +476,18 @@ fn map_comment(cu_comment: &ClickUpComment) -> Comment {
         created_at: map_timestamp(&cu_comment.date),
         updated_at: None,
         position: None,
+    }
+}
+
+/// Sorting key for priority (lower = more urgent).
+/// urgent=1, high=2, normal=3, low=4, None=5
+fn priority_sort_key(priority: Option<&str>) -> u8 {
+    match priority {
+        Some("urgent") => 1,
+        Some("high") => 2,
+        Some("normal") => 3,
+        Some("low") => 4,
+        _ => 5,
     }
 }
 
@@ -569,7 +631,11 @@ impl IssueProvider for ClickUpClient {
         // Values are properly URL-encoded by reqwest's .query() method.
         let mut base_params: Vec<(&str, String)> = vec![];
 
-        let include_closed = matches!(filter.state.as_deref(), Some("closed") | Some("all"));
+        let include_closed = matches!(filter.state.as_deref(), Some("closed") | Some("all"))
+            || matches!(
+                filter.state_category.as_deref(),
+                Some("done") | Some("cancelled")
+            );
         if include_closed {
             base_params.push(("include_closed", "true".to_string()));
         }
@@ -593,18 +659,32 @@ impl IssueProvider for ClickUpClient {
             }
         }
 
+        // Track whether client-side sorting is needed for unsupported fields
+        let mut client_side_sort: Option<String> = None;
+
         if let Some(order_by) = &filter.sort_by {
-            let cu_order_by = match order_by.as_str() {
-                "created_at" | "created" => "created",
-                "updated_at" | "updated" => "updated",
-                _ => "updated",
-            };
-            base_params.push(("order_by", cu_order_by.to_string()));
+            match order_by.as_str() {
+                "created_at" | "created" => {
+                    base_params.push(("order_by", "created".to_string()));
+                }
+                "updated_at" | "updated" => {
+                    base_params.push(("order_by", "updated".to_string()));
+                }
+                other => {
+                    // Unsupported by ClickUp API — will sort client-side after fetch
+                    client_side_sort = Some(other.to_string());
+                    warn!(
+                        sort_by = other,
+                        "ClickUp API does not support sorting by '{}', applying client-side sort",
+                        other
+                    );
+                }
+            }
         }
 
-        if let Some(order) = &filter.sort_order
-            && order == "asc"
-        {
+        let sort_order_is_asc = filter.sort_order.as_deref().is_some_and(|o| o == "asc");
+
+        if sort_order_is_asc && client_side_sort.is_none() {
             base_params.push(("reverse", "true".to_string()));
         }
 
@@ -628,6 +708,21 @@ impl IssueProvider for ClickUpClient {
             }
         }
 
+        // Filter by stateCategory if provided (semantic status filtering).
+        // This must happen on raw ClickUp tasks before mapping, since the actual
+        // status name (e.g., "Backlog", "In Progress") is lost during map_task().
+        if let Some(ref state_category) = filter.state_category {
+            let statuses = self.get_statuses().await?;
+            let matching_status_names: Vec<String> = statuses
+                .items
+                .iter()
+                .filter(|s| s.category == *state_category)
+                .map(|s| s.name.to_lowercase())
+                .collect();
+
+            all_tasks.retain(|t| matching_status_names.contains(&t.status.status.to_lowercase()));
+        }
+
         let mut issues: Vec<Issue> = all_tasks.iter().map(map_task).collect();
 
         // Filter by state client-side if needed
@@ -643,6 +738,62 @@ impl IssueProvider for ClickUpClient {
             }
         }
 
+        // Labels AND operator: ClickUp API uses OR by default. For AND, post-filter.
+        if filter.labels_operator.as_deref() == Some("and") {
+            if let Some(ref required_labels) = filter.labels {
+                let required: Vec<String> =
+                    required_labels.iter().map(|l| l.to_lowercase()).collect();
+                issues.retain(|issue| {
+                    let issue_labels: Vec<String> =
+                        issue.labels.iter().map(|l| l.to_lowercase()).collect();
+                    required.iter().all(|r| issue_labels.contains(r))
+                });
+            }
+        }
+
+        // Client-side search filtering (ClickUp API has no search endpoint for tasks)
+        if let Some(ref query) = filter.search {
+            let q = query.to_lowercase();
+            issues.retain(|issue| {
+                issue.title.to_lowercase().contains(&q)
+                    || issue
+                        .description
+                        .as_ref()
+                        .is_some_and(|d| d.to_lowercase().contains(&q))
+                    || issue.key.to_lowercase().contains(&q)
+            });
+        }
+
+        // Client-side sorting for fields unsupported by ClickUp API
+        if let Some(ref sort_field) = client_side_sort {
+            match sort_field.as_str() {
+                "priority" => {
+                    issues.sort_by(|a, b| {
+                        let pa = priority_sort_key(a.priority.as_deref());
+                        let pb = priority_sort_key(b.priority.as_deref());
+                        if sort_order_is_asc {
+                            pa.cmp(&pb)
+                        } else {
+                            pb.cmp(&pa)
+                        }
+                    });
+                }
+                "title" => {
+                    issues.sort_by(|a, b| {
+                        let cmp = a.title.to_lowercase().cmp(&b.title.to_lowercase());
+                        if sort_order_is_asc {
+                            cmp
+                        } else {
+                            cmp.reverse()
+                        }
+                    });
+                }
+                _ => {
+                    // Unknown sort field — leave as-is (API default order)
+                }
+            }
+        }
+
         // Apply offset within first page and limit
         let offset_in_first_page = offset % PAGE_SIZE as usize;
         if offset_in_first_page < issues.len() {
@@ -653,7 +804,23 @@ impl IssueProvider for ClickUpClient {
 
         issues.truncate(limit);
 
-        Ok(issues.into())
+        // Build sort info metadata
+        let sort_info = SortInfo {
+            sort_by: filter.sort_by.clone(),
+            sort_order: if sort_order_is_asc {
+                SortOrder::Asc
+            } else {
+                SortOrder::Desc
+            },
+            available_sorts: vec![
+                "created_at".into(),
+                "updated_at".into(),
+                "priority".into(),
+                "title".into(),
+            ],
+        };
+
+        Ok(ProviderResult::new(issues).with_sort_info(sort_info))
     }
 
     async fn get_issue(&self, key: &str) -> Result<Issue> {
@@ -827,6 +994,53 @@ impl IssueProvider for ClickUpClient {
         })
     }
 
+    async fn upload_attachment(
+        &self,
+        issue_key: &str,
+        filename: &str,
+        data: &[u8],
+    ) -> Result<String> {
+        let task_id = self.resolve_to_native_id(issue_key).await?;
+        let url = format!("{}/task/{}/attachment", self.base_url, task_id);
+
+        let part = reqwest::multipart::Part::bytes(data.to_vec())
+            .file_name(filename.to_string())
+            .mime_str("application/octet-stream")
+            .map_err(|e| Error::Http(format!("Failed to create multipart: {}", e)))?;
+
+        let form = reqwest::multipart::Form::new().part("attachment", part);
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", &self.token)
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+
+        // ClickUp returns: { "attachment": { "url": "..." } } or similar
+        let body: serde_json::Value = response.json().await.map_err(|e| {
+            Error::InvalidData(format!("Failed to parse attachment response: {}", e))
+        })?;
+
+        // Extract URL from response
+        let download_url = body
+            .pointer("/url")
+            .or_else(|| body.pointer("/attachment/url"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        Ok(download_url)
+    }
+
     async fn get_statuses(&self) -> Result<ProviderResult<IssueStatus>> {
         let url = format!("{}/list/{}", self.base_url, self.list_id);
         let list_info: ClickUpListInfo = self.get(&url).await?;
@@ -836,12 +1050,7 @@ impl IssueProvider for ClickUpClient {
             .iter()
             .enumerate()
             .map(|(idx, s)| {
-                let category = match s.status_type.as_deref() {
-                    Some("open") => "open".to_string(),
-                    Some("closed") | Some("done") => "done".to_string(),
-                    Some("custom") => "in_progress".to_string(),
-                    _ => "custom".to_string(),
-                };
+                let category = map_status_category(s.status_type.as_deref(), &s.status);
                 IssueStatus {
                     id: s.status.clone(),
                     name: s.status.clone(),
@@ -1609,6 +1818,59 @@ mod tests {
         let issue = map_task(&task);
         assert!(issue.parent.is_none());
         assert!(issue.subtasks.is_empty());
+    }
+
+    #[test]
+    fn test_map_status_category_name_heuristics() {
+        // Explicit types
+        assert_eq!(map_status_category(Some("closed"), "Done"), "done");
+        assert_eq!(map_status_category(Some("done"), "Complete"), "done");
+
+        // Custom statuses — name-based mapping
+        assert_eq!(map_status_category(Some("custom"), "Backlog"), "backlog");
+        assert_eq!(
+            map_status_category(Some("custom"), "Product Backlog"),
+            "backlog"
+        );
+        assert_eq!(map_status_category(Some("custom"), "To Do"), "todo");
+        assert_eq!(map_status_category(Some("custom"), "New"), "todo");
+        assert_eq!(
+            map_status_category(Some("custom"), "In Progress"),
+            "in_progress"
+        );
+        assert_eq!(
+            map_status_category(Some("custom"), "Code Review"),
+            "in_progress"
+        );
+        assert_eq!(map_status_category(Some("custom"), "Doing"), "in_progress");
+        assert_eq!(map_status_category(Some("custom"), "Active"), "in_progress");
+        assert_eq!(map_status_category(Some("custom"), "Done"), "done");
+        assert_eq!(map_status_category(Some("custom"), "Completed"), "done");
+        assert_eq!(map_status_category(Some("custom"), "Resolved"), "done");
+        assert_eq!(
+            map_status_category(Some("custom"), "Cancelled"),
+            "cancelled"
+        );
+        assert_eq!(map_status_category(Some("custom"), "Archived"), "cancelled");
+        assert_eq!(map_status_category(Some("custom"), "Rejected"), "cancelled");
+
+        // Open type — defaults to "todo"
+        assert_eq!(map_status_category(Some("open"), "Open"), "todo");
+
+        // Unknown custom status — defaults to "in_progress"
+        assert_eq!(
+            map_status_category(Some("custom"), "Some Custom Status"),
+            "in_progress"
+        );
+    }
+
+    #[test]
+    fn test_priority_sort_key() {
+        assert_eq!(priority_sort_key(Some("urgent")), 1);
+        assert_eq!(priority_sort_key(Some("high")), 2);
+        assert_eq!(priority_sort_key(Some("normal")), 3);
+        assert_eq!(priority_sort_key(Some("low")), 4);
+        assert_eq!(priority_sort_key(None), 5);
     }
 
     // =========================================================================
@@ -2628,6 +2890,302 @@ mod tests {
 
             assert_eq!(issue.key, "DEV-701");
             assert_eq!(issue.parent, Some("CU-parent_id".to_string()));
+        }
+
+        #[tokio::test]
+        async fn test_get_issues_search_filter() {
+            let server = MockServer::start_async().await;
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345/task");
+                then.status(200).json_body(serde_json::json!({
+                    "tasks": [
+                        {
+                            "id": "1", "name": "Fix login bug",
+                            "description": "Authentication fails",
+                            "text_content": "Authentication fails",
+                            "status": {"status": "open", "type": "open"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/1"
+                        },
+                        {
+                            "id": "2", "name": "Add dark mode",
+                            "description": "Theme support",
+                            "text_content": "Theme support",
+                            "status": {"status": "open", "type": "open"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/2"
+                        },
+                        {
+                            "id": "3", "name": "Update docs",
+                            "description": "Fix login instructions",
+                            "text_content": "Fix login instructions",
+                            "status": {"status": "open", "type": "open"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/3"
+                        }
+                    ]
+                }));
+            });
+
+            let client = create_test_client(&server);
+
+            // Search by title
+            let issues = client
+                .get_issues(IssueFilter {
+                    search: Some("login".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+            assert_eq!(issues.len(), 2);
+            assert!(issues.iter().any(|i| i.title == "Fix login bug"));
+            assert!(issues.iter().any(|i| i.title == "Update docs")); // matches description
+
+            // Search by key
+            let issues = client
+                .get_issues(IssueFilter {
+                    search: Some("CU-2".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+            assert_eq!(issues.len(), 1);
+            assert_eq!(issues[0].title, "Add dark mode");
+
+            // Search — no matches
+            let issues = client
+                .get_issues(IssueFilter {
+                    search: Some("nonexistent".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+            assert!(issues.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_get_issues_sort_by_priority() {
+            let server = MockServer::start_async().await;
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345/task");
+                then.status(200).json_body(serde_json::json!({
+                    "tasks": [
+                        {
+                            "id": "1", "name": "Low task",
+                            "status": {"status": "open", "type": "open"},
+                            "priority": {"id": "4", "priority": "low"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/1"
+                        },
+                        {
+                            "id": "2", "name": "Urgent task",
+                            "status": {"status": "open", "type": "open"},
+                            "priority": {"id": "1", "priority": "urgent"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/2"
+                        },
+                        {
+                            "id": "3", "name": "Normal task",
+                            "status": {"status": "open", "type": "open"},
+                            "priority": {"id": "3", "priority": "normal"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/3"
+                        }
+                    ]
+                }));
+            });
+
+            let client = create_test_client(&server);
+
+            // Sort by priority descending (most urgent first)
+            let result = client
+                .get_issues(IssueFilter {
+                    sort_by: Some("priority".to_string()),
+                    sort_order: Some("asc".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            assert_eq!(result.items[0].priority, Some("urgent".to_string()));
+            assert_eq!(result.items[1].priority, Some("normal".to_string()));
+            assert_eq!(result.items[2].priority, Some("low".to_string()));
+
+            // Verify sort_info is populated
+            let sort_info = result.sort_info.unwrap();
+            assert_eq!(sort_info.sort_by, Some("priority".to_string()));
+            assert!(sort_info.available_sorts.contains(&"priority".into()));
+        }
+
+        #[tokio::test]
+        async fn test_get_issues_sort_by_title() {
+            let server = MockServer::start_async().await;
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345/task");
+                then.status(200).json_body(serde_json::json!({
+                    "tasks": [
+                        {
+                            "id": "1", "name": "Charlie",
+                            "status": {"status": "open", "type": "open"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/1"
+                        },
+                        {
+                            "id": "2", "name": "Alpha",
+                            "status": {"status": "open", "type": "open"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/2"
+                        },
+                        {
+                            "id": "3", "name": "Bravo",
+                            "status": {"status": "open", "type": "open"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/3"
+                        }
+                    ]
+                }));
+            });
+
+            let client = create_test_client(&server);
+
+            let result = client
+                .get_issues(IssueFilter {
+                    sort_by: Some("title".to_string()),
+                    sort_order: Some("asc".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            assert_eq!(result.items[0].title, "Alpha");
+            assert_eq!(result.items[1].title, "Bravo");
+            assert_eq!(result.items[2].title, "Charlie");
+        }
+
+        #[tokio::test]
+        async fn test_get_statuses_category_mapping() {
+            let server = MockServer::start_async().await;
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345");
+                then.status(200).json_body(serde_json::json!({
+                    "statuses": [
+                        {"status": "Backlog", "type": "custom", "color": "#aaa", "orderindex": 0},
+                        {"status": "To Do", "type": "open", "color": "#bbb", "orderindex": 1},
+                        {"status": "In Progress", "type": "custom", "color": "#ccc", "orderindex": 2},
+                        {"status": "In Review", "type": "custom", "color": "#ddd", "orderindex": 3},
+                        {"status": "Done", "type": "closed", "color": "#eee", "orderindex": 4},
+                        {"status": "Cancelled", "type": "custom", "color": "#fff", "orderindex": 5},
+                        {"status": "Archived", "type": "custom", "color": "#000", "orderindex": 6}
+                    ]
+                }));
+            });
+
+            let client = create_test_client(&server);
+            let statuses = client.get_statuses().await.unwrap().items;
+
+            assert_eq!(statuses.len(), 7);
+            assert_eq!(statuses[0].name, "Backlog");
+            assert_eq!(statuses[0].category, "backlog");
+            assert_eq!(statuses[1].name, "To Do");
+            assert_eq!(statuses[1].category, "todo");
+            assert_eq!(statuses[2].name, "In Progress");
+            assert_eq!(statuses[2].category, "in_progress");
+            assert_eq!(statuses[3].name, "In Review");
+            assert_eq!(statuses[3].category, "in_progress");
+            assert_eq!(statuses[4].name, "Done");
+            assert_eq!(statuses[4].category, "done");
+            assert_eq!(statuses[5].name, "Cancelled");
+            assert_eq!(statuses[5].category, "cancelled");
+            assert_eq!(statuses[6].name, "Archived");
+            assert_eq!(statuses[6].category, "cancelled");
+        }
+
+        #[tokio::test]
+        async fn test_get_issues_state_category_filter() {
+            let server = MockServer::start_async().await;
+
+            // Mock for get_statuses (called by stateCategory filter)
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345").query_param_exists("!");
+                then.status(200).json_body(serde_json::json!({
+                    "statuses": [
+                        {"status": "Backlog", "type": "custom"},
+                        {"status": "To Do", "type": "open"},
+                        {"status": "In Progress", "type": "custom"},
+                        {"status": "Done", "type": "closed"}
+                    ]
+                }));
+            });
+
+            // This exact path mock for list info (no query params)
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345");
+                then.status(200).json_body(serde_json::json!({
+                    "statuses": [
+                        {"status": "Backlog", "type": "custom"},
+                        {"status": "To Do", "type": "open"},
+                        {"status": "In Progress", "type": "custom"},
+                        {"status": "Done", "type": "closed"}
+                    ]
+                }));
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345/task");
+                then.status(200).json_body(serde_json::json!({
+                    "tasks": [
+                        {
+                            "id": "1", "name": "Backlog task",
+                            "status": {"status": "Backlog", "type": "custom"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/1"
+                        },
+                        {
+                            "id": "2", "name": "In progress task",
+                            "status": {"status": "In Progress", "type": "custom"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/2"
+                        },
+                        {
+                            "id": "3", "name": "Todo task",
+                            "status": {"status": "To Do", "type": "open"},
+                            "tags": [], "assignees": [],
+                            "url": "https://app.clickup.com/t/3"
+                        }
+                    ]
+                }));
+            });
+
+            let client = create_test_client(&server);
+
+            // Filter by in_progress category
+            let issues = client
+                .get_issues(IssueFilter {
+                    state_category: Some("in_progress".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+            assert_eq!(issues.len(), 1);
+            assert_eq!(issues[0].title, "In progress task");
+
+            // Filter by backlog category
+            let issues = client
+                .get_issues(IssueFilter {
+                    state_category: Some("backlog".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+            assert_eq!(issues.len(), 1);
+            assert_eq!(issues[0].title, "Backlog task");
         }
     }
 }

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -18,6 +18,14 @@ use crate::types::{
 /// Maximum number of tasks per page in ClickUp API.
 const PAGE_SIZE: u32 = 100;
 
+/// Percent-encode a tag name for use in ClickUp URL paths.
+fn encode_tag(tag: &str) -> String {
+    tag.replace('%', "%25")
+        .replace(' ', "%20")
+        .replace('#', "%23")
+        .replace('/', "%2F")
+}
+
 /// ClickUp API client.
 pub struct ClickUpClient {
     base_url: String,
@@ -739,16 +747,15 @@ impl IssueProvider for ClickUpClient {
         }
 
         // Labels AND operator: ClickUp API uses OR by default. For AND, post-filter.
-        if filter.labels_operator.as_deref() == Some("and") {
-            if let Some(ref required_labels) = filter.labels {
-                let required: Vec<String> =
-                    required_labels.iter().map(|l| l.to_lowercase()).collect();
-                issues.retain(|issue| {
-                    let issue_labels: Vec<String> =
-                        issue.labels.iter().map(|l| l.to_lowercase()).collect();
-                    required.iter().all(|r| issue_labels.contains(r))
-                });
-            }
+        if filter.labels_operator.as_deref() == Some("and")
+            && let Some(ref required_labels) = filter.labels
+        {
+            let required: Vec<String> = required_labels.iter().map(|l| l.to_lowercase()).collect();
+            issues.retain(|issue| {
+                let issue_labels: Vec<String> =
+                    issue.labels.iter().map(|l| l.to_lowercase()).collect();
+                required.iter().all(|r| issue_labels.contains(r))
+            });
         }
 
         // Client-side search filtering (ClickUp API has no search endpoint for tasks)
@@ -946,10 +953,83 @@ impl IssueProvider for ClickUpClient {
             status,
             priority,
             parent,
+            tags: None, // Tags updated via separate API below
         };
 
         let task: ClickUpTask = self.put(&url, &request).await?;
+
+        // Update tags via ClickUp Tag API (PUT /task ignores tags field).
+        // POST /task/{id}/tag/{name} to add, DELETE /task/{id}/tag/{name} to remove.
+        if let Some(ref new_labels) = input.labels {
+            let current_tags: Vec<String> = task.tags.iter().map(|t| t.name.clone()).collect();
+            let new_tags: Vec<String> = new_labels.iter().map(|l| l.to_lowercase()).collect();
+
+            // Remove tags not in new list
+            for tag in &current_tags {
+                if !new_tags.iter().any(|t| t.eq_ignore_ascii_case(tag)) {
+                    let tag_url =
+                        format!("{}/task/{}/tag/{}", self.base_url, task.id, encode_tag(tag));
+                    if let Err(e) = self.delete(&tag_url).await {
+                        warn!(tag = tag, error = %e, "Failed to remove tag");
+                    }
+                }
+            }
+
+            // Add tags not in current list
+            for tag in &new_tags {
+                if !current_tags.iter().any(|t| t.eq_ignore_ascii_case(tag)) {
+                    let tag_url =
+                        format!("{}/task/{}/tag/{}", self.base_url, task.id, encode_tag(tag));
+                    let resp = self
+                        .request(reqwest::Method::POST, &tag_url)
+                        .send()
+                        .await
+                        .map_err(|e| Error::Http(e.to_string()))?;
+                    if !resp.status().is_success() {
+                        warn!(
+                            tag = tag,
+                            status = resp.status().as_u16(),
+                            "Failed to add tag"
+                        );
+                    }
+                }
+            }
+
+            // Re-fetch task to get updated tags
+            let updated_task: ClickUpTask = self.get(&url).await?;
+            return Ok(map_task(&updated_task));
+        }
+
         Ok(map_task(&task))
+    }
+
+    async fn set_custom_fields(&self, issue_key: &str, fields: &[serde_json::Value]) -> Result<()> {
+        let task_id = self.resolve_to_native_id(issue_key).await?;
+        for field in fields {
+            let field_id = field["id"].as_str().unwrap_or_default();
+            if field_id.is_empty() {
+                continue;
+            }
+            let url = format!("{}/task/{}/field/{}", self.base_url, task_id, field_id);
+            let body = serde_json::json!({ "value": field["value"] });
+            let resp = self
+                .request(reqwest::Method::POST, &url)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| Error::Http(e.to_string()))?;
+            if !resp.status().is_success() {
+                let status = resp.status().as_u16();
+                let msg = resp.text().await.unwrap_or_default();
+                warn!(
+                    field_id = field_id,
+                    status = status,
+                    "Failed to set custom field: {}",
+                    msg
+                );
+            }
+        }
+        Ok(())
     }
 
     async fn get_comments(&self, issue_key: &str) -> Result<ProviderResult<Comment>> {

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -20,10 +20,7 @@ const PAGE_SIZE: u32 = 100;
 
 /// Percent-encode a tag name for use in ClickUp URL paths.
 fn encode_tag(tag: &str) -> String {
-    tag.replace('%', "%25")
-        .replace(' ', "%20")
-        .replace('#', "%23")
-        .replace('/', "%2F")
+    urlencoding::encode(tag).into_owned()
 }
 
 /// ClickUp API client.

--- a/crates/plugins/api/clickup/src/enricher.rs
+++ b/crates/plugins/api/clickup/src/enricher.rs
@@ -126,8 +126,21 @@ impl ToolEnricher for ClickUpSchemaEnricher {
             obj.insert(cf_name, goal_id);
         }
 
-        // NOTE: priority name→number conversion is handled by ClickUp client
-        // (priority_to_clickup), not here. Enricher only adds the enum to schema.
+        // Transform priority name to ClickUp numeric value (only for direct issue tools,
+        // epic tools pass priority as string to executor which handles conversion).
+        if is_issue_tool
+            && let Some(obj) = args.as_object_mut()
+            && let Some(priority) = obj.get("priority").and_then(|v| v.as_str())
+        {
+            let numeric = match priority {
+                "urgent" => 1,
+                "high" => 2,
+                "normal" => 3,
+                "low" => 4,
+                _ => 3, // default to normal
+            };
+            obj.insert("priority".into(), json!(numeric));
+        }
 
         // Transform cf_* params to customFields array
         let Some(obj) = args.as_object_mut() else {
@@ -354,7 +367,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clickup_enricher_transform_args_priority_passthrough() {
+    fn test_clickup_enricher_transform_args_priority() {
         let enricher = ClickUpSchemaEnricher::new(sample_metadata());
         let mut args = json!({
             "title": "Test",
@@ -363,8 +376,7 @@ mod tests {
 
         enricher.transform_args("create_issue", &mut args);
 
-        // Priority stays as string — ClickUp client handles name→number conversion
-        assert_eq!(args["priority"], "high");
+        assert_eq!(args["priority"], 2);
     }
 
     #[test]
@@ -449,12 +461,11 @@ mod tests {
     }
 
     #[test]
-    fn test_clickup_enricher_priority_passthrough_unknown() {
+    fn test_clickup_enricher_priority_default() {
         let enricher = ClickUpSchemaEnricher::new(sample_metadata());
         let mut args = json!({"title": "Test", "priority": "unknown_value"});
         enricher.transform_args("create_issue", &mut args);
-        // Priority stays as string — ClickUp client handles conversion
-        assert_eq!(args["priority"], "unknown_value");
+        assert_eq!(args["priority"], 3); // default to normal
     }
 
     #[test]

--- a/crates/plugins/api/clickup/src/enricher.rs
+++ b/crates/plugins/api/clickup/src/enricher.rs
@@ -126,21 +126,8 @@ impl ToolEnricher for ClickUpSchemaEnricher {
             obj.insert(cf_name, goal_id);
         }
 
-        // Transform priority name to ClickUp numeric value (only for direct issue tools,
-        // epic tools pass priority as string to executor which handles conversion).
-        if is_issue_tool
-            && let Some(obj) = args.as_object_mut()
-            && let Some(priority) = obj.get("priority").and_then(|v| v.as_str())
-        {
-            let numeric = match priority {
-                "urgent" => 1,
-                "high" => 2,
-                "normal" => 3,
-                "low" => 4,
-                _ => 3, // default to normal
-            };
-            obj.insert("priority".into(), json!(numeric));
-        }
+        // NOTE: priority name→number conversion is handled by ClickUp client
+        // (priority_to_clickup), not here. Enricher only adds the enum to schema.
 
         // Transform cf_* params to customFields array
         let Some(obj) = args.as_object_mut() else {
@@ -367,7 +354,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clickup_enricher_transform_args_priority() {
+    fn test_clickup_enricher_transform_args_priority_passthrough() {
         let enricher = ClickUpSchemaEnricher::new(sample_metadata());
         let mut args = json!({
             "title": "Test",
@@ -376,7 +363,8 @@ mod tests {
 
         enricher.transform_args("create_issue", &mut args);
 
-        assert_eq!(args["priority"], 2);
+        // Priority stays as string — ClickUp client handles name→number conversion
+        assert_eq!(args["priority"], "high");
     }
 
     #[test]
@@ -461,11 +449,12 @@ mod tests {
     }
 
     #[test]
-    fn test_clickup_enricher_priority_default() {
+    fn test_clickup_enricher_priority_passthrough_unknown() {
         let enricher = ClickUpSchemaEnricher::new(sample_metadata());
         let mut args = json!({"title": "Test", "priority": "unknown_value"});
         enricher.transform_args("create_issue", &mut args);
-        assert_eq!(args["priority"], 3); // default to normal
+        // Priority stays as string — ClickUp client handles conversion
+        assert_eq!(args["priority"], "unknown_value");
     }
 
     #[test]

--- a/crates/plugins/api/clickup/src/enricher.rs
+++ b/crates/plugins/api/clickup/src/enricher.rs
@@ -32,7 +32,7 @@ impl ClickUpSchemaEnricher {
 const REMOVE_PARAMS: &[&str] = &["issueType", "components", "projectId"];
 
 /// Parameters to remove from get_issues.
-const GET_ISSUES_REMOVE_PARAMS: &[&str] = &["projectKey", "nativeQuery", "stateCategory"];
+const GET_ISSUES_REMOVE_PARAMS: &[&str] = &["projectKey", "nativeQuery"];
 
 impl ToolEnricher for ClickUpSchemaEnricher {
     fn supported_categories(&self) -> &[ToolCategory] {
@@ -44,6 +44,20 @@ impl ToolEnricher for ClickUpSchemaEnricher {
 
         if tool_name == "get_issues" {
             schema.remove_params(GET_ISSUES_REMOVE_PARAMS);
+
+            // Add stateCategory enum for semantic status filtering
+            schema.add_enum_param(
+                "stateCategory",
+                &["backlog", "todo", "in_progress", "done", "cancelled"],
+                "Filter by semantic status category. Maps to provider-specific statuses using name heuristics.",
+            );
+
+            // Add labelsOperator enum
+            schema.add_enum_param(
+                "labelsOperator",
+                &["and", "or"],
+                "Label matching logic: 'and' requires all labels, 'or' requires any (default: 'or').",
+            );
         }
 
         // Add status enum from metadata
@@ -433,5 +447,38 @@ mod tests {
         let mut args = json!({"title": "Test", "priority": "unknown_value"});
         enricher.transform_args("create_issue", &mut args);
         assert_eq!(args["priority"], 3); // default to normal
+    }
+
+    #[test]
+    fn test_clickup_enricher_state_category_not_removed() {
+        let enricher = ClickUpSchemaEnricher::new(sample_metadata());
+        let mut schema = ToolSchema::from_json(&json!({
+            "type": "object",
+            "properties": {
+                "stateCategory": { "type": "string" },
+                "nativeQuery": { "type": "string" },
+                "projectKey": { "type": "string" },
+            },
+        }));
+
+        enricher.enrich_schema("get_issues", &mut schema);
+
+        // stateCategory should be enriched with enum, NOT removed
+        assert!(schema.properties.contains_key("stateCategory"));
+        let sc = schema.properties.get("stateCategory").unwrap();
+        assert_eq!(
+            sc.enum_values,
+            Some(vec![
+                "backlog".into(),
+                "todo".into(),
+                "in_progress".into(),
+                "done".into(),
+                "cancelled".into(),
+            ])
+        );
+
+        // These should still be removed
+        assert!(!schema.properties.contains_key("nativeQuery"));
+        assert!(!schema.properties.contains_key("projectKey"));
     }
 }

--- a/crates/plugins/api/clickup/src/enricher.rs
+++ b/crates/plugins/api/clickup/src/enricher.rs
@@ -98,20 +98,38 @@ impl ToolEnricher for ClickUpSchemaEnricher {
             schema.remove_params(&["customFields"]);
 
             for field in &self.metadata.custom_fields {
-                let param_name = sanitize_field_name(&field.name);
                 let field_schema = custom_field_to_schema(field);
+                if field_schema.is_null() {
+                    continue; // Skip unsupported field types
+                }
+                let param_name = sanitize_field_name(&field.name);
                 schema.add_param(&param_name, field_schema);
             }
         }
     }
 
     fn transform_args(&self, tool_name: &str, args: &mut Value) {
-        if tool_name != "create_issue" && tool_name != "update_issue" {
+        let is_issue_tool = tool_name == "create_issue" || tool_name == "update_issue";
+        let is_epic_tool = tool_name == "create_epic" || tool_name == "update_epic";
+
+        if !is_issue_tool && !is_epic_tool {
             return;
         }
 
-        // Transform priority name to ClickUp numeric value
-        if let Some(obj) = args.as_object_mut()
+        // For epic tools: copy goalId → cf_goals so custom field transform picks it up.
+        // Keep goalId in args — executor needs it for tag transition.
+        if is_epic_tool
+            && let Some(obj) = args.as_object_mut()
+            && let Some(goal_id) = obj.get("goalId").cloned()
+        {
+            let cf_name = sanitize_field_name("Goals");
+            obj.insert(cf_name, goal_id);
+        }
+
+        // Transform priority name to ClickUp numeric value (only for direct issue tools,
+        // epic tools pass priority as string to executor which handles conversion).
+        if is_issue_tool
+            && let Some(obj) = args.as_object_mut()
             && let Some(priority) = obj.get("priority").and_then(|v| v.as_str())
         {
             let numeric = match priority {
@@ -194,6 +212,7 @@ fn custom_field_to_schema(field: &crate::metadata::ClickUpCustomField) -> Value 
         ClickUpFieldType::Email => "email",
         ClickUpFieldType::Url => "url",
         ClickUpFieldType::Phone => "phone",
+        ClickUpFieldType::Unknown => return json!(null), // Skip unsupported field types
     };
 
     json!({

--- a/crates/plugins/api/clickup/src/metadata.rs
+++ b/crates/plugins/api/clickup/src/metadata.rs
@@ -12,7 +12,7 @@ pub struct ClickUpMetadata {
     #[serde(default)]
     pub statuses: Vec<ClickUpStatus>,
     /// Custom fields defined for the list.
-    #[serde(default)]
+    #[serde(default, alias = "customFields")]
     pub custom_fields: Vec<ClickUpCustomField>,
 }
 
@@ -33,6 +33,7 @@ pub struct ClickUpCustomField {
     /// Human-readable name.
     pub name: String,
     /// Field type.
+    #[serde(alias = "type")]
     pub field_type: ClickUpFieldType,
     /// Whether this field is required.
     #[serde(default)]
@@ -47,6 +48,7 @@ pub struct ClickUpCustomField {
 #[serde(rename_all = "snake_case")]
 pub enum ClickUpFieldType {
     /// Single select dropdown → value is name, transforms to orderindex.
+    #[serde(alias = "drop_down")]
     Dropdown,
     /// Multi-select labels → value is name array, transforms to id array.
     Labels,
@@ -66,6 +68,9 @@ pub enum ClickUpFieldType {
     Url,
     /// Phone → pass-through as string.
     Phone,
+    /// Catch-all for unknown/unsupported field types (automatic_progress, etc.)
+    #[serde(other)]
+    Unknown,
 }
 
 /// Option for dropdown/labels custom fields.

--- a/crates/plugins/api/clickup/src/types.rs
+++ b/crates/plugins/api/clickup/src/types.rs
@@ -201,6 +201,8 @@ pub struct UpdateTaskRequest {
     pub priority: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
 }
 
 /// Request body for creating a comment.


### PR DESCRIPTION
## Summary

Restores feature parity for ClickUp MCP tools that regressed during migration:

- **Search filtering**: `get_issues` now performs client-side text filtering across name, description, custom_id, id
- **stateCategory**: Re-added semantic status filter with name-based heuristic mapping (backlog, todo, in_progress, done, cancelled)
- **Epic tools**: Implemented `get_epics`, `create_epic`, `update_epic` with goal tag (G1-G9) management and subtask progress
- **Status mapping**: Uses name heuristics instead of just ClickUp's `status_type` field
- **Attachments**: `add_issue_comment` now supports file attachments via ClickUp attachment API
- **Sorting**: Client-side sorting with `provider_limitations` warning for unsupported fields
- **Labels AND logic**: `labelsOperator` post-filtering for AND semantics
- **get_issue extras**: Added `include_comments`, `include_relations` params and `subtasks_count` field

Closes #113