### PR TITLE
feat: add slack messenger provider (#84)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/plugins/api/clickup",
     "crates/plugins/api/jira",
     "crates/plugins/api/fireflies",
+    "crates/plugins/api/slack",
     # Pipeline plugins
     "crates/plugins/format-pipeline",
 ]

--- a/crates/devboy-cli/Cargo.toml
+++ b/crates/devboy-cli/Cargo.toml
@@ -20,6 +20,7 @@ devboy-gitlab = { path = "../plugins/api/gitlab" }
 devboy-clickup = { path = "../plugins/api/clickup" }
 devboy-jira = { path = "../plugins/api/jira" }
 devboy-fireflies = { path = "../plugins/api/fireflies" }
+devboy-slack = { path = "../plugins/api/slack" }
 devboy-format-pipeline = { path = "../plugins/format-pipeline" }
 tokio.workspace = true
 serde.workspace = true

--- a/crates/devboy-cli/src/doctor/checks/credentials.rs
+++ b/crates/devboy-cli/src/doctor/checks/credentials.rs
@@ -10,6 +10,7 @@ pub struct GitHubTokenCheck;
 pub struct GitLabTokenCheck;
 pub struct ClickUpTokenCheck;
 pub struct JiraTokenCheck;
+pub struct SlackTokenCheck;
 
 struct CredentialSpec {
     provider: &'static str,
@@ -159,6 +160,10 @@ fn jira_configured(context: &ContextConfig) -> bool {
     context.jira.is_some()
 }
 
+fn slack_configured(context: &ContextConfig) -> bool {
+    context.slack.is_some()
+}
+
 fn validate_github_token(token: &str) -> TokenFormat {
     let token = token.trim();
     if token.starts_with("ghp_")
@@ -202,6 +207,19 @@ fn validate_jira_token(token: &str) -> TokenFormat {
         TokenFormat::Recognized
     } else {
         TokenFormat::Suspicious("token is shorter than a typical Jira API token or credential pair")
+    }
+}
+
+fn validate_slack_token(token: &str) -> TokenFormat {
+    let token = token.trim();
+    if token.starts_with("xoxb-") {
+        TokenFormat::Recognized
+    } else if token.starts_with("xox") {
+        TokenFormat::Suspicious("expected a Slack bot token prefix like xoxb-")
+    } else if token.len() >= 20 {
+        TokenFormat::Suspicious("token does not look like a Slack OAuth token")
+    } else {
+        TokenFormat::Suspicious("token is shorter than a typical Slack bot token")
     }
 }
 
@@ -332,6 +350,39 @@ impl DiagnosticCheck for JiraTokenCheck {
             .as_ref()
             .and_then(resolve_active_provider_context)
             .is_some_and(|active| jira_configured(&active.config));
+
+        spec.build_result(self, ctx, configured)
+    }
+}
+
+#[async_trait]
+impl DiagnosticCheck for SlackTokenCheck {
+    fn id(&self) -> &'static str {
+        "credentials.slack"
+    }
+
+    fn name(&self) -> &'static str {
+        "Slack bot token available"
+    }
+
+    fn category(&self) -> &'static str {
+        "Credentials"
+    }
+
+    async fn run(&self, ctx: &DiagnosticContext) -> CheckResult {
+        let spec = CredentialSpec {
+            provider: "slack",
+            label: "Slack",
+            help_key: "slack.token",
+            format_hint: "Slack bot token (xoxb-...)",
+            validator: validate_slack_token,
+        };
+
+        let configured = ctx
+            .config
+            .as_ref()
+            .and_then(resolve_active_provider_context)
+            .is_some_and(|active| slack_configured(&active.config));
 
         spec.build_result(self, ctx, configured)
     }

--- a/crates/devboy-cli/src/doctor/checks/providers.rs
+++ b/crates/devboy-cli/src/doctor/checks/providers.rs
@@ -1,7 +1,9 @@
 use crate::doctor::checks::{resolve_active_provider_context, resolve_secret};
 use crate::doctor::{CheckResult, CheckStatus, DiagnosticCheck, DiagnosticContext};
 use async_trait::async_trait;
-use devboy_core::{ClickUpConfig, ContextConfig, GitHubConfig, GitLabConfig, JiraConfig};
+use devboy_core::{
+    ClickUpConfig, ContextConfig, GitHubConfig, GitLabConfig, JiraConfig, SlackConfig,
+};
 use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderMap, USER_AGENT};
 use reqwest::{Client, Method};
 use serde::Deserialize;
@@ -12,6 +14,7 @@ pub struct GitHubApiCheck;
 pub struct GitLabApiCheck;
 pub struct ClickUpApiCheck;
 pub struct JiraApiCheck;
+pub struct SlackApiCheck;
 
 #[derive(Debug, Clone)]
 struct RateLimitInfo {
@@ -411,6 +414,39 @@ async fn jira_connectivity(
     })
 }
 
+async fn slack_connectivity(
+    config: &SlackConfig,
+    token: &str,
+) -> Result<ConnectivityOutcome, String> {
+    let mut client =
+        devboy_slack::SlackClient::new(token).with_required_scopes(config.required_scopes.clone());
+    if let Some(base_url) = &config.base_url {
+        client = client.with_base_url(base_url);
+    }
+
+    let info = client
+        .auth_info()
+        .await
+        .map_err(|error| error.to_string())?;
+
+    if !info.missing_scopes.is_empty() {
+        return Err(format!(
+            "missing required scopes: {}",
+            info.missing_scopes.join(", ")
+        ));
+    }
+
+    Ok(ConnectivityOutcome {
+        message: format!("Slack API authenticated for workspace {}", info.team_name),
+        user: Some(ProviderIdentity {
+            username: info.user_id,
+            name: info.user_name,
+            email: None,
+        }),
+        rate_limit: None,
+    })
+}
+
 use std::pin::Pin;
 
 type ConnectFuture<'a> =
@@ -608,6 +644,32 @@ impl DiagnosticCheck for JiraApiCheck {
             "jira",
             |c| c.jira.clone(),
             |cfg, token| Box::pin(jira_connectivity(cfg, token)),
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl DiagnosticCheck for SlackApiCheck {
+    fn id(&self) -> &'static str {
+        "providers.slack"
+    }
+
+    fn name(&self) -> &'static str {
+        "Slack API connectivity"
+    }
+
+    fn category(&self) -> &'static str {
+        "Provider Connectivity"
+    }
+
+    async fn run(&self, ctx: &DiagnosticContext) -> CheckResult {
+        run_provider_check(
+            self,
+            ctx,
+            "slack",
+            |c| c.slack.clone(),
+            |cfg, token| Box::pin(slack_connectivity(cfg, token)),
         )
         .await
     }

--- a/crates/devboy-cli/src/doctor/mod.rs
+++ b/crates/devboy-cli/src/doctor/mod.rs
@@ -3,11 +3,13 @@ mod output;
 
 use self::checks::config::{ActiveContextCheck, ConfigExistsCheck, ConfigValidTomlCheck};
 use self::checks::credentials::{
-    ClickUpTokenCheck, GitHubTokenCheck, GitLabTokenCheck, JiraTokenCheck,
+    ClickUpTokenCheck, GitHubTokenCheck, GitLabTokenCheck, JiraTokenCheck, SlackTokenCheck,
 };
 use self::checks::environment::{ConfigDirCheck, CredentialStoreCheck, OsSupportCheck};
 use self::checks::mcp::McpToolsCheck;
-use self::checks::providers::{ClickUpApiCheck, GitHubApiCheck, GitLabApiCheck, JiraApiCheck};
+use self::checks::providers::{
+    ClickUpApiCheck, GitHubApiCheck, GitLabApiCheck, JiraApiCheck, SlackApiCheck,
+};
 use self::checks::proxy::ProxyServersCheck;
 use self::output::console::{print_check_list, print_report, summarize};
 use self::output::json::print_json_report;
@@ -149,10 +151,12 @@ impl CheckRegistry {
         registry.register(Box::new(GitLabTokenCheck));
         registry.register(Box::new(ClickUpTokenCheck));
         registry.register(Box::new(JiraTokenCheck));
+        registry.register(Box::new(SlackTokenCheck));
         registry.register(Box::new(GitHubApiCheck));
         registry.register(Box::new(GitLabApiCheck));
         registry.register(Box::new(ClickUpApiCheck));
         registry.register(Box::new(JiraApiCheck));
+        registry.register(Box::new(SlackApiCheck));
         registry.register(Box::new(McpToolsCheck));
         registry.register(Box::new(ProxyServersCheck));
         registry

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -15,7 +15,7 @@ use devboy_clickup::ClickUpClient;
 use devboy_core::{
     BuiltinToolsConfig, ClickUpConfig, Config, ContextConfig, GitHubConfig, GitLabConfig,
     IssueFilter, IssueProvider, JiraConfig, MergeRequestProvider, MrFilter, Provider,
-    ProxyMcpServerConfig,
+    ProxyMcpServerConfig, SlackConfig,
 };
 use devboy_github::GitHubClient;
 use devboy_gitlab::GitLabClient;
@@ -24,6 +24,7 @@ use devboy_mcp::{
     JSONRPC_VERSION, JsonRpcRequest, KNOWN_BUILTIN_TOOLS, McpProxyClient, McpServer, ProxyManager,
     ProxyTransport, RequestId,
 };
+use devboy_slack::SlackClient;
 use devboy_storage::{ChainStore, CredentialStore};
 use dialoguer::{Confirm, Input, MultiSelect, Password};
 use doctor::{DoctorOptions, OutputFormat};
@@ -179,7 +180,7 @@ enum Commands {
 
     /// Test provider connection
     Test {
-        /// Provider to test (github, gitlab, clickup, jira)
+        /// Provider to test (github, gitlab, clickup, jira, slack)
         provider: String,
     },
 
@@ -625,6 +626,7 @@ struct InitOptions {
     gitlab: Option<GitLabConfig>,
     clickup: Option<ClickUpConfig>,
     jira: Option<JiraConfig>,
+    slack: Option<SlackConfig>,
     tokens: Vec<(String, String)>, // (key, value) pairs for keychain
     proxy: Option<ProxyMcpServerConfig>,
 }
@@ -1196,6 +1198,7 @@ fn build_config(options: &InitOptions) -> Config {
         || options.gitlab.is_some()
         || options.clickup.is_some()
         || options.jira.is_some()
+        || options.slack.is_some()
     {
         let context = ContextConfig {
             github: options.github.clone(),
@@ -1203,6 +1206,7 @@ fn build_config(options: &InitOptions) -> Config {
             clickup: options.clickup.clone(),
             jira: options.jira.clone(),
             fireflies: None,
+            slack: options.slack.clone(),
         };
         config.contexts.insert(context_name, context);
     }
@@ -1437,6 +1441,32 @@ fn handle_config_command(command: ConfigCommands) -> Result<()> {
                 println!();
             }
 
+            if let Some(slack) = &config.slack {
+                println!("[slack]");
+                if let Some(team_id) = &slack.team_id {
+                    println!("  team_id = {}", team_id);
+                }
+                if let Some(workspace) = &slack.workspace {
+                    println!("  workspace = {}", workspace);
+                }
+                if let Some(base_url) = &slack.base_url {
+                    println!("  base_url = {}", base_url);
+                }
+                if let Some(client_id) = &slack.client_id {
+                    println!("  client_id = {}", client_id);
+                }
+                if let Some(redirect_uri) = &slack.redirect_uri {
+                    println!("  redirect_uri = {}", redirect_uri);
+                }
+                println!("  required_scopes = {}", slack.required_scopes.join(", "));
+                if store.exists("slack.token") {
+                    println!("  token = ******* (in keychain)");
+                } else {
+                    println!("  token = (not set)");
+                }
+                println!();
+            }
+
             if !config.has_any_provider() {
                 println!("No providers configured.");
                 println!();
@@ -1444,6 +1474,9 @@ fn handle_config_command(command: ConfigCommands) -> Result<()> {
                 println!("  devboy config set github.owner <owner>");
                 println!("  devboy config set github.repo <repo>");
                 println!("  devboy config set-secret github.token <token>");
+                println!("To configure Slack:");
+                println!("  devboy config set slack.workspace <workspace>");
+                println!("  devboy config set-secret slack.token <xoxb-token>");
             }
         }
 
@@ -1792,9 +1825,69 @@ async fn handle_test_command(provider: &str) -> Result<()> {
             }
         }
 
+        "slack" => {
+            let slack = config
+                .slack
+                .as_ref()
+                .context("Slack not configured. Run: devboy config set slack.workspace <name>")?;
+
+            let token = store
+                .get("slack.token")
+                .context("Failed to get token")?
+                .context(
+                    "Slack bot token not set. Run: devboy config set-secret slack.token <xoxb-token>",
+                )?;
+
+            println!("Testing Slack connection...");
+            if let Some(workspace) = &slack.workspace {
+                println!("  Workspace: {}", workspace);
+            }
+            if let Some(team_id) = &slack.team_id {
+                println!("  Team ID: {}", team_id);
+            }
+
+            let mut client =
+                SlackClient::new(token).with_required_scopes(slack.required_scopes.clone());
+            if let Some(base_url) = &slack.base_url {
+                client = client.with_base_url(base_url);
+            }
+
+            match client.auth_info().await {
+                Ok(info) => {
+                    println!("  Team: {} ({})", info.team_name, info.team_id);
+                    if let Some(user_name) = info.user_name.as_deref() {
+                        println!("  Authenticated as: {} ({})", info.user_id, user_name);
+                    } else {
+                        println!("  Authenticated as: {}", info.user_id);
+                    }
+                    if let Some(bot_id) = info.bot_id.as_deref() {
+                        println!("  Bot ID: {}", bot_id);
+                    }
+                    println!("  Scopes: {}", info.scopes.join(", "));
+                    if !info.missing_scopes.is_empty() {
+                        println!("  Missing scopes: {}", info.missing_scopes.join(", "));
+                        println!();
+                        println!("Slack connection failed health check!");
+                        anyhow::bail!(
+                            "Slack token is missing required scopes: {}",
+                            info.missing_scopes.join(", ")
+                        );
+                    }
+                    println!();
+                    println!("Slack connection successful!");
+                }
+                Err(e) => {
+                    println!("  Error: {}", e);
+                    println!();
+                    println!("Slack connection failed!");
+                    return Err(e.into());
+                }
+            }
+        }
+
         _ => {
             println!("Unknown provider: {}", provider);
-            println!("Supported providers: github, gitlab, clickup, jira");
+            println!("Supported providers: github, gitlab, clickup, jira, slack");
         }
     }
 
@@ -2162,6 +2255,7 @@ fn get_proxy_url_from_env(name: &str) -> Option<String> {
 /// - `DEVBOY_CONTEXTS_{NAME}_GITLAB_URL` + `_PROJECT_ID` -> GitLab provider
 /// - `DEVBOY_CONTEXTS_{NAME}_CLICKUP_LIST_ID` -> ClickUp provider
 /// - `DEVBOY_CONTEXTS_{NAME}_JIRA_URL` + `_PROJECT_KEY` + `_EMAIL` -> Jira provider
+/// - `DEVBOY_CONTEXTS_{NAME}_SLACK_WORKSPACE` or `_TEAM_ID` -> Slack provider
 ///
 /// Tokens are resolved via the credential store (which checks env vars first).
 ///
@@ -2250,7 +2344,7 @@ fn add_env_only_contexts(
 /// - "MY_PROJECT_GITLAB_URL" -> ("MY_PROJECT", "GITLAB", "URL")
 fn parse_context_env_key(key: &str) -> Option<(String, String, String)> {
     // Known provider prefixes (in order of specificity)
-    let providers = ["GITHUB", "GITLAB", "CLICKUP", "JIRA"];
+    let providers = ["GITHUB", "GITLAB", "CLICKUP", "JIRA", "SLACK"];
 
     for provider in providers {
         // Look for _PROVIDER_ in the key
@@ -2288,6 +2382,12 @@ struct EnvContextBuilder {
     jira_url: Option<String>,
     jira_project_key: Option<String>,
     jira_email: Option<String>,
+    // Slack
+    slack_team_id: Option<String>,
+    slack_workspace: Option<String>,
+    slack_base_url: Option<String>,
+    slack_client_id: Option<String>,
+    slack_redirect_uri: Option<String>,
 }
 
 impl EnvContextBuilder {
@@ -2316,6 +2416,12 @@ impl EnvContextBuilder {
             ("JIRA", "URL") => self.jira_url = Some(value),
             ("JIRA", "PROJECT_KEY") | ("JIRA", "PROJECT") => self.jira_project_key = Some(value),
             ("JIRA", "EMAIL") => self.jira_email = Some(value),
+            // Slack
+            ("SLACK", "TEAM_ID") | ("SLACK", "TEAM") => self.slack_team_id = Some(value),
+            ("SLACK", "WORKSPACE") => self.slack_workspace = Some(value),
+            ("SLACK", "BASE_URL") | ("SLACK", "URL") => self.slack_base_url = Some(value),
+            ("SLACK", "CLIENT_ID") => self.slack_client_id = Some(value),
+            ("SLACK", "REDIRECT_URI") => self.slack_redirect_uri = Some(value),
             // Unknown fields are silently ignored
             _ => {
                 tracing::debug!(
@@ -2380,6 +2486,23 @@ impl EnvContextBuilder {
             clickup,
             jira,
             fireflies: None,
+            slack: if self.slack_team_id.is_some()
+                || self.slack_workspace.is_some()
+                || self.slack_base_url.is_some()
+                || self.slack_client_id.is_some()
+                || self.slack_redirect_uri.is_some()
+            {
+                Some(SlackConfig {
+                    team_id: self.slack_team_id.clone(),
+                    workspace: self.slack_workspace.clone(),
+                    base_url: self.slack_base_url.clone(),
+                    client_id: self.slack_client_id.clone(),
+                    redirect_uri: self.slack_redirect_uri.clone(),
+                    required_scopes: devboy_core::default_slack_required_scopes(),
+                })
+            } else {
+                None
+            },
         };
 
         if context.has_any_provider() {
@@ -2489,6 +2612,24 @@ fn add_context_providers_from_env(
         } else {
             tracing::warn!(
                 "Fireflies configured for context '{}' but no API key found",
+                context_name
+            );
+        }
+    }
+
+    if let Some(slack) = &context.slack {
+        if let Some(token) = get_token_for_context(store, context_name, "slack") {
+            let mut client =
+                SlackClient::new(token).with_required_scopes(slack.required_scopes.clone());
+            if let Some(base_url) = &slack.base_url {
+                client = client.with_base_url(base_url);
+            }
+            server.add_messenger_provider(Arc::new(client));
+            tracing::info!("Added Slack provider to context '{}'", context_name);
+            added = true;
+        } else {
+            tracing::warn!(
+                "Slack configured for context '{}' but no bot token found",
                 context_name
             );
         }
@@ -2690,6 +2831,25 @@ fn add_context_providers(
         } else {
             tracing::warn!(
                 "Fireflies configured for context '{}' but no API key found",
+                context_name
+            );
+        }
+    }
+
+    if let Some(slack) = &context.slack {
+        if let Some(token) = get_token_for_context(store, context_name, "slack") {
+            let mut client =
+                SlackClient::new(token).with_required_scopes(slack.required_scopes.clone());
+            if let Some(base_url) = &slack.base_url {
+                client = client.with_base_url(base_url);
+            }
+            server.add_messenger_provider(Arc::new(client));
+            tracing::info!("Added Slack provider to context '{}'", context_name);
+            added = true;
+        } else {
+            tracing::warn!(
+                "Slack configured in context '{}' but no token found (tried contexts.{}.slack.token then slack.token)",
+                context_name,
                 context_name
             );
         }

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -2624,7 +2624,7 @@ fn add_context_providers_from_env(
             if let Some(base_url) = &slack.base_url {
                 client = client.with_base_url(base_url);
             }
-            server.add_messenger_provider(Arc::new(client));
+            server.add_messenger_provider_to_context(context_name, Arc::new(client));
             tracing::info!("Added Slack provider to context '{}'", context_name);
             added = true;
         } else {
@@ -2843,7 +2843,7 @@ fn add_context_providers(
             if let Some(base_url) = &slack.base_url {
                 client = client.with_base_url(base_url);
             }
-            server.add_messenger_provider(Arc::new(client));
+            server.add_messenger_provider_to_context(context_name, Arc::new(client));
             tracing::info!("Added Slack provider to context '{}'", context_name);
             added = true;
         } else {

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -1836,7 +1836,9 @@ async fn handle_test_command(provider: &str) -> Result<()> {
             let slack = config
                 .slack
                 .as_ref()
-                .context("Slack not configured. Run: devboy config set slack.workspace <name>")?;
+                .context(
+                    "Slack not configured. Run: devboy config set slack.team_id <team-id> or devboy config set slack.workspace <name>",
+                )?;
 
             let token = store
                 .get("slack.token")

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -473,7 +473,14 @@ async fn main() -> Result<()> {
         EnvFilter::new("info")
     };
 
-    tracing_subscriber::fmt().with_env_filter(filter).init();
+    let is_mcp_command = matches!(cli.command, Some(Commands::Mcp { .. }));
+
+    let builder = tracing_subscriber::fmt().with_env_filter(filter);
+    if is_mcp_command {
+        builder.with_writer(std::io::stderr).init();
+    } else {
+        builder.init();
+    }
 
     // Run update check in background for interactive commands (skip for mcp, upgrade, and no-command).
     // Spawned as a background task to avoid blocking CLI startup on network calls.

--- a/crates/devboy-cli/src/upgrade.rs
+++ b/crates/devboy-cli/src/upgrade.rs
@@ -254,7 +254,7 @@ fn run_managed_upgrade(install_method: &crate::update_check::InstallMethod) -> R
             .context("Failed to spawn helper process for upgrade")?;
 
         println!("\x1b[33mThe upgrade will run in the background after this process exits.\x1b[0m");
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(windows))]

--- a/crates/devboy-core/src/config.rs
+++ b/crates/devboy-core/src/config.rs
@@ -64,6 +64,10 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fireflies: Option<FirefliesConfig>,
 
+    /// Slack configuration (messenger)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slack: Option<SlackConfig>,
+
     /// Named contexts (profiles) configuration.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub contexts: BTreeMap<String, ContextConfig>,
@@ -136,6 +140,10 @@ pub struct ContextConfig {
     /// Fireflies.ai configuration (meeting notes)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fireflies: Option<FirefliesConfig>,
+
+    /// Slack configuration (messenger)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slack: Option<SlackConfig>,
 }
 
 /// GitHub provider configuration.
@@ -186,6 +194,58 @@ pub struct JiraConfig {
 pub struct FirefliesConfig {
     // API key is stored in OS keychain (key: "fireflies.token")
     // No fields needed — config just enables the provider
+}
+
+/// Slack provider configuration (messenger).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlackConfig {
+    /// Optional Slack workspace/team ID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<String>,
+    /// Optional human-readable workspace name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<String>,
+    /// Slack API base URL override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    /// OAuth app client ID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    /// OAuth redirect URI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redirect_uri: Option<String>,
+    /// Required bot scopes expected by devboy Slack integration.
+    #[serde(
+        default = "default_slack_required_scopes",
+        skip_serializing_if = "is_default_slack_required_scopes"
+    )]
+    pub required_scopes: Vec<String>,
+}
+
+impl Default for SlackConfig {
+    fn default() -> Self {
+        Self {
+            team_id: None,
+            workspace: None,
+            base_url: None,
+            client_id: None,
+            redirect_uri: None,
+            required_scopes: default_slack_required_scopes(),
+        }
+    }
+}
+
+pub fn default_slack_required_scopes() -> Vec<String> {
+    vec![
+        "channels:read".to_string(),
+        "channels:history".to_string(),
+        "chat:write".to_string(),
+        "users:read".to_string(),
+    ]
+}
+
+fn is_default_slack_required_scopes(scopes: &[String]) -> bool {
+    scopes == default_slack_required_scopes().as_slice()
 }
 
 /// Configuration for controlling which built-in tools are available.
@@ -438,6 +498,7 @@ impl Config {
             || self.clickup.is_some()
             || self.jira.is_some()
             || self.fireflies.is_some()
+            || self.slack.is_some()
             || self.contexts.values().any(ContextConfig::has_any_provider)
     }
 
@@ -455,6 +516,9 @@ impl Config {
         }
         if self.jira.is_some() {
             providers.push("jira");
+        }
+        if self.slack.is_some() {
+            providers.push("slack");
         }
         providers
     }
@@ -516,6 +580,7 @@ impl Config {
             clickup: self.clickup.clone(),
             jira: self.jira.clone(),
             fireflies: self.fireflies.clone(),
+            slack: self.slack.clone(),
         };
 
         if ctx.has_any_provider() {
@@ -608,6 +673,22 @@ impl Config {
                     }
                 }
             }
+            "slack" => {
+                let config = self.slack.get_or_insert_with(SlackConfig::default);
+                match field {
+                    "team_id" | "team" => config.team_id = Some(value.to_string()),
+                    "workspace" => config.workspace = Some(value.to_string()),
+                    "base_url" | "url" => config.base_url = Some(value.to_string()),
+                    "client_id" => config.client_id = Some(value.to_string()),
+                    "redirect_uri" => config.redirect_uri = Some(value.to_string()),
+                    _ => {
+                        return Err(Error::Config(format!(
+                            "Unknown Slack config field: {}",
+                            field
+                        )));
+                    }
+                }
+            }
             _ => {
                 return Err(Error::Config(format!("Unknown provider: {}", provider)));
             }
@@ -685,6 +766,22 @@ impl Config {
                     ))),
                 }
             }
+            "slack" => {
+                let Some(config) = &self.slack else {
+                    return Ok(None);
+                };
+                match field {
+                    "team_id" | "team" => Ok(config.team_id.clone()),
+                    "workspace" => Ok(config.workspace.clone()),
+                    "base_url" | "url" => Ok(config.base_url.clone()),
+                    "client_id" => Ok(config.client_id.clone()),
+                    "redirect_uri" => Ok(config.redirect_uri.clone()),
+                    _ => Err(Error::Config(format!(
+                        "Unknown Slack config field: {}",
+                        field
+                    ))),
+                }
+            }
             _ => Err(Error::Config(format!("Unknown provider: {}", provider))),
         }
     }
@@ -698,6 +795,7 @@ impl ContextConfig {
             || self.clickup.is_some()
             || self.jira.is_some()
             || self.fireflies.is_some()
+            || self.slack.is_some()
     }
 
     /// Return configured provider names for this context.
@@ -714,6 +812,9 @@ impl ContextConfig {
         }
         if self.jira.is_some() {
             providers.push("jira");
+        }
+        if self.slack.is_some() {
+            providers.push("slack");
         }
         providers
     }
@@ -1052,6 +1153,7 @@ mod tests {
                 email: "e".to_string(),
             }),
             fireflies: None,
+            slack: None,
             contexts: BTreeMap::new(),
             active_context: None,
             proxy_mcp_servers: Vec::new(),
@@ -1131,6 +1233,7 @@ mod tests {
             clickup: None,
             jira: None,
             fireflies: None,
+            slack: None,
             contexts: BTreeMap::new(),
             active_context: None,
             proxy_mcp_servers: Vec::new(),

--- a/crates/devboy-core/src/config.rs
+++ b/crates/devboy-core/src/config.rs
@@ -239,6 +239,12 @@ pub fn default_slack_required_scopes() -> Vec<String> {
     vec![
         "channels:read".to_string(),
         "channels:history".to_string(),
+        "groups:read".to_string(),
+        "groups:history".to_string(),
+        "im:read".to_string(),
+        "im:history".to_string(),
+        "mpim:read".to_string(),
+        "mpim:history".to_string(),
         "chat:write".to_string(),
         "users:read".to_string(),
     ]
@@ -872,6 +878,20 @@ mod tests {
         let providers = config.configured_providers();
         assert!(providers.contains(&"github"));
         assert!(providers.contains(&"gitlab"));
+    }
+
+    #[test]
+    fn test_default_slack_required_scopes_cover_default_conversation_types() {
+        let scopes = default_slack_required_scopes();
+
+        assert!(scopes.contains(&"channels:read".to_string()));
+        assert!(scopes.contains(&"channels:history".to_string()));
+        assert!(scopes.contains(&"groups:read".to_string()));
+        assert!(scopes.contains(&"groups:history".to_string()));
+        assert!(scopes.contains(&"im:read".to_string()));
+        assert!(scopes.contains(&"im:history".to_string()));
+        assert!(scopes.contains(&"mpim:read".to_string()));
+        assert!(scopes.contains(&"mpim:history".to_string()));
     }
 
     #[test]

--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -58,5 +58,5 @@ pub use tool_category::ToolCategory;
 pub use config::{
     BuiltinToolsConfig, ClickUpConfig, Config, ContextConfig, FirefliesConfig,
     FormatPipelineConfig, GitHubConfig, GitLabConfig, JiraConfig, ProxyMatchingConfig,
-    ProxyMcpServerConfig,
+    ProxyMcpServerConfig, SlackConfig, default_slack_required_scopes,
 };

--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! This crate provides the foundational abstractions used across all devboy components:
 //!
-//! - **Provider traits**: [`IssueProvider`], [`MergeRequestProvider`], [`Provider`]
-//! - **Unified types**: [`Issue`], [`MergeRequest`], [`Discussion`], [`Comment`], [`FileDiff`]
+//! - **Provider traits**: [`IssueProvider`], [`MergeRequestProvider`], [`MessengerProvider`], [`Provider`]
+//! - **Unified types**: [`Issue`], [`MergeRequest`], [`MessengerChat`], [`MessengerMessage`], [`Discussion`], [`Comment`], [`FileDiff`]
 //! - **Configuration**: [`Config`], [`GitHubConfig`], [`GitLabConfig`]
 //! - **Error handling**: [`Error`], [`Result`]
 //!
@@ -34,17 +34,20 @@ pub use error::{Error, Result};
 
 // Re-export provider traits
 pub use provider::{
-    IssueProvider, MeetingNotesProvider, MergeRequestProvider, PipelineProvider, Provider,
+    IssueProvider, MeetingNotesProvider, MergeRequestProvider, MessengerProvider, PipelineProvider,
+    Provider,
 };
 
 // Re-export all types
 pub use types::{
     CodePosition, Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput,
-    Discussion, FailedJob, FileDiff, GetPipelineInput, GetUsersOptions, Issue, IssueFilter,
-    IssueLink, IssueRelations, IssueStatus, JobLogMode, JobLogOptions, JobLogOutput, MeetingFilter,
-    MeetingNote, MeetingSpeaker, MeetingTranscript, MergeRequest, MrFilter, Pagination,
-    PipelineInfo, PipelineJob, PipelineStage, PipelineStatus, PipelineSummary, ProviderResult,
-    Release, ReleaseAsset, SortInfo, SortOrder, TranscriptSentence, UpdateIssueInput, User,
+    Discussion, FailedJob, FileDiff, GetChatsParams, GetMessagesParams, GetPipelineInput,
+    GetUsersOptions, Issue, IssueFilter, IssueLink, IssueRelations, IssueStatus, JobLogMode,
+    JobLogOptions, JobLogOutput, MeetingFilter, MeetingNote, MeetingSpeaker, MeetingTranscript,
+    MergeRequest, MessageAttachment, MessageAuthor, MessengerChat, MessengerMessage, MrFilter,
+    Pagination, PipelineInfo, PipelineJob, PipelineStage, PipelineStatus, PipelineSummary,
+    ProviderResult, Release, ReleaseAsset, SearchMessagesParams, SendMessageParams, SortInfo,
+    SortOrder, TranscriptSentence, UpdateIssueInput, User,
 };
 
 // Re-export enricher traits and utilities

--- a/crates/devboy-core/src/provider.rs
+++ b/crates/devboy-core/src/provider.rs
@@ -8,9 +8,10 @@ use async_trait::async_trait;
 use crate::error::{Error, Result};
 use crate::types::{
     Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, Discussion, FileDiff,
-    GetPipelineInput, GetUsersOptions, Issue, IssueFilter, IssueRelations, IssueStatus,
-    JobLogOptions, JobLogOutput, MeetingFilter, MeetingNote, MeetingTranscript, MergeRequest,
-    MrFilter, PipelineInfo, ProviderResult, Release, UpdateIssueInput, User,
+    GetChatsParams, GetMessagesParams, GetPipelineInput, GetUsersOptions, Issue, IssueFilter,
+    IssueRelations, IssueStatus, JobLogOptions, JobLogOutput, MeetingFilter, MeetingNote,
+    MeetingTranscript, MergeRequest, MessengerChat, MessengerMessage, MrFilter, PipelineInfo,
+    ProviderResult, Release, SearchMessagesParams, SendMessageParams, UpdateIssueInput, User,
 };
 
 /// Provider for working with issues.
@@ -237,4 +238,31 @@ pub trait MeetingNotesProvider: Send + Sync {
         query: &str,
         filter: MeetingFilter,
     ) -> Result<ProviderResult<MeetingNote>>;
+}
+
+/// Provider for team messenger systems.
+///
+/// Implementations include Slack.
+#[async_trait]
+pub trait MessengerProvider: Send + Sync {
+    /// Get the provider name for logging (e.g. "slack").
+    fn provider_name(&self) -> &'static str;
+
+    /// Get available chats, channels, groups, or DMs.
+    async fn get_chats(&self, params: GetChatsParams) -> Result<ProviderResult<MessengerChat>>;
+
+    /// Get message history for a specific chat.
+    async fn get_messages(
+        &self,
+        params: GetMessagesParams,
+    ) -> Result<ProviderResult<MessengerMessage>>;
+
+    /// Search messages across chats.
+    async fn search_messages(
+        &self,
+        params: SearchMessagesParams,
+    ) -> Result<ProviderResult<MessengerMessage>>;
+
+    /// Send a message to a chat or thread.
+    async fn send_message(&self, params: SendMessageParams) -> Result<MessengerMessage>;
 }

--- a/crates/devboy-core/src/tool_category.rs
+++ b/crates/devboy-core/src/tool_category.rs
@@ -30,4 +30,8 @@ pub enum ToolCategory {
     /// Meeting notes tools: transcripts, summaries, search.
     /// Providers: Fireflies
     MeetingNotes,
+
+    /// Messenger tools: chats, messages, search, sending.
+    /// Providers: Slack
+    Messenger,
 }

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -923,3 +923,158 @@ pub struct MeetingFilter {
     /// Skip N results
     pub skip: Option<u32>,
 }
+
+// =============================================================================
+// Messenger
+// =============================================================================
+
+/// Chat type in a messenger provider.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatType {
+    /// One-to-one direct message.
+    Direct,
+    /// Multi-user private conversation.
+    Group,
+    /// Public or private channel-like room.
+    #[default]
+    Channel,
+}
+
+/// Unified messenger chat/channel representation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MessengerChat {
+    /// Provider-specific chat ID.
+    pub id: String,
+    /// Stable display key for the chat.
+    pub key: String,
+    /// Human-readable chat name.
+    pub name: String,
+    /// Kind of chat.
+    pub chat_type: ChatType,
+    /// Source provider name (e.g. "slack").
+    pub source: String,
+    /// Number of members when available.
+    pub member_count: Option<u32>,
+    /// Optional chat/topic description.
+    pub description: Option<String>,
+    /// Whether the chat is currently active / not archived.
+    pub is_active: bool,
+}
+
+/// Author metadata for a messenger message.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MessageAuthor {
+    /// Provider-specific user ID.
+    pub id: String,
+    /// Display name.
+    pub name: String,
+    /// Username/handle when available.
+    pub username: Option<String>,
+    /// Avatar URL.
+    pub avatar_url: Option<String>,
+}
+
+/// Attached file, link, or rich object on a message.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MessageAttachment {
+    /// Provider-specific attachment ID when available.
+    pub id: Option<String>,
+    /// Attachment title or filename.
+    pub name: Option<String>,
+    /// Attachment type/kind (e.g. "file", "image", "link").
+    pub attachment_type: Option<String>,
+    /// Direct or canonical URL.
+    pub url: Option<String>,
+    /// Optional mime type.
+    pub mime_type: Option<String>,
+}
+
+/// Unified messenger message representation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MessengerMessage {
+    /// Provider-specific message ID.
+    pub id: String,
+    /// Chat ID this message belongs to.
+    pub chat_id: String,
+    /// Message text/body.
+    pub text: String,
+    /// Message author.
+    pub author: MessageAuthor,
+    /// Source provider name (e.g. "slack").
+    pub source: String,
+    /// Message timestamp (ISO 8601 or provider timestamp string).
+    pub timestamp: String,
+    /// Parent thread identifier when this message is in a thread.
+    pub thread_id: Option<String>,
+    /// Direct parent/replied-to message identifier when available.
+    pub reply_to_id: Option<String>,
+    /// Attachments associated with the message.
+    pub attachments: Vec<MessageAttachment>,
+    /// Whether the message was edited after creation.
+    pub is_edited: bool,
+}
+
+/// Parameters for listing available messenger chats.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GetChatsParams {
+    /// Optional free-text search/filter for chat names.
+    pub search: Option<String>,
+    /// Restrict to a specific chat type.
+    pub chat_type: Option<ChatType>,
+    /// Maximum number of results to return.
+    pub limit: Option<u32>,
+    /// Cursor/token for provider pagination.
+    pub cursor: Option<String>,
+    /// Include inactive/archived chats.
+    pub include_inactive: Option<bool>,
+}
+
+/// Parameters for reading message history from a chat.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GetMessagesParams {
+    /// Chat/channel ID to fetch from.
+    pub chat_id: String,
+    /// Maximum number of messages to return.
+    pub limit: Option<u32>,
+    /// Cursor/token for provider pagination.
+    pub cursor: Option<String>,
+    /// Optional thread identifier to fetch replies for a thread.
+    pub thread_id: Option<String>,
+    /// Only include messages after this timestamp/date.
+    pub since: Option<String>,
+    /// Only include messages before this timestamp/date.
+    pub until: Option<String>,
+}
+
+/// Parameters for cross-chat message search.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SearchMessagesParams {
+    /// Search query/keyword.
+    pub query: String,
+    /// Restrict search to a specific chat.
+    pub chat_id: Option<String>,
+    /// Maximum number of matches to return.
+    pub limit: Option<u32>,
+    /// Cursor/token for provider pagination.
+    pub cursor: Option<String>,
+    /// Only include messages after this timestamp/date.
+    pub since: Option<String>,
+    /// Only include messages before this timestamp/date.
+    pub until: Option<String>,
+}
+
+/// Parameters for sending a new message.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SendMessageParams {
+    /// Destination chat/channel ID.
+    pub chat_id: String,
+    /// Message body text.
+    pub text: String,
+    /// Optional thread identifier to post as a threaded reply.
+    pub thread_id: Option<String>,
+    /// Optional direct parent message ID when supported.
+    pub reply_to_id: Option<String>,
+    /// Optional attachments to include or reference.
+    pub attachments: Vec<MessageAttachment>,
+}

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -1054,9 +1054,9 @@ pub struct GetMessagesParams {
     pub cursor: Option<String>,
     /// Optional thread identifier to fetch replies for a thread.
     pub thread_id: Option<String>,
-    /// Only include messages after this timestamp/date.
+    /// Only include messages after this provider timestamp string.
     pub since: Option<String>,
-    /// Only include messages before this timestamp/date.
+    /// Only include messages before this provider timestamp string.
     pub until: Option<String>,
 }
 
@@ -1071,9 +1071,9 @@ pub struct SearchMessagesParams {
     pub limit: Option<u32>,
     /// Cursor/token for provider pagination.
     pub cursor: Option<String>,
-    /// Only include messages after this timestamp/date.
+    /// Only include messages after this provider timestamp string.
     pub since: Option<String>,
-    /// Only include messages before this timestamp/date.
+    /// Only include messages before this provider timestamp string.
     pub until: Option<String>,
 }
 

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -384,6 +384,9 @@ pub struct Pagination {
     pub total: Option<u32>,
     /// Whether there are more items
     pub has_more: bool,
+    /// Provider pagination cursor/token for fetching the next page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 // =============================================================================
@@ -580,6 +583,7 @@ mod tests {
             limit: 10,
             total: Some(100),
             has_more: true,
+            next_cursor: Some("cursor-1".into()),
         };
         let result = ProviderResult::new(vec!["a", "b"]).with_pagination(pagination);
         assert_eq!(result.items, vec!["a", "b"]);
@@ -588,6 +592,7 @@ mod tests {
         assert!(pag.has_more);
         assert_eq!(pag.offset, 0);
         assert_eq!(pag.limit, 10);
+        assert_eq!(pag.next_cursor.as_deref(), Some("cursor-1"));
     }
 
     #[test]
@@ -622,6 +627,7 @@ mod tests {
                 limit: 5,
                 total: Some(50),
                 has_more: true,
+                next_cursor: Some("cursor-2".into()),
             })
             .with_sort_info(SortInfo {
                 sort_by: Some("priority".into()),
@@ -631,6 +637,13 @@ mod tests {
         assert!(result.pagination.is_some());
         assert!(result.sort_info.is_some());
         assert_eq!(result.items, vec!["x"]);
+        assert_eq!(
+            result
+                .pagination
+                .as_ref()
+                .and_then(|pagination| pagination.next_cursor.as_deref()),
+            Some("cursor-2")
+        );
     }
 }
 

--- a/crates/devboy-executor/Cargo.toml
+++ b/crates/devboy-executor/Cargo.toml
@@ -14,6 +14,7 @@ devboy-github = { path = "../plugins/api/github" }
 devboy-clickup = { path = "../plugins/api/clickup" }
 devboy-jira = { path = "../plugins/api/jira" }
 devboy-fireflies = { path = "../plugins/api/fireflies" }
+devboy-slack = { path = "../plugins/api/slack" }
 devboy-format-pipeline = { path = "../plugins/format-pipeline" }
 
 tokio.workspace = true

--- a/crates/devboy-executor/src/context.rs
+++ b/crates/devboy-executor/src/context.rs
@@ -39,6 +39,13 @@ pub enum JiraScope {
     MultiProject { keys: Vec<String> },
 }
 
+/// Scope for Slack API calls.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SlackScope {
+    /// Single Slack workspace/team.
+    Workspace { team_id: Option<String> },
+}
+
 /// Provider connection configuration with typed scope.
 ///
 /// Each variant carries only the fields relevant to that provider.
@@ -83,6 +90,16 @@ pub enum ProviderConfig {
         #[serde(default)]
         extra: HashMap<String, serde_json::Value>,
     },
+    /// Slack messenger provider.
+    Slack {
+        base_url: String,
+        access_token: String,
+        scope: SlackScope,
+        #[serde(default)]
+        required_scopes: Vec<String>,
+        #[serde(default)]
+        extra: HashMap<String, serde_json::Value>,
+    },
     /// Fully dynamic variant for community/custom provider plugins.
     Custom {
         name: String,
@@ -99,6 +116,7 @@ impl ProviderConfig {
             Self::ClickUp { .. } => "clickup",
             Self::Jira { .. } => "jira",
             Self::Fireflies { .. } => "fireflies",
+            Self::Slack { .. } => "slack",
             Self::Custom { name, .. } => name,
         }
     }

--- a/crates/devboy-executor/src/factory.rs
+++ b/crates/devboy-executor/src/factory.rs
@@ -1,8 +1,8 @@
-use devboy_core::{Error, MeetingNotesProvider, Provider, Result, ToolEnricher};
+use devboy_core::{Error, MeetingNotesProvider, MessengerProvider, Provider, Result, ToolEnricher};
 
 use crate::context::{
     ClickUpScope, GitHubScope, GitLabScope, JiraScope, ProviderConfig, ProviderMetadata,
-    ProxyConfig,
+    ProxyConfig, SlackScope,
 };
 
 /// Create a provider instance from a typed `ProviderConfig`.
@@ -112,6 +112,11 @@ pub fn create_provider(
             operation: "Fireflies is a MeetingNotesProvider, not a Provider. Use create_meeting_notes_provider() instead.".into(),
         }),
 
+        ProviderConfig::Slack { .. } => Err(Error::ProviderUnsupported {
+            provider: "slack".into(),
+            operation: "Slack is a MessengerProvider, not a Provider. Use create_messenger_provider() instead.".into(),
+        }),
+
         ProviderConfig::Custom { name, .. } => Err(Error::ProviderNotFound(format!(
             "custom provider '{name}' not yet supported"
         ))),
@@ -132,6 +137,27 @@ pub fn create_meeting_notes_provider(
         other => Err(Error::ProviderUnsupported {
             provider: other.provider_name().into(),
             operation: "not a meeting notes provider".into(),
+        }),
+    }
+}
+
+/// Create a messenger provider from config.
+pub fn create_messenger_provider(config: &ProviderConfig) -> Result<Box<dyn MessengerProvider>> {
+    match config {
+        ProviderConfig::Slack {
+            base_url,
+            access_token,
+            scope: SlackScope::Workspace { .. },
+            required_scopes,
+            ..
+        } => Ok(Box::new(
+            devboy_slack::SlackClient::new(access_token)
+                .with_base_url(base_url)
+                .with_required_scopes(required_scopes.clone()),
+        )),
+        other => Err(Error::ProviderUnsupported {
+            provider: other.provider_name().into(),
+            operation: "not a messenger provider".into(),
         }),
     }
 }
@@ -166,6 +192,7 @@ pub fn create_enricher(
         ProviderConfig::Fireflies { .. } => {
             Some(Box::new(devboy_fireflies::FirefliesSchemaEnricher))
         }
+        ProviderConfig::Slack { .. } => None,
         ProviderConfig::Custom { .. } => None,
     }
 }

--- a/crates/devboy-executor/src/output.rs
+++ b/crates/devboy-executor/src/output.rs
@@ -293,6 +293,7 @@ mod tests {
                 limit: 10,
                 total: Some(50),
                 has_more: true,
+                next_cursor: None,
             }),
             sort_info: Some(devboy_core::SortInfo {
                 sort_by: Some("created_at".into()),

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -1992,9 +1992,13 @@ impl ToolHandler {
             return ToolCallResult::error("No messenger providers configured".to_string());
         }
 
-        let params: GetMessengerChatsParams = arguments
-            .map(|value| serde_json::from_value(value).unwrap_or_default())
-            .unwrap_or_default();
+        let params: GetMessengerChatsParams = match arguments {
+            Some(value) => match serde_json::from_value(value) {
+                Ok(params) => params,
+                Err(e) => return ToolCallResult::error(format!("Invalid params: {e}")),
+            },
+            None => GetMessengerChatsParams::default(),
+        };
 
         let request = GetChatsParams {
             search: params.search,

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -2258,9 +2258,10 @@ fn format_messenger_messages(
 }
 
 fn format_single_messenger_message(message: &devboy_core::MessengerMessage) -> String {
+    let text = message.text.replace('\r', "\\r").replace('\n', "\\n");
     let mut line = format!(
         "- [{}] {} ({}) in `{}`: {}",
-        message.timestamp, message.author.name, message.author.id, message.chat_id, message.text
+        message.timestamp, message.author.name, message.author.id, message.chat_id, text
     );
     if let Some(thread_id) = message.thread_id.as_deref() {
         line.push_str(&format!(" thread=`{}`", thread_id));
@@ -3409,6 +3410,30 @@ mod tests {
 
         assert!(output.contains("hello"));
         assert!(output.contains("next_cursor=`msg-cursor-1`"));
+    }
+
+    #[test]
+    fn test_format_single_messenger_message_escapes_newlines() {
+        let output = format_single_messenger_message(&devboy_core::MessengerMessage {
+            id: "1710000000.000100".into(),
+            chat_id: "C123".into(),
+            text: "hello\nworld\r\nnext".into(),
+            author: devboy_core::MessageAuthor {
+                id: "U123".into(),
+                name: "Andrey".into(),
+                username: Some("andrey".into()),
+                avatar_url: None,
+            },
+            source: "slack".into(),
+            timestamp: "1710000000.000100".into(),
+            thread_id: None,
+            reply_to_id: None,
+            attachments: vec![],
+            is_edited: false,
+        });
+
+        assert!(output.contains("hello\\nworld\\r\\nnext"));
+        assert!(!output.contains("hello\nworld"));
     }
 
     #[tokio::test]

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -2007,7 +2007,12 @@ impl ToolHandler {
         let mut last_error: Option<String> = None;
         for provider in &self.messenger_providers {
             match provider.get_chats(request.clone()).await {
-                Ok(result) => return ToolCallResult::text(format_messenger_chats(&result.items)),
+                Ok(result) => {
+                    return ToolCallResult::text(format_messenger_chats(
+                        &result.items,
+                        result.pagination.as_ref(),
+                    ));
+                }
                 Err(e) => {
                     tracing::warn!(
                         "Messenger provider {} failed: {}",
@@ -2050,7 +2055,10 @@ impl ToolHandler {
         for provider in &self.messenger_providers {
             match provider.get_messages(request.clone()).await {
                 Ok(result) => {
-                    return ToolCallResult::text(format_messenger_messages(&result.items));
+                    return ToolCallResult::text(format_messenger_messages(
+                        &result.items,
+                        result.pagination.as_ref(),
+                    ));
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -2094,7 +2102,10 @@ impl ToolHandler {
         for provider in &self.messenger_providers {
             match provider.search_messages(request.clone()).await {
                 Ok(result) => {
-                    return ToolCallResult::text(format_messenger_messages(&result.items));
+                    return ToolCallResult::text(format_messenger_messages(
+                        &result.items,
+                        result.pagination.as_ref(),
+                    ));
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -2193,9 +2204,12 @@ impl ToolHandler {
     }
 }
 
-fn format_messenger_chats(chats: &[devboy_core::MessengerChat]) -> String {
+fn format_messenger_chats(
+    chats: &[devboy_core::MessengerChat],
+    pagination: Option<&devboy_core::Pagination>,
+) -> String {
     if chats.is_empty() {
-        return "No chats found.".to_string();
+        return format_messenger_pagination("No chats found.".to_string(), pagination);
     }
 
     let mut output = format!("# Messenger Chats ({})\n\n", chats.len());
@@ -2220,12 +2234,15 @@ fn format_messenger_chats(chats: &[devboy_core::MessengerChat]) -> String {
             description
         ));
     }
-    output
+    format_messenger_pagination(output, pagination)
 }
 
-fn format_messenger_messages(messages: &[devboy_core::MessengerMessage]) -> String {
+fn format_messenger_messages(
+    messages: &[devboy_core::MessengerMessage],
+    pagination: Option<&devboy_core::Pagination>,
+) -> String {
     if messages.is_empty() {
-        return "No messages found.".to_string();
+        return format_messenger_pagination("No messages found.".to_string(), pagination);
     }
 
     let mut output = format!("# Messages ({})\n\n", messages.len());
@@ -2233,7 +2250,7 @@ fn format_messenger_messages(messages: &[devboy_core::MessengerMessage]) -> Stri
         output.push_str(&format_single_messenger_message(message));
         output.push('\n');
     }
-    output
+    format_messenger_pagination(output, pagination)
 }
 
 fn format_single_messenger_message(message: &devboy_core::MessengerMessage) -> String {
@@ -2248,6 +2265,26 @@ fn format_single_messenger_message(message: &devboy_core::MessengerMessage) -> S
         line.push_str(&format!(" attachments={}", message.attachments.len()));
     }
     line
+}
+
+fn format_messenger_pagination(
+    mut output: String,
+    pagination: Option<&devboy_core::Pagination>,
+) -> String {
+    let Some(pagination) = pagination else {
+        return output;
+    };
+
+    if pagination.has_more || pagination.next_cursor.is_some() {
+        output.push_str("\nPagination:");
+        output.push_str(&format!(" has_more={}", pagination.has_more));
+        if let Some(cursor) = pagination.next_cursor.as_deref() {
+            output.push_str(&format!(" next_cursor=`{}`", cursor));
+        }
+        output.push('\n');
+    }
+
+    output
 }
 
 // =============================================================================
@@ -3309,6 +3346,65 @@ mod tests {
             crate::protocol::ToolResultContent::Text { text } => text,
         };
         assert!(content.contains("Missing required parameter: key"));
+    }
+
+    #[test]
+    fn test_format_messenger_chats_includes_next_cursor() {
+        let output = format_messenger_chats(
+            &[devboy_core::MessengerChat {
+                id: "C123".into(),
+                key: "slack:C123".into(),
+                name: "engineering".into(),
+                chat_type: devboy_core::types::ChatType::Channel,
+                source: "slack".into(),
+                member_count: Some(4),
+                description: Some("Team chat".into()),
+                is_active: true,
+            }],
+            Some(&devboy_core::Pagination {
+                offset: 0,
+                limit: 1,
+                total: None,
+                has_more: true,
+                next_cursor: Some("chat-cursor-1".into()),
+            }),
+        );
+
+        assert!(output.contains("engineering"));
+        assert!(output.contains("next_cursor=`chat-cursor-1`"));
+    }
+
+    #[test]
+    fn test_format_messenger_messages_includes_next_cursor() {
+        let output = format_messenger_messages(
+            &[devboy_core::MessengerMessage {
+                id: "1710000000.000100".into(),
+                chat_id: "C123".into(),
+                text: "hello".into(),
+                author: devboy_core::MessageAuthor {
+                    id: "U123".into(),
+                    name: "Andrey".into(),
+                    username: Some("andrey".into()),
+                    avatar_url: None,
+                },
+                source: "slack".into(),
+                timestamp: "1710000000.000100".into(),
+                thread_id: None,
+                reply_to_id: None,
+                attachments: vec![],
+                is_edited: false,
+            }],
+            Some(&devboy_core::Pagination {
+                offset: 0,
+                limit: 1,
+                total: None,
+                has_more: true,
+                next_cursor: Some("msg-cursor-1".into()),
+            }),
+        );
+
+        assert!(output.contains("hello"));
+        assert!(output.contains("next_cursor=`msg-cursor-1`"));
     }
 
     #[tokio::test]

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -19,11 +19,15 @@ pub enum ToolCategory {
     MergeRequests,
     /// Tools that require a meeting notes provider (Fireflies).
     MeetingNotes,
+    /// Tools that require a messenger provider (Slack).
+    Messenger,
 }
 
+use devboy_core::types::ChatType;
 use devboy_core::{
-    CodePosition, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, IssueFilter,
-    IssueProvider, MergeRequestProvider, MrFilter, Provider, UpdateIssueInput,
+    CodePosition, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, GetChatsParams,
+    GetMessagesParams, IssueFilter, IssueProvider, MergeRequestProvider, MrFilter, Provider,
+    SearchMessagesParams, SendMessageParams, UpdateIssueInput,
 };
 use devboy_format_pipeline::{OutputFormat, Pipeline, PipelineConfig};
 use serde::{Deserialize, Serialize};
@@ -700,6 +704,140 @@ define_tools! {
             },
             "required": ["query"]
         }
+    },
+
+    "get_messenger_chats" => handle_get_messenger_chats {
+        category: ToolCategory::Messenger,
+        description: "List available messenger chats, channels, groups, or direct messages.",
+        schema: {
+            "type": "object",
+            "properties": {
+                "search": {
+                    "type": "string",
+                    "description": "Optional chat name search"
+                },
+                "chat_type": {
+                    "type": "string",
+                    "enum": ["direct", "group", "channel"],
+                    "description": "Optional chat type filter"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of chats to return",
+                    "minimum": 1,
+                    "maximum": 1000
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Provider pagination cursor"
+                },
+                "include_inactive": {
+                    "type": "boolean",
+                    "description": "Include archived or inactive chats"
+                }
+            }
+        }
+    },
+
+    "get_chat_messages" => handle_get_chat_messages {
+        category: ToolCategory::Messenger,
+        description: "Get message history for a chat or fetch replies for a specific thread.",
+        schema: {
+            "type": "object",
+            "properties": {
+                "chat_id": {
+                    "type": "string",
+                    "description": "Messenger chat ID"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of messages to return",
+                    "minimum": 1,
+                    "maximum": 1000
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Provider pagination cursor"
+                },
+                "thread_id": {
+                    "type": "string",
+                    "description": "Thread identifier to fetch replies for"
+                },
+                "since": {
+                    "type": "string",
+                    "description": "Only include messages after this provider timestamp"
+                },
+                "until": {
+                    "type": "string",
+                    "description": "Only include messages before this provider timestamp"
+                }
+            },
+            "required": ["chat_id"]
+        }
+    },
+
+    "search_chat_messages" => handle_search_chat_messages {
+        category: ToolCategory::Messenger,
+        description: "Search messages across accessible chats or within a specific chat.",
+        schema: {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Message search query"
+                },
+                "chat_id": {
+                    "type": "string",
+                    "description": "Optional chat ID to scope the search"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of matches to return",
+                    "minimum": 1,
+                    "maximum": 1000
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Provider pagination cursor"
+                },
+                "since": {
+                    "type": "string",
+                    "description": "Only include messages after this provider timestamp"
+                },
+                "until": {
+                    "type": "string",
+                    "description": "Only include messages before this provider timestamp"
+                }
+            },
+            "required": ["query"]
+        }
+    },
+
+    "send_message" => handle_send_message {
+        category: ToolCategory::Messenger,
+        description: "Send a message to a chat or as a threaded reply.",
+        schema: {
+            "type": "object",
+            "properties": {
+                "chat_id": {
+                    "type": "string",
+                    "description": "Messenger chat ID"
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Message body"
+                },
+                "thread_id": {
+                    "type": "string",
+                    "description": "Optional thread identifier for replies"
+                },
+                "reply_to_id": {
+                    "type": "string",
+                    "description": "Optional provider-specific parent message ID"
+                }
+            },
+            "required": ["chat_id", "text"]
+        }
     };
 
     // Context management (handled by McpServer, not ToolHandler)
@@ -715,6 +853,7 @@ fn get_provider_name(provider: &dyn Provider) -> &'static str {
 pub struct ToolHandler {
     providers: Vec<Arc<dyn Provider>>,
     meeting_providers: Vec<Arc<dyn devboy_core::MeetingNotesProvider>>,
+    messenger_providers: Vec<Arc<dyn devboy_core::MessengerProvider>>,
     pipeline_config: PipelineConfig,
 }
 
@@ -724,6 +863,7 @@ impl ToolHandler {
         Self {
             providers,
             meeting_providers: Vec::new(),
+            messenger_providers: Vec::new(),
             pipeline_config: PipelineConfig::default(),
         }
     }
@@ -737,6 +877,15 @@ impl ToolHandler {
         self
     }
 
+    /// Add messenger providers (e.g., Slack).
+    pub fn with_messenger_providers(
+        mut self,
+        providers: Vec<Arc<dyn devboy_core::MessengerProvider>>,
+    ) -> Self {
+        self.messenger_providers = providers;
+        self
+    }
+
     /// Create with custom pipeline configuration.
     pub fn with_pipeline_config(mut self, config: PipelineConfig) -> Self {
         self.pipeline_config = config;
@@ -746,6 +895,11 @@ impl ToolHandler {
     /// Check if meeting notes providers are configured.
     pub fn has_meeting_providers(&self) -> bool {
         !self.meeting_providers.is_empty()
+    }
+
+    /// Check if messenger providers are configured.
+    pub fn has_messenger_providers(&self) -> bool {
+        !self.messenger_providers.is_empty()
     }
 
     // =========================================================================
@@ -1830,6 +1984,178 @@ impl ToolHandler {
     }
 
     // =========================================================================
+    // MESSENGER HANDLERS
+    // =========================================================================
+
+    async fn handle_get_messenger_chats(&self, arguments: Option<Value>) -> ToolCallResult {
+        if self.messenger_providers.is_empty() {
+            return ToolCallResult::error("No messenger providers configured".to_string());
+        }
+
+        let params: GetMessengerChatsParams = arguments
+            .map(|value| serde_json::from_value(value).unwrap_or_default())
+            .unwrap_or_default();
+
+        let request = GetChatsParams {
+            search: params.search,
+            chat_type: params.chat_type,
+            limit: params.limit,
+            cursor: params.cursor,
+            include_inactive: params.include_inactive,
+        };
+
+        let mut last_error: Option<String> = None;
+        for provider in &self.messenger_providers {
+            match provider.get_chats(request.clone()).await {
+                Ok(result) => return ToolCallResult::text(format_messenger_chats(&result.items)),
+                Err(e) => {
+                    tracing::warn!(
+                        "Messenger provider {} failed: {}",
+                        provider.provider_name(),
+                        e
+                    );
+                    last_error = Some(format!("{}: {}", provider.provider_name(), e));
+                }
+            }
+        }
+
+        ToolCallResult::error(
+            last_error.unwrap_or_else(|| "No messenger providers configured".to_string()),
+        )
+    }
+
+    async fn handle_get_chat_messages(&self, arguments: Option<Value>) -> ToolCallResult {
+        if self.messenger_providers.is_empty() {
+            return ToolCallResult::error("No messenger providers configured".to_string());
+        }
+
+        let params: GetChatMessagesParams = match arguments {
+            Some(value) => match serde_json::from_value(value) {
+                Ok(params) => params,
+                Err(e) => return ToolCallResult::error(format!("Invalid params: {e}")),
+            },
+            None => return ToolCallResult::error("chat_id is required".to_string()),
+        };
+
+        let request = GetMessagesParams {
+            chat_id: params.chat_id,
+            limit: params.limit,
+            cursor: params.cursor,
+            thread_id: params.thread_id,
+            since: params.since,
+            until: params.until,
+        };
+
+        let mut last_error: Option<String> = None;
+        for provider in &self.messenger_providers {
+            match provider.get_messages(request.clone()).await {
+                Ok(result) => {
+                    return ToolCallResult::text(format_messenger_messages(&result.items));
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "Messenger provider {} failed: {}",
+                        provider.provider_name(),
+                        e
+                    );
+                    last_error = Some(format!("{}: {}", provider.provider_name(), e));
+                }
+            }
+        }
+
+        ToolCallResult::error(
+            last_error.unwrap_or_else(|| "No messenger providers configured".to_string()),
+        )
+    }
+
+    async fn handle_search_chat_messages(&self, arguments: Option<Value>) -> ToolCallResult {
+        if self.messenger_providers.is_empty() {
+            return ToolCallResult::error("No messenger providers configured".to_string());
+        }
+
+        let params: SearchChatMessagesParams = match arguments {
+            Some(value) => match serde_json::from_value(value) {
+                Ok(params) => params,
+                Err(e) => return ToolCallResult::error(format!("Invalid params: {e}")),
+            },
+            None => return ToolCallResult::error("query is required".to_string()),
+        };
+
+        let request = SearchMessagesParams {
+            query: params.query,
+            chat_id: params.chat_id,
+            limit: params.limit,
+            cursor: params.cursor,
+            since: params.since,
+            until: params.until,
+        };
+
+        let mut last_error: Option<String> = None;
+        for provider in &self.messenger_providers {
+            match provider.search_messages(request.clone()).await {
+                Ok(result) => {
+                    return ToolCallResult::text(format_messenger_messages(&result.items));
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "Messenger provider {} failed: {}",
+                        provider.provider_name(),
+                        e
+                    );
+                    last_error = Some(format!("{}: {}", provider.provider_name(), e));
+                }
+            }
+        }
+
+        ToolCallResult::error(
+            last_error.unwrap_or_else(|| "No messenger providers configured".to_string()),
+        )
+    }
+
+    async fn handle_send_message(&self, arguments: Option<Value>) -> ToolCallResult {
+        if self.messenger_providers.is_empty() {
+            return ToolCallResult::error("No messenger providers configured".to_string());
+        }
+
+        let params: SendMessengerMessageParams = match arguments {
+            Some(value) => match serde_json::from_value(value) {
+                Ok(params) => params,
+                Err(e) => return ToolCallResult::error(format!("Invalid params: {e}")),
+            },
+            None => return ToolCallResult::error("chat_id and text are required".to_string()),
+        };
+
+        let request = SendMessageParams {
+            chat_id: params.chat_id,
+            text: params.text,
+            thread_id: params.thread_id,
+            reply_to_id: params.reply_to_id,
+            attachments: vec![],
+        };
+
+        let mut last_error: Option<String> = None;
+        for provider in &self.messenger_providers {
+            match provider.send_message(request.clone()).await {
+                Ok(message) => {
+                    return ToolCallResult::text(format_single_messenger_message(&message));
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "Messenger provider {} failed: {}",
+                        provider.provider_name(),
+                        e
+                    );
+                    last_error = Some(format!("{}: {}", provider.provider_name(), e));
+                }
+            }
+        }
+
+        ToolCallResult::error(
+            last_error.unwrap_or_else(|| "No messenger providers configured".to_string()),
+        )
+    }
+
+    // =========================================================================
     // HELPER METHODS
     // =========================================================================
 
@@ -1865,6 +2191,63 @@ impl ToolHandler {
 
         Pipeline::with_config(config)
     }
+}
+
+fn format_messenger_chats(chats: &[devboy_core::MessengerChat]) -> String {
+    if chats.is_empty() {
+        return "No chats found.".to_string();
+    }
+
+    let mut output = format!("# Messenger Chats ({})\n\n", chats.len());
+    for chat in chats {
+        let description = chat.description.as_deref().unwrap_or("-");
+        let members = chat
+            .member_count
+            .map(|count| count.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let active = if chat.is_active { "active" } else { "inactive" };
+        output.push_str(&format!(
+            "- {} [{}] id=`{}` members={} status={} desc={}\n",
+            chat.name,
+            match chat.chat_type {
+                ChatType::Direct => "direct",
+                ChatType::Group => "group",
+                ChatType::Channel => "channel",
+            },
+            chat.id,
+            members,
+            active,
+            description
+        ));
+    }
+    output
+}
+
+fn format_messenger_messages(messages: &[devboy_core::MessengerMessage]) -> String {
+    if messages.is_empty() {
+        return "No messages found.".to_string();
+    }
+
+    let mut output = format!("# Messages ({})\n\n", messages.len());
+    for message in messages {
+        output.push_str(&format_single_messenger_message(message));
+        output.push('\n');
+    }
+    output
+}
+
+fn format_single_messenger_message(message: &devboy_core::MessengerMessage) -> String {
+    let mut line = format!(
+        "- [{}] {} ({}) in `{}`: {}",
+        message.timestamp, message.author.name, message.author.id, message.chat_id, message.text
+    );
+    if let Some(thread_id) = message.thread_id.as_deref() {
+        line.push_str(&format!(" thread=`{}`", thread_id));
+    }
+    if !message.attachments.is_empty() {
+        line.push_str(&format!(" attachments={}", message.attachments.len()));
+    }
+    line
 }
 
 // =============================================================================
@@ -2080,6 +2463,43 @@ struct SearchMeetingNotesParams {
     host_email: Option<String>,
     limit: Option<u32>,
     offset: Option<u32>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GetMessengerChatsParams {
+    search: Option<String>,
+    chat_type: Option<ChatType>,
+    limit: Option<u32>,
+    cursor: Option<String>,
+    include_inactive: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetChatMessagesParams {
+    chat_id: String,
+    limit: Option<u32>,
+    cursor: Option<String>,
+    thread_id: Option<String>,
+    since: Option<String>,
+    until: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchChatMessagesParams {
+    query: String,
+    chat_id: Option<String>,
+    limit: Option<u32>,
+    cursor: Option<String>,
+    since: Option<String>,
+    until: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SendMessengerMessageParams {
+    chat_id: String,
+    text: String,
+    thread_id: Option<String>,
+    reply_to_id: Option<String>,
 }
 
 // =============================================================================
@@ -2795,8 +3215,8 @@ mod tests {
         let handler = ToolHandler::new(vec![]);
         let tools = handler.available_tools();
 
-        // 9 issue tools + 6 MR tools + 2 pipeline tools + 3 meeting tools = 20 total
-        assert_eq!(tools.len(), 20);
+        // 9 issue tools + 6 MR tools + 2 pipeline tools + 3 meeting tools + 4 messenger tools = 24 total
+        assert_eq!(tools.len(), 24);
     }
 
     #[tokio::test]

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -28,6 +28,7 @@ pub struct McpServer {
     proxy_manager: ProxyManager,
     builtin_tools_config: BuiltinToolsConfig,
     meeting_providers: Vec<Arc<dyn devboy_core::MeetingNotesProvider>>,
+    messenger_providers: Vec<Arc<dyn devboy_core::MessengerProvider>>,
 }
 
 impl McpServer {
@@ -42,6 +43,7 @@ impl McpServer {
             proxy_manager: ProxyManager::new(),
             builtin_tools_config: BuiltinToolsConfig::default(),
             meeting_providers: Vec::new(),
+            messenger_providers: Vec::new(),
         }
     }
 
@@ -64,6 +66,10 @@ impl McpServer {
 
     pub fn add_meeting_provider(&mut self, provider: Arc<dyn devboy_core::MeetingNotesProvider>) {
         self.meeting_providers.push(provider);
+    }
+
+    pub fn add_messenger_provider(&mut self, provider: Arc<dyn devboy_core::MessengerProvider>) {
+        self.messenger_providers.push(provider);
     }
 
     /// Add a provider to the server.

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -275,7 +275,8 @@ impl McpServer {
     pub fn handle_tools_list(&self, id: RequestId) -> JsonRpcResponse {
         let providers = self.active_providers();
         let handler = ToolHandler::new(providers.clone())
-            .with_meeting_providers(self.meeting_providers.clone());
+            .with_meeting_providers(self.meeting_providers.clone())
+            .with_messenger_providers(self.messenger_providers.clone());
         let mut tools = handler.available_tools();
 
         // Pre-compute category availability to avoid repeated provider lookups.
@@ -288,6 +289,7 @@ impl McpServer {
             )
         });
         let has_meeting_providers = handler.has_meeting_providers();
+        let has_messenger_providers = handler.has_messenger_providers();
 
         // Filter tools based on available providers (dynamic filtering).
         // This prevents exposing tools that would always fail due to missing providers.
@@ -297,6 +299,7 @@ impl McpServer {
                     ToolCategory::Issues => has_issue_providers,
                     ToolCategory::MergeRequests => has_mr_providers,
                     ToolCategory::MeetingNotes => has_meeting_providers,
+                    ToolCategory::Messenger => has_messenger_providers,
                 })
                 .unwrap_or(true) // Tools without category are always available
         });
@@ -433,7 +436,8 @@ impl McpServer {
                     proxy_result
                 } else {
                     let handler = ToolHandler::new(self.active_providers())
-                        .with_meeting_providers(self.meeting_providers.clone());
+                        .with_meeting_providers(self.meeting_providers.clone())
+                        .with_messenger_providers(self.messenger_providers.clone());
                     handler.execute(&params.name, params.arguments).await
                 }
             }

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -23,12 +23,12 @@ use crate::transport::{IncomingMessage, StdioTransport};
 /// MCP server for devboy-tools.
 pub struct McpServer {
     contexts: HashMap<String, Vec<Arc<dyn Provider>>>,
+    messenger_contexts: HashMap<String, Vec<Arc<dyn devboy_core::MessengerProvider>>>,
     active_context: RwLock<String>,
     initialized: bool,
     proxy_manager: ProxyManager,
     builtin_tools_config: BuiltinToolsConfig,
     meeting_providers: Vec<Arc<dyn devboy_core::MeetingNotesProvider>>,
-    messenger_providers: Vec<Arc<dyn devboy_core::MessengerProvider>>,
 }
 
 impl McpServer {
@@ -36,14 +36,16 @@ impl McpServer {
     pub fn new() -> Self {
         let mut contexts = HashMap::new();
         contexts.insert("default".to_string(), Vec::new());
+        let mut messenger_contexts = HashMap::new();
+        messenger_contexts.insert("default".to_string(), Vec::new());
         Self {
             contexts,
+            messenger_contexts,
             active_context: RwLock::new("default".to_string()),
             initialized: false,
             proxy_manager: ProxyManager::new(),
             builtin_tools_config: BuiltinToolsConfig::default(),
             meeting_providers: Vec::new(),
-            messenger_providers: Vec::new(),
         }
     }
 
@@ -69,7 +71,18 @@ impl McpServer {
     }
 
     pub fn add_messenger_provider(&mut self, provider: Arc<dyn devboy_core::MessengerProvider>) {
-        self.messenger_providers.push(provider);
+        self.add_messenger_provider_to_context("default", provider);
+    }
+
+    pub fn add_messenger_provider_to_context(
+        &mut self,
+        context: &str,
+        provider: Arc<dyn devboy_core::MessengerProvider>,
+    ) {
+        self.messenger_contexts
+            .entry(context.to_string())
+            .or_default()
+            .push(provider);
     }
 
     /// Add a provider to the server.
@@ -91,6 +104,9 @@ impl McpServer {
     /// Ensure a named context exists, even if it has no providers.
     pub fn ensure_context(&mut self, context: &str) {
         self.contexts.entry(context.to_string()).or_default();
+        self.messenger_contexts
+            .entry(context.to_string())
+            .or_default();
     }
 
     /// Set active context.
@@ -129,6 +145,15 @@ impl McpServer {
     pub fn active_providers(&self) -> Vec<Arc<dyn Provider>> {
         let active = self.active_context_name();
         self.contexts.get(&active).cloned().unwrap_or_default()
+    }
+
+    /// Get messenger providers in active context.
+    pub fn active_messenger_providers(&self) -> Vec<Arc<dyn devboy_core::MessengerProvider>> {
+        let active = self.active_context_name();
+        self.messenger_contexts
+            .get(&active)
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Get providers in the default context.
@@ -276,7 +301,7 @@ impl McpServer {
         let providers = self.active_providers();
         let handler = ToolHandler::new(providers.clone())
             .with_meeting_providers(self.meeting_providers.clone())
-            .with_messenger_providers(self.messenger_providers.clone());
+            .with_messenger_providers(self.active_messenger_providers());
         let mut tools = handler.available_tools();
 
         // Pre-compute category availability to avoid repeated provider lookups.
@@ -437,7 +462,7 @@ impl McpServer {
                 } else {
                     let handler = ToolHandler::new(self.active_providers())
                         .with_meeting_providers(self.meeting_providers.clone())
-                        .with_messenger_providers(self.messenger_providers.clone());
+                        .with_messenger_providers(self.active_messenger_providers());
                     handler.execute(&params.name, params.arguments).await
                 }
             }
@@ -463,9 +488,12 @@ mod tests {
     use crate::protocol::{JSONRPC_VERSION, RequestId, ToolCallResult, ToolResultContent};
 
     use async_trait::async_trait;
+    use devboy_core::types::ChatType;
     use devboy_core::{
-        Comment, CreateCommentInput, CreateIssueInput, Discussion, FileDiff, Issue, IssueFilter,
-        IssueProvider, MergeRequest, MergeRequestProvider, MrFilter, UpdateIssueInput, User,
+        Comment, CreateCommentInput, CreateIssueInput, Discussion, FileDiff, GetChatsParams,
+        GetMessagesParams, Issue, IssueFilter, IssueProvider, MergeRequest, MergeRequestProvider,
+        MessageAuthor, MessengerChat, MessengerMessage, MessengerProvider, MrFilter,
+        SearchMessagesParams, SendMessageParams, UpdateIssueInput, User,
     };
 
     /// Test provider that simulates a GitHub-like provider (supports both issues and MRs).
@@ -557,6 +585,69 @@ mod tests {
                 name: None,
                 email: None,
                 avatar_url: None,
+            })
+        }
+    }
+
+    struct TestMessengerProvider;
+
+    #[async_trait]
+    impl MessengerProvider for TestMessengerProvider {
+        fn provider_name(&self) -> &'static str {
+            "slack"
+        }
+
+        async fn get_chats(
+            &self,
+            _params: GetChatsParams,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<MessengerChat>> {
+            Ok(vec![MessengerChat {
+                id: "C123".to_string(),
+                key: "slack:C123".to_string(),
+                name: "general".to_string(),
+                chat_type: ChatType::Channel,
+                source: "slack".to_string(),
+                member_count: Some(3),
+                description: None,
+                is_active: true,
+            }]
+            .into())
+        }
+
+        async fn get_messages(
+            &self,
+            _params: GetMessagesParams,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<MessengerMessage>> {
+            Ok(vec![].into())
+        }
+
+        async fn search_messages(
+            &self,
+            _params: SearchMessagesParams,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<MessengerMessage>> {
+            Ok(vec![].into())
+        }
+
+        async fn send_message(
+            &self,
+            _params: SendMessageParams,
+        ) -> devboy_core::Result<MessengerMessage> {
+            Ok(MessengerMessage {
+                id: "1710000000.000100".to_string(),
+                chat_id: "C123".to_string(),
+                text: "test".to_string(),
+                author: MessageAuthor {
+                    id: "U123".to_string(),
+                    name: "DevBoy".to_string(),
+                    username: Some("devboy".to_string()),
+                    avatar_url: None,
+                },
+                source: "slack".to_string(),
+                timestamp: "1710000000.000100".to_string(),
+                thread_id: None,
+                reply_to_id: None,
+                attachments: vec![],
+                is_edited: false,
             })
         }
     }
@@ -1186,5 +1277,43 @@ mod tests {
         // Switch to custom context and verify provider is there
         server.set_active_context("custom").unwrap();
         assert_eq!(server.active_providers().len(), 1);
+    }
+
+    #[test]
+    fn test_messenger_providers_are_scoped_to_active_context() {
+        let mut server = McpServer::new();
+        server.ensure_context("slack-context");
+        server.ensure_context("plain-context");
+        server.add_messenger_provider_to_context("slack-context", Arc::new(TestMessengerProvider));
+
+        server.set_active_context("plain-context").unwrap();
+        let plain_result: ToolsListResult = serde_json::from_value(
+            server
+                .handle_tools_list(RequestId::Number(1))
+                .result
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            !plain_result
+                .tools
+                .iter()
+                .any(|tool| tool.name == "get_messenger_chats")
+        );
+
+        server.set_active_context("slack-context").unwrap();
+        let slack_result: ToolsListResult = serde_json::from_value(
+            server
+                .handle_tools_list(RequestId::Number(2))
+                .result
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            slack_result
+                .tools
+                .iter()
+                .any(|tool| tool.name == "get_messenger_chats")
+        );
     }
 }

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -79,6 +79,7 @@ impl McpServer {
         context: &str,
         provider: Arc<dyn devboy_core::MessengerProvider>,
     ) {
+        self.contexts.entry(context.to_string()).or_default();
         self.messenger_contexts
             .entry(context.to_string())
             .or_default()
@@ -1315,5 +1316,18 @@ mod tests {
                 .iter()
                 .any(|tool| tool.name == "get_messenger_chats")
         );
+    }
+
+    #[test]
+    fn test_add_messenger_provider_creates_context_for_activation() {
+        let mut server = McpServer::new();
+        server.add_messenger_provider_to_context("messenger-only", Arc::new(TestMessengerProvider));
+
+        assert!(
+            server
+                .context_names()
+                .contains(&"messenger-only".to_string())
+        );
+        assert!(server.set_active_context("messenger-only").is_ok());
     }
 }

--- a/crates/plugins/api/gitlab/src/client.rs
+++ b/crates/plugins/api/gitlab/src/client.rs
@@ -207,6 +207,7 @@ impl GitLabClient {
             limit,
             total: x_total,
             has_more,
+            next_cursor: None,
         })
     }
 

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -990,6 +990,7 @@ impl IssueProvider for JiraClient {
                     limit,
                     total: None, // Jira Cloud cursor-based, no total
                     has_more: next_page_token.is_some(),
+                    next_cursor: next_page_token,
                 });
                 result.sort_info = Some(devboy_core::SortInfo {
                     sort_by: Some(order_by.into()),
@@ -1043,6 +1044,7 @@ impl IssueProvider for JiraClient {
                     limit,
                     total,
                     has_more,
+                    next_cursor: None,
                 });
                 result.sort_info = Some(devboy_core::SortInfo {
                     sort_by: Some(order_by.into()),

--- a/crates/plugins/api/slack/Cargo.toml
+++ b/crates/plugins/api/slack/Cargo.toml
@@ -14,10 +14,10 @@ serde.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 httpmock.workspace = true
-tokio.workspace = true
 
 [lints]
 workspace = true

--- a/crates/plugins/api/slack/Cargo.toml
+++ b/crates/plugins/api/slack/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "devboy-slack"
+description = "Slack provider implementation for devboy-tools"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+devboy-core = { path = "../../../devboy-core" }
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+httpmock.workspace = true
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -30,7 +31,7 @@ pub struct SlackAuthInfo {
     pub missing_scopes: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SlackClient {
     token: String,
     base_url: String,
@@ -38,6 +39,19 @@ pub struct SlackClient {
     required_scopes: Vec<String>,
     user_cache: Arc<RwLock<HashMap<String, MessageAuthor>>>,
     rate_limiter: Arc<SlackRateLimiter>,
+}
+
+impl fmt::Debug for SlackClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SlackClient")
+            .field("token", &"<redacted>")
+            .field("base_url", &self.base_url)
+            .field("http", &self.http)
+            .field("required_scopes", &self.required_scopes)
+            .field("user_cache", &self.user_cache)
+            .field("rate_limiter", &self.rate_limiter)
+            .finish()
+    }
 }
 
 const SLACK_READ_INTERVAL: Duration = Duration::from_millis(1200);

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -1,4 +1,6 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use devboy_core::types::ChatType;
@@ -32,6 +34,7 @@ pub struct SlackClient {
     base_url: String,
     http: reqwest::Client,
     required_scopes: Vec<String>,
+    user_cache: Arc<RwLock<HashMap<String, MessageAuthor>>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -180,6 +183,7 @@ impl SlackClient {
             base_url: DEFAULT_SLACK_API_URL.to_string(),
             http: reqwest::Client::new(),
             required_scopes: devboy_core::default_slack_required_scopes(),
+            user_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -448,6 +452,16 @@ impl SlackClient {
     }
 
     async fn get_user(&self, user_id: &str) -> Result<MessageAuthor> {
+        if let Some(cached) = self
+            .user_cache
+            .read()
+            .map_err(|_| Error::Config("Slack user cache lock poisoned".to_string()))?
+            .get(user_id)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+
         let payload: SlackUsersInfoResponse = self
             .post_form("users.info", &[("user", user_id.to_string())])
             .await?;
@@ -470,12 +484,19 @@ impl SlackClient {
             .or_else(|| username.clone())
             .unwrap_or_else(|| user.id.clone());
 
-        Ok(MessageAuthor {
+        let author = MessageAuthor {
             id: user.id,
             name,
             username,
             avatar_url: profile.and_then(|profile| profile.image_72.clone()),
-        })
+        };
+
+        self.user_cache
+            .write()
+            .map_err(|_| Error::Config("Slack user cache lock poisoned".to_string()))?
+            .insert(user_id.to_string(), author.clone());
+
+        Ok(author)
     }
 }
 
@@ -1083,6 +1104,60 @@ mod tests {
         assert_eq!(result.chat_id, "C123");
         assert_eq!(result.text, "hello world");
         assert_eq!(result.author.name, "Devboy");
+    }
+
+    #[tokio::test]
+    async fn get_messages_caches_resolved_users() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/conversations.history");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "messages": [
+                    {
+                        "ts": "1710000000.000100",
+                        "text": "First",
+                        "user": "U123"
+                    },
+                    {
+                        "ts": "1710000001.000100",
+                        "text": "Second",
+                        "user": "U123"
+                    }
+                ]
+            }));
+        });
+        let users_info = server.mock(|when, then| {
+            when.method(POST).path("/users.info");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "user": {
+                    "id": "U123",
+                    "name": "andrey",
+                    "profile": {
+                        "display_name": "Andrey"
+                    }
+                }
+            }));
+        });
+
+        let client = SlackClient::new("xoxb-test").with_base_url(server.base_url());
+        let result = client
+            .get_messages(GetMessagesParams {
+                chat_id: "C123".to_string(),
+                limit: Some(20),
+                cursor: None,
+                thread_id: None,
+                since: None,
+                until: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(result.items[0].author.name, "Andrey");
+        assert_eq!(result.items[1].author.name, "Andrey");
+        users_info.assert_calls(1);
     }
 
     #[test]

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -326,12 +326,14 @@ impl SlackClient {
             .as_ref()
             .map(|meta| !meta.next_cursor.is_empty())
             .unwrap_or(false);
+        let next_cursor = slack_next_cursor(payload.response_metadata.as_ref());
 
         Ok(ProviderResult::new(items).with_pagination(Pagination {
             offset: 0,
             limit,
             total: None,
             has_more,
+            next_cursor,
         }))
     }
 
@@ -374,12 +376,14 @@ impl SlackClient {
                 .as_ref()
                 .map(|meta| !meta.next_cursor.is_empty())
                 .unwrap_or(false);
+        let next_cursor = slack_next_cursor(payload.response_metadata.as_ref());
 
         Ok(ProviderResult::new(items).with_pagination(Pagination {
             offset: 0,
             limit,
             total: None,
             has_more,
+            next_cursor,
         }))
     }
 
@@ -506,7 +510,7 @@ impl MessengerProvider for SlackClient {
         let limit = params.limit.unwrap_or(20) as usize;
         let mut found = Vec::new();
 
-        let has_more = if let Some(chat_id) = params.chat_id.as_ref() {
+        let (has_more, next_cursor) = if let Some(chat_id) = params.chat_id.as_ref() {
             let messages = self
                 .get_messages_page(&GetMessagesParams {
                     chat_id: chat_id.clone(),
@@ -517,6 +521,7 @@ impl MessengerProvider for SlackClient {
                     until: params.until.clone(),
                 })
                 .await?;
+            let pagination = messages.pagination.clone();
             for message in messages.items {
                 if message.text.to_lowercase().contains(&query) {
                     found.push(message);
@@ -525,7 +530,10 @@ impl MessengerProvider for SlackClient {
                     }
                 }
             }
-            messages.pagination.map(|p| p.has_more).unwrap_or(false)
+            (
+                pagination.as_ref().map(|p| p.has_more).unwrap_or(false),
+                pagination.and_then(|p| p.next_cursor),
+            )
         } else {
             let chats = self
                 .get_conversations(&GetChatsParams {
@@ -536,6 +544,7 @@ impl MessengerProvider for SlackClient {
                     include_inactive: Some(false),
                 })
                 .await?;
+            let chats_pagination = chats.pagination.clone();
             let mut has_more = chats
                 .pagination
                 .as_ref()
@@ -568,7 +577,7 @@ impl MessengerProvider for SlackClient {
                     break;
                 }
             }
-            has_more
+            (has_more, chats_pagination.and_then(|p| p.next_cursor))
         };
 
         Ok(ProviderResult::new(found).with_pagination(Pagination {
@@ -576,6 +585,7 @@ impl MessengerProvider for SlackClient {
             limit: limit as u32,
             total: None,
             has_more,
+            next_cursor,
         }))
     }
 
@@ -729,6 +739,13 @@ fn slack_conversation_types(chat_type: Option<ChatType>) -> &'static str {
         Some(ChatType::Channel) => "public_channel,private_channel",
         None => "public_channel,private_channel,mpim,im",
     }
+}
+
+fn slack_next_cursor(metadata: Option<&SlackResponseMetadata>) -> Option<String> {
+    metadata
+        .map(|metadata| metadata.next_cursor.trim())
+        .filter(|cursor| !cursor.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn normalize_ts_param(value: Option<&str>) -> Option<Cow<'_, str>> {
@@ -940,7 +957,7 @@ mod tests {
                         "purpose": { "value": "Team chat" }
                     }
                 ],
-                "response_metadata": { "next_cursor": "" }
+                "response_metadata": { "next_cursor": "chat-cursor-1" }
             }));
         });
 
@@ -953,6 +970,13 @@ mod tests {
         assert_eq!(result.items.len(), 1);
         assert_eq!(result.items[0].name, "engineering");
         assert_eq!(result.items[0].chat_type, ChatType::Channel);
+        assert_eq!(
+            result
+                .pagination
+                .as_ref()
+                .and_then(|pagination| pagination.next_cursor.as_deref()),
+            Some("chat-cursor-1")
+        );
     }
 
     #[tokio::test]
@@ -975,7 +999,8 @@ mod tests {
                         "user": "U123",
                         "thread_ts": "1710000000.000100"
                     }
-                ]
+                ],
+                "response_metadata": { "next_cursor": "reply-cursor-1" }
             }));
         });
         server.mock(|when, then| {
@@ -1013,6 +1038,13 @@ mod tests {
             Some("1710000000.000100")
         );
         assert_eq!(result.items[0].author.name, "Andrey");
+        assert_eq!(
+            result
+                .pagination
+                .as_ref()
+                .and_then(|pagination| pagination.next_cursor.as_deref()),
+            Some("reply-cursor-1")
+        );
     }
 
     #[tokio::test]

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use devboy_core::types::ChatType;
@@ -12,6 +13,8 @@ use devboy_core::{
 use reqwest::header::HeaderMap;
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
+use tokio::sync::Mutex;
+use tokio::time::{Instant, sleep_until};
 use tracing::debug;
 
 use crate::DEFAULT_SLACK_API_URL;
@@ -35,6 +38,29 @@ pub struct SlackClient {
     http: reqwest::Client,
     required_scopes: Vec<String>,
     user_cache: Arc<RwLock<HashMap<String, MessageAuthor>>>,
+    rate_limiter: Arc<SlackRateLimiter>,
+}
+
+const SLACK_READ_INTERVAL: Duration = Duration::from_millis(1200);
+const SLACK_WRITE_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SlackRateLimitBucket {
+    Read,
+    Write,
+}
+
+#[derive(Debug)]
+struct SlackRateLimiter {
+    state: Mutex<SlackRateLimitState>,
+    read_interval: Duration,
+    write_interval: Duration,
+}
+
+#[derive(Debug)]
+struct SlackRateLimitState {
+    read_ready_at: Instant,
+    write_ready_at: Instant,
 }
 
 #[derive(Debug, Deserialize)]
@@ -184,6 +210,10 @@ impl SlackClient {
             http: reqwest::Client::new(),
             required_scopes: devboy_core::default_slack_required_scopes(),
             user_cache: Arc::new(RwLock::new(HashMap::new())),
+            rate_limiter: Arc::new(SlackRateLimiter::new(
+                SLACK_READ_INTERVAL,
+                SLACK_WRITE_INTERVAL,
+            )),
         }
     }
 
@@ -205,13 +235,7 @@ impl SlackClient {
         let url = format!("{}/auth.test", self.base_url);
         debug!(url, "slack auth.test request");
 
-        let response = self
-            .http
-            .post(&url)
-            .bearer_auth(&self.token)
-            .send()
-            .await
-            .map_err(|e| Error::Network(e.to_string()))?;
+        let response = self.send_form_request("auth.test", &[]).await?;
 
         let status = response.status();
         let headers = response.headers().clone();
@@ -275,19 +299,53 @@ impl SlackClient {
     where
         T: DeserializeOwned,
     {
-        let url = format!("{}/{}", self.base_url, method);
-        debug!(url, "slack api request");
-
-        let response = self
-            .http
-            .post(&url)
-            .bearer_auth(&self.token)
-            .form(params)
-            .send()
-            .await
-            .map_err(|e| Error::Network(e.to_string()))?;
-
+        let response = self.send_form_request(method, params).await?;
         map_http_error(response).await
+    }
+
+    async fn send_form_request(
+        &self,
+        method: &str,
+        params: &[(&str, String)],
+    ) -> Result<reqwest::Response> {
+        let url = format!("{}/{}", self.base_url, method);
+        let bucket = slack_rate_limit_bucket(method);
+        debug!(url, ?bucket, "slack api request");
+
+        for attempt in 0..2 {
+            self.rate_limiter.acquire(bucket).await;
+
+            let response = self
+                .http
+                .post(&url)
+                .bearer_auth(&self.token)
+                .form(params)
+                .send()
+                .await
+                .map_err(|e| Error::Network(e.to_string()))?;
+
+            if response.status().as_u16() != 429 {
+                return Ok(response);
+            }
+
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<u64>().ok());
+
+            self.rate_limiter
+                .on_rate_limited(bucket, retry_after.map(Duration::from_secs))
+                .await;
+
+            if attempt == 0 && retry_after.is_some() {
+                continue;
+            }
+
+            return Ok(response);
+        }
+
+        unreachable!("slack request retry loop should always return");
     }
 
     async fn get_conversations(
@@ -769,6 +827,13 @@ fn slack_next_cursor(metadata: Option<&SlackResponseMetadata>) -> Option<String>
         .map(ToOwned::to_owned)
 }
 
+fn slack_rate_limit_bucket(method: &str) -> SlackRateLimitBucket {
+    match method {
+        "chat.postMessage" => SlackRateLimitBucket::Write,
+        _ => SlackRateLimitBucket::Read,
+    }
+}
+
 fn normalize_ts_param(value: Option<&str>) -> Option<Cow<'_, str>> {
     let value = value?.trim();
     if value.is_empty() {
@@ -794,6 +859,61 @@ fn parse_scopes(headers: &HeaderMap) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+impl SlackRateLimiter {
+    fn new(read_interval: Duration, write_interval: Duration) -> Self {
+        let now = Instant::now();
+        Self {
+            state: Mutex::new(SlackRateLimitState {
+                read_ready_at: now,
+                write_ready_at: now,
+            }),
+            read_interval,
+            write_interval,
+        }
+    }
+
+    async fn acquire(&self, bucket: SlackRateLimitBucket) {
+        let (wait_until, interval) = {
+            let mut state = self.state.lock().await;
+            let now = Instant::now();
+            let (ready_at, interval) = match bucket {
+                SlackRateLimitBucket::Read => (&mut state.read_ready_at, self.read_interval),
+                SlackRateLimitBucket::Write => (&mut state.write_ready_at, self.write_interval),
+            };
+            let wait_until = (*ready_at).max(now);
+            *ready_at = wait_until + interval;
+            (wait_until, interval)
+        };
+
+        debug!(
+            ?bucket,
+            ?wait_until,
+            ?interval,
+            "slack rate limiter acquired slot"
+        );
+
+        if wait_until > Instant::now() {
+            sleep_until(wait_until).await;
+        }
+    }
+
+    async fn on_rate_limited(&self, bucket: SlackRateLimitBucket, retry_after: Option<Duration>) {
+        let delay = retry_after.unwrap_or_else(|| match bucket {
+            SlackRateLimitBucket::Read => self.read_interval,
+            SlackRateLimitBucket::Write => self.write_interval,
+        });
+        let next_ready = Instant::now() + delay;
+        let mut state = self.state.lock().await;
+        let ready_at = match bucket {
+            SlackRateLimitBucket::Read => &mut state.read_ready_at,
+            SlackRateLimitBucket::Write => &mut state.write_ready_at,
+        };
+        if next_ready > *ready_at {
+            *ready_at = next_ready;
+        }
+    }
 }
 
 async fn map_http_error<T>(response: reqwest::Response) -> Result<T>
@@ -1168,5 +1288,40 @@ mod tests {
         assert!(text.contains("[docs](https://example.com)"));
         assert!(text.contains("@U123"));
         assert!(text.contains("#general"));
+    }
+
+    #[test]
+    fn rate_limit_bucket_matches_write_method() {
+        assert_eq!(
+            slack_rate_limit_bucket("chat.postMessage"),
+            SlackRateLimitBucket::Write
+        );
+        assert_eq!(
+            slack_rate_limit_bucket("conversations.history"),
+            SlackRateLimitBucket::Read
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_limiter_spaces_same_bucket_requests() {
+        let limiter = SlackRateLimiter::new(Duration::from_millis(25), Duration::from_millis(10));
+
+        let start = std::time::Instant::now();
+        limiter.acquire(SlackRateLimitBucket::Read).await;
+        limiter.acquire(SlackRateLimitBucket::Read).await;
+
+        assert!(start.elapsed() >= Duration::from_millis(20));
+    }
+
+    #[tokio::test]
+    async fn rate_limiter_keeps_read_and_write_buckets_independent() {
+        let limiter = SlackRateLimiter::new(Duration::from_millis(50), Duration::from_millis(10));
+
+        limiter.acquire(SlackRateLimitBucket::Read).await;
+
+        let start = std::time::Instant::now();
+        limiter.acquire(SlackRateLimitBucket::Write).await;
+
+        assert!(start.elapsed() < Duration::from_millis(25));
     }
 }

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -247,18 +247,8 @@ impl SlackClient {
         debug!(url, "slack auth.test request");
 
         let response = self.send_form_request("auth.test", &[]).await?;
-
-        let status = response.status();
         let headers = response.headers().clone();
-        if !status.is_success() {
-            let text = response.text().await.unwrap_or_default();
-            return Err(Error::from_status(status.as_u16(), text));
-        }
-
-        let payload: SlackAuthTestResponse = response
-            .json()
-            .await
-            .map_err(|e| Error::InvalidData(e.to_string()))?;
+        let payload: SlackAuthTestResponse = map_http_error(response).await?;
 
         if !payload.ok {
             let message = payload
@@ -1137,7 +1127,13 @@ fn normalize_mrkdwn(text: &str) -> String {
 
 fn normalize_slack_token(token: &str) -> String {
     if let Some(user) = token.strip_prefix('@') {
-        return format!("@{}", user);
+        let mut parts = user.splitn(2, '|');
+        let user_id = parts.next().unwrap_or(user);
+        let label = parts
+            .next()
+            .filter(|label| !label.is_empty())
+            .unwrap_or(user_id);
+        return format!("@{}", label);
     }
     if let Some(rest) = token.strip_prefix('#') {
         let mut parts = rest.splitn(2, '|');
@@ -1168,7 +1164,7 @@ mod tests {
             then.status(200)
                 .header(
                     "x-oauth-scopes",
-                    "channels:read, channels:history, chat:write, users:read",
+                    "channels:read, channels:history, groups:read, groups:history, im:read, im:history, mpim:read, mpim:history, chat:write, users:read",
                 )
                 .json_body(serde_json::json!({
                     "ok": true,
@@ -1528,6 +1524,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn auth_info_maps_rate_limit_to_rate_limited_error() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/auth.test");
+            then.status(429).header("retry-after", "7");
+        });
+
+        let error = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .auth_info()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::RateLimited {
+                retry_after: Some(7)
+            }
+        ));
+    }
+
+    #[tokio::test]
     async fn search_messages_rejects_empty_query() {
         let error = SlackClient::new("xoxb-test")
             .search_messages(SearchMessagesParams {
@@ -1749,6 +1767,7 @@ mod tests {
         assert!(parse_scopes(&HeaderMap::new()).is_empty());
 
         assert_eq!(normalize_slack_token("@U123"), "@U123");
+        assert_eq!(normalize_slack_token("@U123|andrey"), "@andrey");
         assert_eq!(normalize_slack_token("#C123|general"), "#general");
         assert_eq!(normalize_slack_token("!here"), "here");
         assert_eq!(

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -12,7 +12,7 @@ use devboy_core::{
 use reqwest::header::HeaderMap;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use tokio::time::{Instant, sleep_until};
 use tracing::debug;
 
@@ -511,13 +511,7 @@ impl SlackClient {
     }
 
     async fn get_user(&self, user_id: &str) -> Result<MessageAuthor> {
-        if let Some(cached) = self
-            .user_cache
-            .read()
-            .map_err(|_| Error::Config("Slack user cache lock poisoned".to_string()))?
-            .get(user_id)
-            .cloned()
-        {
+        if let Some(cached) = self.user_cache.read().await.get(user_id).cloned() {
             return Ok(cached);
         }
 
@@ -552,7 +546,7 @@ impl SlackClient {
 
         self.user_cache
             .write()
-            .map_err(|_| Error::Config("Slack user cache lock poisoned".to_string()))?
+            .await
             .insert(user_id.to_string(), author.clone());
 
         Ok(author)

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -11,8 +11,8 @@ use devboy_core::{
     SendMessageParams,
 };
 use reqwest::header::HeaderMap;
-use serde::Deserialize;
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tokio::time::{Instant, sleep_until};
 use tracing::debug;
@@ -122,6 +122,18 @@ struct SlackMessagesResponse {
     messages: Vec<SlackMessage>,
     has_more: Option<bool>,
     response_metadata: Option<SlackResponseMetadata>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct SlackSearchCursor {
+    version: u8,
+    current_chat_id: Option<String>,
+    current_message_cursor: Option<String>,
+    #[serde(default)]
+    current_message_offset: usize,
+    #[serde(default)]
+    pending_chat_ids: Vec<String>,
+    next_chats_cursor: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -614,49 +626,115 @@ impl MessengerProvider for SlackClient {
                 pagination.and_then(|p| p.next_cursor),
             )
         } else {
-            let chats = self
-                .get_conversations(&GetChatsParams {
-                    search: None,
-                    chat_type: None,
-                    limit: Some(100),
-                    cursor: params.cursor.clone(),
-                    include_inactive: Some(false),
-                })
-                .await?;
-            let chats_pagination = chats.pagination.clone();
-            let mut has_more = chats
-                .pagination
-                .as_ref()
-                .map(|p| p.has_more)
-                .unwrap_or(false);
+            let mut state = parse_search_cursor(params.cursor.as_deref())?;
+            let mut chats_loaded = state.current_chat_id.is_some()
+                || !state.pending_chat_ids.is_empty()
+                || state.next_chats_cursor.is_some()
+                || params.cursor.is_some();
 
-            for chat in chats.items {
-                let messages = self
-                    .get_messages_page(&GetMessagesParams {
-                        chat_id: chat.id.clone(),
-                        limit: Some(100),
-                        cursor: None,
-                        thread_id: None,
-                        since: params.since.clone(),
-                        until: params.until.clone(),
-                    })
-                    .await?;
-
-                for message in messages.items {
-                    if message.text.to_lowercase().contains(&query) {
-                        found.push(message);
-                        if found.len() >= limit {
-                            break;
-                        }
-                    }
-                }
-
-                has_more = has_more || messages.pagination.map(|p| p.has_more).unwrap_or(false);
+            loop {
                 if found.len() >= limit {
                     break;
                 }
+
+                if let Some(chat_id) = state.current_chat_id.clone() {
+                    let messages = self
+                        .get_messages_page(&GetMessagesParams {
+                            chat_id,
+                            limit: Some(100),
+                            cursor: state.current_message_cursor.clone(),
+                            thread_id: None,
+                            since: params.since.clone(),
+                            until: params.until.clone(),
+                        })
+                        .await?;
+                    let pagination = messages.pagination.clone();
+                    let page_len = messages.items.len();
+
+                    for message in messages
+                        .items
+                        .into_iter()
+                        .skip(state.current_message_offset)
+                    {
+                        state.current_message_offset += 1;
+                        if message.text.to_lowercase().contains(&query) {
+                            found.push(message);
+                            if found.len() >= limit {
+                                break;
+                            }
+                        }
+                    }
+
+                    if found.len() >= limit {
+                        if state.current_message_offset >= page_len {
+                            let next_message_cursor = pagination
+                                .as_ref()
+                                .and_then(|page| page.next_cursor.clone());
+                            if pagination
+                                .as_ref()
+                                .map(|page| page.has_more)
+                                .unwrap_or(false)
+                            {
+                                state.current_message_cursor = next_message_cursor;
+                                state.current_message_offset = 0;
+                            } else {
+                                state.current_chat_id = None;
+                                state.current_message_cursor = None;
+                                state.current_message_offset = 0;
+                            }
+                        }
+                        break;
+                    }
+
+                    let next_message_cursor = pagination
+                        .as_ref()
+                        .and_then(|page| page.next_cursor.clone());
+                    if pagination
+                        .as_ref()
+                        .map(|page| page.has_more)
+                        .unwrap_or(false)
+                    {
+                        state.current_message_cursor = next_message_cursor;
+                        state.current_message_offset = 0;
+                        continue;
+                    }
+
+                    state.current_chat_id = None;
+                    state.current_message_cursor = None;
+                    state.current_message_offset = 0;
+                    continue;
+                }
+
+                if !state.pending_chat_ids.is_empty() {
+                    state.current_chat_id = Some(state.pending_chat_ids.remove(0));
+                    state.current_message_cursor = None;
+                    state.current_message_offset = 0;
+                    continue;
+                }
+
+                if chats_loaded && state.next_chats_cursor.is_none() {
+                    break;
+                }
+
+                let chats = self
+                    .get_conversations(&GetChatsParams {
+                        search: None,
+                        chat_type: None,
+                        limit: Some(100),
+                        cursor: state.next_chats_cursor.clone(),
+                        include_inactive: Some(false),
+                    })
+                    .await?;
+                state.pending_chat_ids = chats.items.into_iter().map(|chat| chat.id).collect();
+                state.next_chats_cursor = chats.pagination.and_then(|page| page.next_cursor);
+                chats_loaded = true;
             }
-            (has_more, chats_pagination.and_then(|p| p.next_cursor))
+
+            let has_more = state.current_chat_id.is_some()
+                || !state.pending_chat_ids.is_empty()
+                || state.next_chats_cursor.is_some();
+            let next_cursor = serialize_search_cursor(&state)?;
+            (has_more, next_cursor)
         };
 
         Ok(ProviderResult::new(found).with_pagination(Pagination {
@@ -711,6 +789,33 @@ impl MessengerProvider for SlackClient {
         )
         .await
     }
+}
+
+fn parse_search_cursor(cursor: Option<&str>) -> Result<SlackSearchCursor> {
+    let Some(cursor) = cursor.map(str::trim).filter(|cursor| !cursor.is_empty()) else {
+        return Ok(SlackSearchCursor::default());
+    };
+
+    match serde_json::from_str::<SlackSearchCursor>(cursor) {
+        Ok(state) => Ok(state),
+        Err(_) => Ok(SlackSearchCursor {
+            next_chats_cursor: Some(cursor.to_string()),
+            ..SlackSearchCursor::default()
+        }),
+    }
+}
+
+fn serialize_search_cursor(state: &SlackSearchCursor) -> Result<Option<String>> {
+    let has_more = state.current_chat_id.is_some()
+        || !state.pending_chat_ids.is_empty()
+        || state.next_chats_cursor.is_some();
+    if !has_more {
+        return Ok(None);
+    }
+
+    serde_json::to_string(state)
+        .map(Some)
+        .map_err(|e| Error::InvalidData(format!("failed to serialize Slack search cursor: {e}")))
 }
 
 fn map_chat(chat: SlackConversation) -> MessengerChat {
@@ -1318,6 +1423,304 @@ mod tests {
     }
 
     #[test]
+    fn client_configuration_helpers_update_settings() {
+        let client = SlackClient::new("xoxb-test")
+            .with_base_url("https://slack.example.test/")
+            .with_required_scopes(vec!["search:read".to_string(), "chat:write".to_string()]);
+
+        assert_eq!(client.base_url, "https://slack.example.test");
+        assert_eq!(
+            client.required_scopes(),
+            ["search:read".to_string(), "chat:write".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_info_maps_invalid_auth_to_unauthorized() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/auth.test");
+            then.status(200).json_body(serde_json::json!({
+                "ok": false,
+                "error": "invalid_auth"
+            }));
+        });
+
+        let error = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .auth_info()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, Error::Unauthorized(message) if message == "invalid_auth"));
+    }
+
+    #[tokio::test]
+    async fn auth_info_maps_missing_scope_to_forbidden() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/auth.test");
+            then.status(200).json_body(serde_json::json!({
+                "ok": false,
+                "error": "missing_scope"
+            }));
+        });
+
+        let error = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .auth_info()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, Error::Forbidden(message) if message == "missing_scope"));
+    }
+
+    #[tokio::test]
+    async fn search_messages_rejects_empty_query() {
+        let error = SlackClient::new("xoxb-test")
+            .search_messages(SearchMessagesParams {
+                query: "   ".to_string(),
+                ..SearchMessagesParams::default()
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, Error::InvalidData(message) if message.contains("must not be empty")));
+    }
+
+    #[tokio::test]
+    async fn search_messages_global_cursor_resumes_within_chat_before_next_chat_page() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/conversations.list");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "channels": [
+                    { "id": "C1", "name": "general", "is_channel": true, "is_archived": false },
+                    { "id": "C2", "name": "random", "is_channel": true, "is_archived": false }
+                ],
+                "response_metadata": { "next_cursor": "chat-page-2" }
+            }));
+        });
+        server.mock(|when, then| {
+            when.method(POST).path("/conversations.history");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "messages": [
+                    { "ts": "1710000000.000100", "text": "no match", "username": "bot" },
+                    { "ts": "1710000001.000100", "text": "Needle on first page", "username": "bot" }
+                ],
+                "has_more": true,
+                "response_metadata": { "next_cursor": "msg-page-2" }
+            }));
+        });
+
+        let client = SlackClient::new("xoxb-test").with_base_url(server.base_url());
+        let first = client
+            .search_messages(SearchMessagesParams {
+                query: "needle".to_string(),
+                limit: Some(1),
+                ..SearchMessagesParams::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(first.items.len(), 1);
+        assert_eq!(first.items[0].chat_id, "C1");
+        assert!(first.pagination.as_ref().unwrap().has_more);
+
+        let cursor = first
+            .pagination
+            .as_ref()
+            .and_then(|pagination| pagination.next_cursor.clone())
+            .unwrap();
+        let state = parse_search_cursor(Some(&cursor)).unwrap();
+        assert_eq!(state.current_chat_id.as_deref(), Some("C1"));
+        assert_eq!(state.current_message_cursor.as_deref(), Some("msg-page-2"));
+        assert_eq!(state.current_message_offset, 0);
+        assert_eq!(state.pending_chat_ids, vec!["C2"]);
+        assert_eq!(state.next_chats_cursor.as_deref(), Some("chat-page-2"));
+    }
+
+    #[test]
+    fn helper_functions_cover_filtering_and_mapping_cases() {
+        let archived_group = SlackConversation {
+            id: "C1".to_string(),
+            name: Some("Project Alpha".to_string()),
+            user: None,
+            is_channel: None,
+            is_group: Some(true),
+            is_im: None,
+            is_mpim: None,
+            is_private: None,
+            is_archived: Some(true),
+            num_members: Some(3),
+            purpose: Some(SlackTextValue {
+                value: Some("".to_string()),
+            }),
+            topic: Some(SlackTextValue {
+                value: Some("Topic text".to_string()),
+            }),
+        };
+
+        assert_eq!(slack_chat_type(&archived_group), ChatType::Group);
+        assert_eq!(conversation_name(&archived_group), "Project Alpha");
+        assert!(!matches_chat_filter(
+            &archived_group,
+            &GetChatsParams {
+                search: Some("alpha".to_string()),
+                chat_type: Some(ChatType::Group),
+                include_inactive: Some(false),
+                ..GetChatsParams::default()
+            }
+        ));
+        assert!(matches_chat_filter(
+            &archived_group,
+            &GetChatsParams {
+                search: Some("alpha".to_string()),
+                chat_type: Some(ChatType::Group),
+                include_inactive: Some(true),
+                ..GetChatsParams::default()
+            }
+        ));
+
+        let direct_chat = SlackConversation {
+            id: "D1".to_string(),
+            name: None,
+            user: Some("U123".to_string()),
+            is_channel: None,
+            is_group: None,
+            is_im: Some(true),
+            is_mpim: None,
+            is_private: None,
+            is_archived: Some(false),
+            num_members: None,
+            purpose: None,
+            topic: None,
+        };
+        assert_eq!(slack_chat_type(&direct_chat), ChatType::Direct);
+        assert_eq!(conversation_name(&direct_chat), "dm-U123");
+
+        let mapped = map_chat(archived_group);
+        assert_eq!(mapped.description.as_deref(), Some("Topic text"));
+        assert!(!mapped.is_active);
+    }
+
+    #[test]
+    fn attachment_and_cursor_helpers_cover_fallback_paths() {
+        let attachments = map_attachments(&SlackMessage {
+            ts: "1710000000.000100".to_string(),
+            text: None,
+            user: None,
+            username: None,
+            bot_id: None,
+            thread_ts: None,
+            parent_user_id: None,
+            subtype: None,
+            edited: None,
+            files: Some(vec![SlackFile {
+                id: Some("F1".to_string()),
+                name: Some("report.pdf".to_string()),
+                mimetype: Some("application/pdf".to_string()),
+                filetype: None,
+                url_private: Some("https://private.example/report.pdf".to_string()),
+                permalink: None,
+            }]),
+            attachments: Some(vec![SlackRichAttachment {
+                id: Some(42),
+                title: None,
+                fallback: Some("Fallback title".to_string()),
+                service_name: Some("docs".to_string()),
+                title_link: None,
+                from_url: Some("https://example.com/doc".to_string()),
+            }]),
+            bot_profile: None,
+        });
+
+        assert_eq!(attachments.len(), 2);
+        assert_eq!(attachments[0].attachment_type.as_deref(), Some("file"));
+        assert_eq!(
+            attachments[0].url.as_deref(),
+            Some("https://private.example/report.pdf")
+        );
+        assert_eq!(attachments[1].id.as_deref(), Some("42"));
+        assert_eq!(attachments[1].name.as_deref(), Some("Fallback title"));
+        assert_eq!(attachments[1].url.as_deref(), Some("https://example.com/doc"));
+
+        assert_eq!(slack_conversation_types(Some(ChatType::Direct)), "im");
+        assert_eq!(slack_conversation_types(Some(ChatType::Group)), "mpim,private_channel");
+        assert_eq!(
+            slack_conversation_types(Some(ChatType::Channel)),
+            "public_channel,private_channel"
+        );
+        assert_eq!(
+            slack_conversation_types(None),
+            "public_channel,private_channel,mpim,im"
+        );
+        assert_eq!(
+            slack_next_cursor(Some(&SlackResponseMetadata {
+                next_cursor: " cursor-1 ".to_string(),
+            })),
+            Some("cursor-1".to_string())
+        );
+        assert_eq!(slack_next_cursor(None), None);
+    }
+
+    #[test]
+    fn ts_scope_and_markdown_helpers_cover_edge_cases() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-oauth-scopes",
+            " channels:read, , chat:write ".parse().unwrap(),
+        );
+
+        assert_eq!(normalize_ts_param(Some(" 1710000000.000100 ")).as_deref(), Some("1710000000.000100"));
+        assert_eq!(normalize_ts_param(Some("not-a-ts")), None);
+        assert_eq!(normalize_ts_param(Some("   ")), None);
+        assert_eq!(
+            parse_scopes(&headers),
+            vec!["channels:read".to_string(), "chat:write".to_string()]
+        );
+        assert!(parse_scopes(&HeaderMap::new()).is_empty());
+
+        assert_eq!(normalize_slack_token("@U123"), "@U123");
+        assert_eq!(normalize_slack_token("#C123|general"), "#general");
+        assert_eq!(normalize_slack_token("!here"), "here");
+        assert_eq!(normalize_slack_token("https://example.com|docs"), "[docs](https://example.com)");
+        assert_eq!(normalize_slack_token("plain-token"), "plain-token");
+        assert_eq!(normalize_mrkdwn("unterminated <https://example.com"), "unterminated <https://example.com");
+    }
+
+    #[test]
+    fn slack_error_helpers_map_expected_variants() {
+        assert!(ensure_ok(true, None).is_ok());
+        assert!(matches!(
+            ensure_ok(false, Some("missing_scope".to_string())).unwrap_err(),
+            Error::Forbidden(message) if message == "missing_scope"
+        ));
+        assert!(matches!(
+            map_slack_error("invalid_auth".to_string()),
+            Error::Unauthorized(message) if message == "invalid_auth"
+        ));
+        assert!(matches!(
+            map_slack_error("not_allowed_token_type".to_string()),
+            Error::Forbidden(message) if message == "not_allowed_token_type"
+        ));
+        assert!(matches!(
+            map_slack_error("channel_not_found".to_string()),
+            Error::NotFound(message) if message == "channel_not_found"
+        ));
+        assert!(matches!(
+            map_slack_error("ratelimited".to_string()),
+            Error::RateLimited { retry_after: None }
+        ));
+        assert!(matches!(
+            map_slack_error("other".to_string()),
+            Error::Api { status: 200, message } if message == "other"
+        ));
+    }
+
+    #[test]
     fn normalize_slack_markup_to_markdownish_text() {
         let text = normalize_mrkdwn(
             "See <https://example.com|docs> and talk to <@U123> in <#C123|general>",
@@ -1360,5 +1763,46 @@ mod tests {
         limiter.acquire(SlackRateLimitBucket::Write).await;
 
         assert!(start.elapsed() < Duration::from_millis(25));
+    }
+
+    #[test]
+    fn parse_search_cursor_accepts_legacy_chat_cursor() {
+        let state = parse_search_cursor(Some("chat-cursor-1")).unwrap();
+
+        assert_eq!(state.next_chats_cursor.as_deref(), Some("chat-cursor-1"));
+        assert!(state.current_chat_id.is_none());
+        assert!(state.pending_chat_ids.is_empty());
+    }
+
+    #[test]
+    fn search_cursor_round_trips_with_message_progress() {
+        let cursor = SlackSearchCursor {
+            version: 1,
+            current_chat_id: Some("C123".to_string()),
+            current_message_cursor: Some("msg-cursor-2".to_string()),
+            current_message_offset: 37,
+            pending_chat_ids: vec!["C124".to_string(), "C125".to_string()],
+            next_chats_cursor: Some("chat-cursor-9".to_string()),
+        };
+
+        let encoded = serialize_search_cursor(&cursor).unwrap().unwrap();
+        let decoded = parse_search_cursor(Some(&encoded)).unwrap();
+
+        assert_eq!(decoded.version, 1);
+        assert_eq!(decoded.current_chat_id.as_deref(), Some("C123"));
+        assert_eq!(
+            decoded.current_message_cursor.as_deref(),
+            Some("msg-cursor-2")
+        );
+        assert_eq!(decoded.current_message_offset, 37);
+        assert_eq!(decoded.pending_chat_ids, vec!["C124", "C125"]);
+        assert_eq!(decoded.next_chats_cursor.as_deref(), Some("chat-cursor-9"));
+    }
+
+    #[test]
+    fn serialize_search_cursor_omits_finished_state() {
+        let encoded = serialize_search_cursor(&SlackSearchCursor::default()).unwrap();
+
+        assert!(encoded.is_none());
     }
 }

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -1,10 +1,15 @@
+use std::borrow::Cow;
+
 use async_trait::async_trait;
+use devboy_core::types::ChatType;
 use devboy_core::{
-    Error, GetChatsParams, GetMessagesParams, MessengerChat, MessengerMessage, MessengerProvider,
-    ProviderResult, Result, SearchMessagesParams, SendMessageParams,
+    Error, GetChatsParams, GetMessagesParams, MessageAttachment, MessageAuthor, MessengerChat,
+    MessengerMessage, MessengerProvider, Pagination, ProviderResult, Result, SearchMessagesParams,
+    SendMessageParams,
 };
 use reqwest::header::HeaderMap;
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use tracing::debug;
 
 use crate::DEFAULT_SLACK_API_URL;
@@ -42,6 +47,130 @@ struct SlackAuthTestResponse {
     user_id: Option<String>,
     #[serde(rename = "bot_id")]
     bot_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackResponseMetadata {
+    #[serde(default)]
+    next_cursor: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackConversationsListResponse {
+    ok: bool,
+    error: Option<String>,
+    #[serde(default)]
+    channels: Vec<SlackConversation>,
+    response_metadata: Option<SlackResponseMetadata>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackConversation {
+    id: String,
+    name: Option<String>,
+    user: Option<String>,
+    is_channel: Option<bool>,
+    is_group: Option<bool>,
+    is_im: Option<bool>,
+    is_mpim: Option<bool>,
+    is_private: Option<bool>,
+    is_archived: Option<bool>,
+    num_members: Option<u32>,
+    purpose: Option<SlackTextValue>,
+    topic: Option<SlackTextValue>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackTextValue {
+    value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackMessagesResponse {
+    ok: bool,
+    error: Option<String>,
+    #[serde(default)]
+    messages: Vec<SlackMessage>,
+    has_more: Option<bool>,
+    response_metadata: Option<SlackResponseMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackPostMessageResponse {
+    ok: bool,
+    error: Option<String>,
+    channel: Option<String>,
+    ts: Option<String>,
+    message: Option<SlackMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackUsersInfoResponse {
+    ok: bool,
+    error: Option<String>,
+    user: Option<SlackUser>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackUser {
+    id: String,
+    name: Option<String>,
+    profile: Option<SlackUserProfile>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackUserProfile {
+    real_name: Option<String>,
+    display_name: Option<String>,
+    image_72: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackMessage {
+    ts: String,
+    text: Option<String>,
+    user: Option<String>,
+    username: Option<String>,
+    bot_id: Option<String>,
+    thread_ts: Option<String>,
+    parent_user_id: Option<String>,
+    subtype: Option<String>,
+    edited: Option<serde_json::Value>,
+    files: Option<Vec<SlackFile>>,
+    attachments: Option<Vec<SlackRichAttachment>>,
+    bot_profile: Option<SlackBotProfile>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackBotProfile {
+    id: Option<String>,
+    name: Option<String>,
+    icons: Option<SlackBotIcons>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackBotIcons {
+    image_72: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackFile {
+    id: Option<String>,
+    name: Option<String>,
+    mimetype: Option<String>,
+    filetype: Option<String>,
+    url_private: Option<String>,
+    permalink: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlackRichAttachment {
+    id: Option<u64>,
+    title: Option<String>,
+    fallback: Option<String>,
+    service_name: Option<String>,
+    title_link: Option<String>,
+    from_url: Option<String>,
 }
 
 impl SlackClient {
@@ -137,6 +266,213 @@ impl SlackClient {
             )))
         }
     }
+
+    async fn post_form<T>(&self, method: &str, params: &[(&str, String)]) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let url = format!("{}/{}", self.base_url, method);
+        debug!(url, "slack api request");
+
+        let response = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.token)
+            .form(params)
+            .send()
+            .await
+            .map_err(|e| Error::Network(e.to_string()))?;
+
+        map_http_error(response).await
+    }
+
+    async fn get_conversations(
+        &self,
+        params: &GetChatsParams,
+    ) -> Result<ProviderResult<MessengerChat>> {
+        let limit = params.limit.unwrap_or(100).min(1000);
+        let mut form = vec![
+            ("limit", limit.to_string()),
+            (
+                "types",
+                slack_conversation_types(params.chat_type).to_string(),
+            ),
+            (
+                "exclude_archived",
+                (!params.include_inactive.unwrap_or(false)).to_string(),
+            ),
+        ];
+        if let Some(cursor) = params.cursor.as_ref() {
+            form.push(("cursor", cursor.clone()));
+        }
+
+        let payload: SlackConversationsListResponse =
+            self.post_form("conversations.list", &form).await?;
+        ensure_ok(payload.ok, payload.error)?;
+
+        let mut items: Vec<_> = payload
+            .channels
+            .into_iter()
+            .filter(|chat| matches_chat_filter(chat, params))
+            .map(map_chat)
+            .collect();
+
+        if let Some(limit) = params.limit {
+            items.truncate(limit as usize);
+        }
+
+        let has_more = payload
+            .response_metadata
+            .as_ref()
+            .map(|meta| !meta.next_cursor.is_empty())
+            .unwrap_or(false);
+
+        Ok(ProviderResult::new(items).with_pagination(Pagination {
+            offset: 0,
+            limit,
+            total: None,
+            has_more,
+        }))
+    }
+
+    async fn get_messages_page(
+        &self,
+        params: &GetMessagesParams,
+    ) -> Result<ProviderResult<MessengerMessage>> {
+        let limit = params.limit.unwrap_or(100).min(1000);
+        let mut form = vec![
+            ("channel", params.chat_id.clone()),
+            ("limit", limit.to_string()),
+            ("inclusive", "true".to_string()),
+        ];
+        if let Some(cursor) = params.cursor.as_ref() {
+            form.push(("cursor", cursor.clone()));
+        }
+        if let Some(since) = normalize_ts_param(params.since.as_deref()) {
+            form.push(("oldest", since.into_owned()));
+        }
+        if let Some(until) = normalize_ts_param(params.until.as_deref()) {
+            form.push(("latest", until.into_owned()));
+        }
+
+        let payload: SlackMessagesResponse = if let Some(thread_id) = params.thread_id.as_ref() {
+            form.push(("ts", thread_id.clone()));
+            self.post_form("conversations.replies", &form).await?
+        } else {
+            self.post_form("conversations.history", &form).await?
+        };
+        ensure_ok(payload.ok, payload.error)?;
+
+        let mut items = Vec::with_capacity(payload.messages.len());
+        for message in payload.messages {
+            items.push(self.map_message(&params.chat_id, message).await?);
+        }
+
+        let has_more = payload.has_more.unwrap_or(false)
+            || payload
+                .response_metadata
+                .as_ref()
+                .map(|meta| !meta.next_cursor.is_empty())
+                .unwrap_or(false);
+
+        Ok(ProviderResult::new(items).with_pagination(Pagination {
+            offset: 0,
+            limit,
+            total: None,
+            has_more,
+        }))
+    }
+
+    async fn map_message(&self, chat_id: &str, message: SlackMessage) -> Result<MessengerMessage> {
+        let ts = message.ts.clone();
+        let thread_id = message.thread_ts.clone();
+        let reply_to_id = thread_id.as_ref().filter(|thread| *thread != &ts).cloned();
+
+        Ok(MessengerMessage {
+            id: ts.clone(),
+            chat_id: chat_id.to_string(),
+            text: normalize_mrkdwn(message.text.as_deref().unwrap_or_default()),
+            author: self.resolve_author(&message).await?,
+            source: "slack".to_string(),
+            timestamp: ts,
+            thread_id,
+            reply_to_id,
+            attachments: map_attachments(&message),
+            is_edited: message.edited.is_some(),
+        })
+    }
+
+    async fn resolve_author(&self, message: &SlackMessage) -> Result<MessageAuthor> {
+        if let Some(user_id) = message.user.as_deref() {
+            return self.get_user(user_id).await;
+        }
+
+        if let Some(bot_profile) = message.bot_profile.as_ref() {
+            return Ok(MessageAuthor {
+                id: bot_profile
+                    .id
+                    .clone()
+                    .or_else(|| message.bot_id.clone())
+                    .unwrap_or_else(|| "slack-bot".to_string()),
+                name: bot_profile
+                    .name
+                    .clone()
+                    .or_else(|| message.username.clone())
+                    .unwrap_or_else(|| "Slack Bot".to_string()),
+                username: message.username.clone(),
+                avatar_url: bot_profile
+                    .icons
+                    .as_ref()
+                    .and_then(|icons| icons.image_72.clone()),
+            });
+        }
+
+        Ok(MessageAuthor {
+            id: message
+                .bot_id
+                .clone()
+                .or_else(|| message.parent_user_id.clone())
+                .unwrap_or_else(|| "unknown".to_string()),
+            name: message
+                .username
+                .clone()
+                .or_else(|| message.subtype.clone())
+                .unwrap_or_else(|| "Unknown".to_string()),
+            username: message.username.clone(),
+            avatar_url: None,
+        })
+    }
+
+    async fn get_user(&self, user_id: &str) -> Result<MessageAuthor> {
+        let payload: SlackUsersInfoResponse = self
+            .post_form("users.info", &[("user", user_id.to_string())])
+            .await?;
+        ensure_ok(payload.ok, payload.error)?;
+
+        let user = payload
+            .user
+            .ok_or_else(|| Error::InvalidData("Slack users.info returned no user".to_string()))?;
+        let profile = user.profile.as_ref();
+        let display_name = profile
+            .and_then(|profile| profile.display_name.clone())
+            .filter(|name| !name.is_empty());
+        let real_name = profile
+            .and_then(|profile| profile.real_name.clone())
+            .filter(|name| !name.is_empty());
+        let username = user.name.filter(|name| !name.is_empty());
+        let name = display_name
+            .clone()
+            .or(real_name)
+            .or_else(|| username.clone())
+            .unwrap_or_else(|| user.id.clone());
+
+        Ok(MessageAuthor {
+            id: user.id,
+            name,
+            username,
+            avatar_url: profile.and_then(|profile| profile.image_72.clone()),
+        })
+    }
 }
 
 #[async_trait]
@@ -145,38 +481,265 @@ impl MessengerProvider for SlackClient {
         "slack"
     }
 
-    async fn get_chats(&self, _params: GetChatsParams) -> Result<ProviderResult<MessengerChat>> {
-        Err(Error::ProviderUnsupported {
-            provider: self.provider_name().to_string(),
-            operation: "get_chats".to_string(),
-        })
+    async fn get_chats(&self, params: GetChatsParams) -> Result<ProviderResult<MessengerChat>> {
+        self.get_conversations(&params).await
     }
 
     async fn get_messages(
         &self,
-        _params: GetMessagesParams,
+        params: GetMessagesParams,
     ) -> Result<ProviderResult<MessengerMessage>> {
-        Err(Error::ProviderUnsupported {
-            provider: self.provider_name().to_string(),
-            operation: "get_messages".to_string(),
-        })
+        self.get_messages_page(&params).await
     }
 
     async fn search_messages(
         &self,
-        _params: SearchMessagesParams,
+        params: SearchMessagesParams,
     ) -> Result<ProviderResult<MessengerMessage>> {
-        Err(Error::ProviderUnsupported {
-            provider: self.provider_name().to_string(),
-            operation: "search_messages".to_string(),
-        })
+        let query = params.query.trim().to_lowercase();
+        if query.is_empty() {
+            return Err(Error::InvalidData(
+                "search query must not be empty".to_string(),
+            ));
+        }
+
+        let limit = params.limit.unwrap_or(20) as usize;
+        let mut found = Vec::new();
+
+        let has_more = if let Some(chat_id) = params.chat_id.as_ref() {
+            let messages = self
+                .get_messages_page(&GetMessagesParams {
+                    chat_id: chat_id.clone(),
+                    limit: Some(params.limit.unwrap_or(100)),
+                    cursor: params.cursor.clone(),
+                    thread_id: None,
+                    since: params.since.clone(),
+                    until: params.until.clone(),
+                })
+                .await?;
+            for message in messages.items {
+                if message.text.to_lowercase().contains(&query) {
+                    found.push(message);
+                    if found.len() >= limit {
+                        break;
+                    }
+                }
+            }
+            messages.pagination.map(|p| p.has_more).unwrap_or(false)
+        } else {
+            let chats = self
+                .get_conversations(&GetChatsParams {
+                    search: None,
+                    chat_type: None,
+                    limit: Some(100),
+                    cursor: params.cursor.clone(),
+                    include_inactive: Some(false),
+                })
+                .await?;
+            let mut has_more = chats
+                .pagination
+                .as_ref()
+                .map(|p| p.has_more)
+                .unwrap_or(false);
+
+            for chat in chats.items {
+                let messages = self
+                    .get_messages_page(&GetMessagesParams {
+                        chat_id: chat.id.clone(),
+                        limit: Some(100),
+                        cursor: None,
+                        thread_id: None,
+                        since: params.since.clone(),
+                        until: params.until.clone(),
+                    })
+                    .await?;
+
+                for message in messages.items {
+                    if message.text.to_lowercase().contains(&query) {
+                        found.push(message);
+                        if found.len() >= limit {
+                            break;
+                        }
+                    }
+                }
+
+                has_more = has_more || messages.pagination.map(|p| p.has_more).unwrap_or(false);
+                if found.len() >= limit {
+                    break;
+                }
+            }
+            has_more
+        };
+
+        Ok(ProviderResult::new(found).with_pagination(Pagination {
+            offset: 0,
+            limit: limit as u32,
+            total: None,
+            has_more,
+        }))
     }
 
     async fn send_message(&self, params: SendMessageParams) -> Result<MessengerMessage> {
-        Err(Error::ProviderUnsupported {
-            provider: self.provider_name().to_string(),
-            operation: format!("send_message to {}", params.chat_id),
-        })
+        let mut form = vec![
+            ("channel", params.chat_id.clone()),
+            ("text", params.text.clone()),
+            ("unfurl_links", "false".to_string()),
+            ("unfurl_media", "false".to_string()),
+        ];
+        if let Some(thread_id) = params.thread_id.as_ref() {
+            form.push(("thread_ts", thread_id.clone()));
+        }
+
+        let payload: SlackPostMessageResponse = self.post_form("chat.postMessage", &form).await?;
+        ensure_ok(payload.ok, payload.error)?;
+
+        let mut message = payload.message.unwrap_or(SlackMessage {
+            ts: payload.ts.clone().unwrap_or_default(),
+            text: Some(params.text),
+            user: None,
+            username: None,
+            bot_id: None,
+            thread_ts: params.thread_id.clone(),
+            parent_user_id: None,
+            subtype: None,
+            edited: None,
+            files: None,
+            attachments: None,
+            bot_profile: None,
+        });
+
+        if message.thread_ts.is_none() {
+            message.thread_ts = params.thread_id;
+        }
+
+        self.map_message(
+            payload.channel.as_deref().unwrap_or(&params.chat_id),
+            message,
+        )
+        .await
+    }
+}
+
+fn map_chat(chat: SlackConversation) -> MessengerChat {
+    let name = conversation_name(&chat);
+    let description = chat
+        .purpose
+        .as_ref()
+        .and_then(|value| value.value.clone())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            chat.topic
+                .as_ref()
+                .and_then(|value| value.value.clone())
+                .filter(|value| !value.is_empty())
+        });
+
+    MessengerChat {
+        id: chat.id.clone(),
+        key: format!("slack:{}", chat.id),
+        name,
+        chat_type: slack_chat_type(&chat),
+        source: "slack".to_string(),
+        member_count: chat.num_members,
+        description,
+        is_active: !chat.is_archived.unwrap_or(false),
+    }
+}
+
+fn map_attachments(message: &SlackMessage) -> Vec<MessageAttachment> {
+    let mut attachments = Vec::new();
+
+    if let Some(files) = message.files.as_ref() {
+        attachments.extend(files.iter().map(|file| MessageAttachment {
+            id: file.id.clone(),
+            name: file.name.clone(),
+            attachment_type: file.filetype.clone().or_else(|| Some("file".to_string())),
+            url: file.permalink.clone().or_else(|| file.url_private.clone()),
+            mime_type: file.mimetype.clone(),
+        }));
+    }
+
+    if let Some(rich_attachments) = message.attachments.as_ref() {
+        attachments.extend(rich_attachments.iter().map(|attachment| {
+            MessageAttachment {
+                id: attachment.id.map(|id| id.to_string()),
+                name: attachment
+                    .title
+                    .clone()
+                    .or_else(|| attachment.fallback.clone()),
+                attachment_type: attachment.service_name.clone(),
+                url: attachment
+                    .title_link
+                    .clone()
+                    .or_else(|| attachment.from_url.clone()),
+                mime_type: None,
+            }
+        }));
+    }
+
+    attachments
+}
+
+fn matches_chat_filter(chat: &SlackConversation, params: &GetChatsParams) -> bool {
+    if let Some(expected) = params.chat_type
+        && slack_chat_type(chat) != expected
+    {
+        return false;
+    }
+
+    if let Some(search) = params.search.as_deref() {
+        let needle = search.to_lowercase();
+        let haystack = conversation_name(chat).to_lowercase();
+        if !haystack.contains(&needle) {
+            return false;
+        }
+    }
+
+    if !params.include_inactive.unwrap_or(false) && chat.is_archived.unwrap_or(false) {
+        return false;
+    }
+
+    true
+}
+
+fn slack_chat_type(chat: &SlackConversation) -> ChatType {
+    if chat.is_im.unwrap_or(false) {
+        ChatType::Direct
+    } else if chat.is_group.unwrap_or(false) || chat.is_mpim.unwrap_or(false) {
+        ChatType::Group
+    } else if chat.is_channel.unwrap_or(false) || chat.is_private.unwrap_or(false) {
+        ChatType::Channel
+    } else {
+        ChatType::Channel
+    }
+}
+
+fn conversation_name(chat: &SlackConversation) -> String {
+    chat.name
+        .clone()
+        .filter(|name| !name.is_empty())
+        .or_else(|| chat.user.clone().map(|user| format!("dm-{}", user)))
+        .unwrap_or_else(|| chat.id.clone())
+}
+
+fn slack_conversation_types(chat_type: Option<ChatType>) -> &'static str {
+    match chat_type {
+        Some(ChatType::Direct) => "im",
+        Some(ChatType::Group) => "mpim,private_channel",
+        Some(ChatType::Channel) => "public_channel,private_channel",
+        None => "public_channel,private_channel,mpim,im",
+    }
+}
+
+fn normalize_ts_param(value: Option<&str>) -> Option<Cow<'_, str>> {
+    let value = value?.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if value.parse::<f64>().is_ok() {
+        Some(Cow::Borrowed(value))
+    } else {
+        None
     }
 }
 
@@ -193,6 +756,109 @@ fn parse_scopes(headers: &HeaderMap) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+async fn map_http_error<T>(response: reqwest::Response) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let status = response.status();
+    let retry_after = response
+        .headers()
+        .get("retry-after")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok());
+
+    if status.as_u16() == 429 {
+        return Err(Error::RateLimited { retry_after });
+    }
+
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        return Err(Error::from_status(status.as_u16(), text));
+    }
+
+    response
+        .json()
+        .await
+        .map_err(|e| Error::InvalidData(e.to_string()))
+}
+
+fn ensure_ok(ok: bool, error: Option<String>) -> Result<()> {
+    if ok {
+        Ok(())
+    } else {
+        Err(map_slack_error(
+            error.unwrap_or_else(|| "unknown_slack_error".to_string()),
+        ))
+    }
+}
+
+fn map_slack_error(message: String) -> Error {
+    match message.as_str() {
+        "invalid_auth" | "not_authed" => Error::Unauthorized(message),
+        "missing_scope" | "not_allowed_token_type" => Error::Forbidden(message),
+        "channel_not_found" | "user_not_found" => Error::NotFound(message),
+        "ratelimited" => Error::RateLimited { retry_after: None },
+        _ => Error::Api {
+            status: 200,
+            message,
+        },
+    }
+}
+
+fn normalize_mrkdwn(text: &str) -> String {
+    let decoded = text
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">");
+
+    let mut output = String::new();
+    let mut chars = decoded.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '<' {
+            let mut token = String::new();
+            let mut closed = false;
+            for next in chars.by_ref() {
+                if next == '>' {
+                    closed = true;
+                    break;
+                }
+                token.push(next);
+            }
+
+            if closed {
+                output.push_str(&normalize_slack_token(&token));
+            } else {
+                output.push('<');
+                output.push_str(&token);
+            }
+        } else {
+            output.push(ch);
+        }
+    }
+
+    output
+}
+
+fn normalize_slack_token(token: &str) -> String {
+    if let Some(user) = token.strip_prefix('@') {
+        return format!("@{}", user);
+    }
+    if let Some(rest) = token.strip_prefix('#') {
+        let mut parts = rest.splitn(2, '|');
+        let _ = parts.next();
+        let label = parts.next().unwrap_or(rest);
+        return format!("#{}", label);
+    }
+    if let Some(rest) = token.strip_prefix('!') {
+        return rest.replace('|', " ");
+    }
+    if let Some((url, label)) = token.split_once('|') {
+        return format!("[{}]({})", label, url);
+    }
+    token.to_string()
 }
 
 #[cfg(test)]
@@ -258,25 +924,142 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn messenger_methods_are_scaffolded_as_unsupported() {
-        let client = SlackClient::new("xoxb-test");
+    async fn get_chats_maps_slack_conversations() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/conversations.list");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "channels": [
+                    {
+                        "id": "C123",
+                        "name": "engineering",
+                        "is_channel": true,
+                        "is_archived": false,
+                        "num_members": 4,
+                        "purpose": { "value": "Team chat" }
+                    }
+                ],
+                "response_metadata": { "next_cursor": "" }
+            }));
+        });
 
-        let err = client
+        let result = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
             .get_chats(GetChatsParams::default())
             .await
-            .unwrap_err();
-        assert!(matches!(err, Error::ProviderUnsupported { .. }));
+            .unwrap();
 
-        let err = client
-            .send_message(SendMessageParams {
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].name, "engineering");
+        assert_eq!(result.items[0].chat_type, ChatType::Channel);
+    }
+
+    #[tokio::test]
+    async fn get_messages_fetches_thread_replies() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/conversations.replies");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "messages": [
+                    {
+                        "ts": "1710000000.000100",
+                        "text": "Root",
+                        "user": "U123",
+                        "thread_ts": "1710000000.000100"
+                    },
+                    {
+                        "ts": "1710000001.000100",
+                        "text": "Reply",
+                        "user": "U123",
+                        "thread_ts": "1710000000.000100"
+                    }
+                ]
+            }));
+        });
+        server.mock(|when, then| {
+            when.method(POST).path("/users.info");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "user": {
+                    "id": "U123",
+                    "name": "andrey",
+                    "profile": {
+                        "display_name": "Andrey",
+                        "real_name": "Andrey Maznyak",
+                        "image_72": "https://example.com/avatar.png"
+                    }
+                }
+            }));
+        });
+
+        let result = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .get_messages(GetMessagesParams {
                 chat_id: "C123".to_string(),
-                text: "hello".to_string(),
-                thread_id: None,
-                reply_to_id: None,
-                attachments: vec![devboy_core::MessageAttachment::default()],
+                limit: Some(20),
+                cursor: None,
+                thread_id: Some("1710000000.000100".to_string()),
+                since: None,
+                until: None,
             })
             .await
-            .unwrap_err();
-        assert!(matches!(err, Error::ProviderUnsupported { .. }));
+            .unwrap();
+
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(
+            result.items[1].reply_to_id.as_deref(),
+            Some("1710000000.000100")
+        );
+        assert_eq!(result.items[0].author.name, "Andrey");
+    }
+
+    #[tokio::test]
+    async fn send_message_maps_response() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/chat.postMessage");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "channel": "C123",
+                "ts": "1710000100.000200",
+                "message": {
+                    "ts": "1710000100.000200",
+                    "text": "hello world",
+                    "bot_profile": {
+                        "id": "B123",
+                        "name": "Devboy",
+                        "icons": { "image_72": "https://example.com/bot.png" }
+                    }
+                }
+            }));
+        });
+
+        let result = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .send_message(SendMessageParams {
+                chat_id: "C123".to_string(),
+                text: "hello world".to_string(),
+                thread_id: None,
+                reply_to_id: None,
+                attachments: vec![],
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.chat_id, "C123");
+        assert_eq!(result.text, "hello world");
+        assert_eq!(result.author.name, "Devboy");
+    }
+
+    #[test]
+    fn normalize_slack_markup_to_markdownish_text() {
+        let text = normalize_mrkdwn(
+            "See <https://example.com|docs> and talk to <@U123> in <#C123|general>",
+        );
+        assert!(text.contains("[docs](https://example.com)"));
+        assert!(text.contains("@U123"));
+        assert!(text.contains("#general"));
     }
 }

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -1481,7 +1481,9 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(matches!(error, Error::InvalidData(message) if message.contains("must not be empty")));
+        assert!(
+            matches!(error, Error::InvalidData(message) if message.contains("must not be empty"))
+        );
     }
 
     #[tokio::test]
@@ -1637,10 +1639,16 @@ mod tests {
         );
         assert_eq!(attachments[1].id.as_deref(), Some("42"));
         assert_eq!(attachments[1].name.as_deref(), Some("Fallback title"));
-        assert_eq!(attachments[1].url.as_deref(), Some("https://example.com/doc"));
+        assert_eq!(
+            attachments[1].url.as_deref(),
+            Some("https://example.com/doc")
+        );
 
         assert_eq!(slack_conversation_types(Some(ChatType::Direct)), "im");
-        assert_eq!(slack_conversation_types(Some(ChatType::Group)), "mpim,private_channel");
+        assert_eq!(
+            slack_conversation_types(Some(ChatType::Group)),
+            "mpim,private_channel"
+        );
         assert_eq!(
             slack_conversation_types(Some(ChatType::Channel)),
             "public_channel,private_channel"
@@ -1666,7 +1674,10 @@ mod tests {
             " channels:read, , chat:write ".parse().unwrap(),
         );
 
-        assert_eq!(normalize_ts_param(Some(" 1710000000.000100 ")).as_deref(), Some("1710000000.000100"));
+        assert_eq!(
+            normalize_ts_param(Some(" 1710000000.000100 ")).as_deref(),
+            Some("1710000000.000100")
+        );
         assert_eq!(normalize_ts_param(Some("not-a-ts")), None);
         assert_eq!(normalize_ts_param(Some("   ")), None);
         assert_eq!(
@@ -1678,9 +1689,15 @@ mod tests {
         assert_eq!(normalize_slack_token("@U123"), "@U123");
         assert_eq!(normalize_slack_token("#C123|general"), "#general");
         assert_eq!(normalize_slack_token("!here"), "here");
-        assert_eq!(normalize_slack_token("https://example.com|docs"), "[docs](https://example.com)");
+        assert_eq!(
+            normalize_slack_token("https://example.com|docs"),
+            "[docs](https://example.com)"
+        );
         assert_eq!(normalize_slack_token("plain-token"), "plain-token");
-        assert_eq!(normalize_mrkdwn("unterminated <https://example.com"), "unterminated <https://example.com");
+        assert_eq!(
+            normalize_mrkdwn("unterminated <https://example.com"),
+            "unterminated <https://example.com"
+        );
     }
 
     #[test]

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -98,11 +98,9 @@ struct SlackConversation {
     id: String,
     name: Option<String>,
     user: Option<String>,
-    is_channel: Option<bool>,
     is_group: Option<bool>,
     is_im: Option<bool>,
     is_mpim: Option<bool>,
-    is_private: Option<bool>,
     is_archived: Option<bool>,
     num_members: Option<u32>,
     purpose: Option<SlackTextValue>,
@@ -905,8 +903,6 @@ fn slack_chat_type(chat: &SlackConversation) -> ChatType {
         ChatType::Direct
     } else if chat.is_group.unwrap_or(false) || chat.is_mpim.unwrap_or(false) {
         ChatType::Group
-    } else if chat.is_channel.unwrap_or(false) || chat.is_private.unwrap_or(false) {
-        ChatType::Channel
     } else {
         ChatType::Channel
     }
@@ -1009,7 +1005,7 @@ impl SlackRateLimiter {
     }
 
     async fn on_rate_limited(&self, bucket: SlackRateLimitBucket, retry_after: Option<Duration>) {
-        let delay = retry_after.unwrap_or_else(|| match bucket {
+        let delay = retry_after.unwrap_or(match bucket {
             SlackRateLimitBucket::Read => self.read_interval,
             SlackRateLimitBucket::Write => self.write_interval,
         });
@@ -1548,11 +1544,9 @@ mod tests {
             id: "C1".to_string(),
             name: Some("Project Alpha".to_string()),
             user: None,
-            is_channel: None,
             is_group: Some(true),
             is_im: None,
             is_mpim: None,
-            is_private: None,
             is_archived: Some(true),
             num_members: Some(3),
             purpose: Some(SlackTextValue {
@@ -1588,11 +1582,9 @@ mod tests {
             id: "D1".to_string(),
             name: None,
             user: Some("U123".to_string()),
-            is_channel: None,
             is_group: None,
             is_im: Some(true),
             is_mpim: None,
-            is_private: None,
             is_archived: Some(false),
             num_members: None,
             purpose: None,

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -585,29 +585,84 @@ impl MessengerProvider for SlackClient {
         let mut found = Vec::new();
 
         let (has_more, next_cursor) = if let Some(chat_id) = params.chat_id.as_ref() {
-            let messages = self
-                .get_messages_page(&GetMessagesParams {
-                    chat_id: chat_id.clone(),
-                    limit: Some(params.limit.unwrap_or(100)),
-                    cursor: params.cursor.clone(),
-                    thread_id: None,
-                    since: params.since.clone(),
-                    until: params.until.clone(),
-                })
-                .await?;
-            let pagination = messages.pagination.clone();
-            for message in messages.items {
-                if message.text.to_lowercase().contains(&query) {
-                    found.push(message);
-                    if found.len() >= limit {
-                        break;
+            let mut state = parse_search_cursor(params.cursor.as_deref())?;
+            if state.current_chat_id.is_none() {
+                state.current_chat_id = Some(chat_id.clone());
+            }
+            if state.current_chat_id.as_deref() != Some(chat_id.as_str()) {
+                state = SlackSearchCursor {
+                    current_chat_id: Some(chat_id.clone()),
+                    ..SlackSearchCursor::default()
+                };
+            }
+            if state.current_message_cursor.is_none()
+                && state.current_message_offset == 0
+                && state.next_chats_cursor.is_some()
+                && !has_pending_chat_ids(&state)
+            {
+                state.current_message_cursor = state.next_chats_cursor.take();
+            }
+
+            loop {
+                let messages = self
+                    .get_messages_page(&GetMessagesParams {
+                        chat_id: chat_id.clone(),
+                        limit: Some(params.limit.unwrap_or(100)),
+                        cursor: state.current_message_cursor.clone(),
+                        thread_id: None,
+                        since: params.since.clone(),
+                        until: params.until.clone(),
+                    })
+                    .await?;
+                let pagination = messages.pagination.clone();
+                let page_len = messages.items.len();
+
+                for message in messages
+                    .items
+                    .into_iter()
+                    .skip(state.current_message_offset)
+                {
+                    state.current_message_offset += 1;
+                    if message.text.to_lowercase().contains(&query) {
+                        found.push(message);
+                        if found.len() >= limit {
+                            break;
+                        }
                     }
                 }
+
+                let page_has_more = pagination.as_ref().map(|p| p.has_more).unwrap_or(false);
+                let next_page_cursor = pagination.as_ref().and_then(|p| p.next_cursor.clone());
+
+                if found.len() >= limit {
+                    if state.current_message_offset >= page_len {
+                        if page_has_more {
+                            state.current_message_cursor = next_page_cursor;
+                            state.current_message_offset = 0;
+                        } else {
+                            state.current_chat_id = None;
+                            state.current_message_cursor = None;
+                            state.current_message_offset = 0;
+                        }
+                    }
+                    break;
+                }
+
+                if page_has_more {
+                    state.current_message_cursor = next_page_cursor;
+                    state.current_message_offset = 0;
+                    continue;
+                }
+
+                state.current_chat_id = None;
+                state.current_message_cursor = None;
+                state.current_message_offset = 0;
+                break;
             }
-            (
-                pagination.as_ref().map(|p| p.has_more).unwrap_or(false),
-                pagination.and_then(|p| p.next_cursor),
-            )
+
+            let has_more = state.current_chat_id.is_some();
+            let next_cursor = serialize_search_cursor(&state)?;
+            (has_more, next_cursor)
         } else {
             let mut state = parse_search_cursor(params.cursor.as_deref())?;
             let mut chats_loaded = state.current_chat_id.is_some()
@@ -1607,6 +1662,74 @@ mod tests {
         assert_eq!(state.pending_chat_ids, vec!["C1", "C2"]);
         assert_eq!(state.pending_chat_index, 1);
         assert_eq!(state.next_chats_cursor.as_deref(), Some("chat-page-2"));
+    }
+
+    #[tokio::test]
+    async fn search_messages_chat_cursor_resumes_within_page_before_next_page() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/conversations.history");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "messages": [
+                    { "ts": "1710000000.000100", "text": "needle first", "username": "bot" },
+                    { "ts": "1710000001.000100", "text": "needle second", "username": "bot" },
+                    { "ts": "1710000002.000100", "text": "no match", "username": "bot" }
+                ],
+                "has_more": true,
+                "response_metadata": { "next_cursor": "msg-page-2" }
+            }));
+        });
+
+        let client = SlackClient::new("xoxb-test").with_base_url(server.base_url());
+        let first = client
+            .search_messages(SearchMessagesParams {
+                chat_id: Some("C1".to_string()),
+                query: "needle".to_string(),
+                limit: Some(1),
+                ..SearchMessagesParams::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(first.items.len(), 1);
+        assert_eq!(first.items[0].text, "needle first");
+        assert!(first.pagination.as_ref().unwrap().has_more);
+
+        let cursor = first
+            .pagination
+            .as_ref()
+            .and_then(|pagination| pagination.next_cursor.clone())
+            .unwrap();
+        let state = parse_search_cursor(Some(&cursor)).unwrap();
+        assert_eq!(state.current_chat_id.as_deref(), Some("C1"));
+        assert_eq!(state.current_message_cursor, None);
+        assert_eq!(state.current_message_offset, 1);
+
+        let second = client
+            .search_messages(SearchMessagesParams {
+                chat_id: Some("C1".to_string()),
+                query: "needle".to_string(),
+                limit: Some(1),
+                cursor: Some(cursor),
+                ..SearchMessagesParams::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(second.items.len(), 1);
+        assert_eq!(second.items[0].text, "needle second");
+        assert!(second.pagination.as_ref().unwrap().has_more);
+
+        let second_cursor = second
+            .pagination
+            .as_ref()
+            .and_then(|pagination| pagination.next_cursor.clone())
+            .unwrap();
+        let second_state = parse_search_cursor(Some(&second_cursor)).unwrap();
+        assert_eq!(second_state.current_chat_id.as_deref(), Some("C1"));
+        assert_eq!(second_state.current_message_cursor, None);
+        assert_eq!(second_state.current_message_offset, 2);
     }
 
     #[test]

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -131,6 +130,8 @@ struct SlackSearchCursor {
     current_message_offset: usize,
     #[serde(default)]
     pending_chat_ids: Vec<String>,
+    #[serde(default)]
+    pending_chat_index: usize,
     next_chats_cursor: Option<String>,
 }
 
@@ -422,11 +423,11 @@ impl SlackClient {
         if let Some(cursor) = params.cursor.as_ref() {
             form.push(("cursor", cursor.clone()));
         }
-        if let Some(since) = normalize_ts_param(params.since.as_deref()) {
-            form.push(("oldest", since.into_owned()));
+        if let Some(since) = normalize_ts_param("since", params.since.as_deref())? {
+            form.push(("oldest", since));
         }
-        if let Some(until) = normalize_ts_param(params.until.as_deref()) {
-            form.push(("latest", until.into_owned()));
+        if let Some(until) = normalize_ts_param("until", params.until.as_deref())? {
+            form.push(("latest", until));
         }
 
         let payload: SlackMessagesResponse = if let Some(thread_id) = params.thread_id.as_ref() {
@@ -626,7 +627,7 @@ impl MessengerProvider for SlackClient {
         } else {
             let mut state = parse_search_cursor(params.cursor.as_deref())?;
             let mut chats_loaded = state.current_chat_id.is_some()
-                || !state.pending_chat_ids.is_empty()
+                || has_pending_chat_ids(&state)
                 || state.next_chats_cursor.is_some()
                 || params.cursor.is_some();
 
@@ -703,8 +704,8 @@ impl MessengerProvider for SlackClient {
                     continue;
                 }
 
-                if !state.pending_chat_ids.is_empty() {
-                    state.current_chat_id = Some(state.pending_chat_ids.remove(0));
+                if let Some(next_chat_id) = take_next_pending_chat_id(&mut state) {
+                    state.current_chat_id = Some(next_chat_id);
                     state.current_message_cursor = None;
                     state.current_message_offset = 0;
                     continue;
@@ -724,12 +725,13 @@ impl MessengerProvider for SlackClient {
                     })
                     .await?;
                 state.pending_chat_ids = chats.items.into_iter().map(|chat| chat.id).collect();
+                state.pending_chat_index = 0;
                 state.next_chats_cursor = chats.pagination.and_then(|page| page.next_cursor);
                 chats_loaded = true;
             }
 
             let has_more = state.current_chat_id.is_some()
-                || !state.pending_chat_ids.is_empty()
+                || has_pending_chat_ids(&state)
                 || state.next_chats_cursor.is_some();
             let next_cursor = serialize_search_cursor(&state)?;
             (has_more, next_cursor)
@@ -745,6 +747,13 @@ impl MessengerProvider for SlackClient {
     }
 
     async fn send_message(&self, params: SendMessageParams) -> Result<MessengerMessage> {
+        if !params.attachments.is_empty() {
+            return Err(Error::ProviderUnsupported {
+                provider: self.provider_name().to_string(),
+                operation: "send_message attachments".to_string(),
+            });
+        }
+
         let thread_ts = params
             .thread_id
             .clone()
@@ -805,7 +814,7 @@ fn parse_search_cursor(cursor: Option<&str>) -> Result<SlackSearchCursor> {
 
 fn serialize_search_cursor(state: &SlackSearchCursor) -> Result<Option<String>> {
     let has_more = state.current_chat_id.is_some()
-        || !state.pending_chat_ids.is_empty()
+        || has_pending_chat_ids(state)
         || state.next_chats_cursor.is_some();
     if !has_more {
         return Ok(None);
@@ -939,16 +948,37 @@ fn slack_rate_limit_bucket(method: &str) -> SlackRateLimitBucket {
     }
 }
 
-fn normalize_ts_param(value: Option<&str>) -> Option<Cow<'_, str>> {
-    let value = value?.trim();
+fn normalize_ts_param(field_name: &str, value: Option<&str>) -> Result<Option<String>> {
+    let Some(value) = value.map(str::trim) else {
+        return Ok(None);
+    };
     if value.is_empty() {
-        return None;
+        return Ok(None);
     }
     if value.parse::<f64>().is_ok() {
-        Some(Cow::Borrowed(value))
+        Ok(Some(value.to_string()))
     } else {
-        None
+        Err(Error::InvalidData(format!(
+            "{field_name} must be a Slack timestamp string"
+        )))
     }
+}
+
+fn has_pending_chat_ids(state: &SlackSearchCursor) -> bool {
+    state.pending_chat_index < state.pending_chat_ids.len()
+}
+
+fn take_next_pending_chat_id(state: &mut SlackSearchCursor) -> Option<String> {
+    let next_chat_id = state
+        .pending_chat_ids
+        .get(state.pending_chat_index)
+        .cloned()?;
+    state.pending_chat_index += 1;
+    if state.pending_chat_index >= state.pending_chat_ids.len() {
+        state.pending_chat_ids.clear();
+        state.pending_chat_index = 0;
+    }
+    Some(next_chat_id)
 }
 
 fn parse_scopes(headers: &HeaderMap) -> Vec<String> {
@@ -1365,6 +1395,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_message_rejects_attachments() {
+        let err = SlackClient::new("xoxb-test")
+            .send_message(SendMessageParams {
+                chat_id: "C123".to_string(),
+                text: "reply message".to_string(),
+                thread_id: None,
+                reply_to_id: None,
+                attachments: vec![MessageAttachment {
+                    id: Some("att-1".to_string()),
+                    name: Some("report.txt".to_string()),
+                    attachment_type: None,
+                    url: None,
+                    mime_type: None,
+                }],
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::ProviderUnsupported { provider, operation }
+                if provider == "slack" && operation == "send_message attachments"
+        ));
+    }
+
+    #[tokio::test]
     async fn get_messages_caches_resolved_users() {
         let server = MockServer::start();
         server.mock(|when, then| {
@@ -1536,7 +1592,8 @@ mod tests {
         assert_eq!(state.current_chat_id.as_deref(), Some("C1"));
         assert_eq!(state.current_message_cursor.as_deref(), Some("msg-page-2"));
         assert_eq!(state.current_message_offset, 0);
-        assert_eq!(state.pending_chat_ids, vec!["C2"]);
+        assert_eq!(state.pending_chat_ids, vec!["C1", "C2"]);
+        assert_eq!(state.pending_chat_index, 1);
         assert_eq!(state.next_chats_cursor.as_deref(), Some("chat-page-2"));
     }
 
@@ -1675,11 +1732,16 @@ mod tests {
         );
 
         assert_eq!(
-            normalize_ts_param(Some(" 1710000000.000100 ")).as_deref(),
+            normalize_ts_param("since", Some(" 1710000000.000100 "))
+                .unwrap()
+                .as_deref(),
             Some("1710000000.000100")
         );
-        assert_eq!(normalize_ts_param(Some("not-a-ts")), None);
-        assert_eq!(normalize_ts_param(Some("   ")), None);
+        assert!(matches!(
+            normalize_ts_param("until", Some("not-a-ts")).unwrap_err(),
+            Error::InvalidData(message) if message == "until must be a Slack timestamp string"
+        ));
+        assert_eq!(normalize_ts_param("since", Some("   ")).unwrap(), None);
         assert_eq!(
             parse_scopes(&headers),
             vec!["channels:read".to_string(), "chat:write".to_string()]
@@ -1791,6 +1853,7 @@ mod tests {
             current_message_cursor: Some("msg-cursor-2".to_string()),
             current_message_offset: 37,
             pending_chat_ids: vec!["C124".to_string(), "C125".to_string()],
+            pending_chat_index: 1,
             next_chats_cursor: Some("chat-cursor-9".to_string()),
         };
 
@@ -1805,7 +1868,32 @@ mod tests {
         );
         assert_eq!(decoded.current_message_offset, 37);
         assert_eq!(decoded.pending_chat_ids, vec!["C124", "C125"]);
+        assert_eq!(decoded.pending_chat_index, 1);
         assert_eq!(decoded.next_chats_cursor.as_deref(), Some("chat-cursor-9"));
+    }
+
+    #[test]
+    fn take_next_pending_chat_id_advances_without_shifting() {
+        let mut state = SlackSearchCursor {
+            pending_chat_ids: vec!["C124".to_string(), "C125".to_string()],
+            ..SlackSearchCursor::default()
+        };
+
+        assert_eq!(
+            take_next_pending_chat_id(&mut state).as_deref(),
+            Some("C124")
+        );
+        assert_eq!(state.pending_chat_ids, vec!["C124", "C125"]);
+        assert_eq!(state.pending_chat_index, 1);
+        assert!(has_pending_chat_ids(&state));
+
+        assert_eq!(
+            take_next_pending_chat_id(&mut state).as_deref(),
+            Some("C125")
+        );
+        assert!(state.pending_chat_ids.is_empty());
+        assert_eq!(state.pending_chat_index, 0);
+        assert!(!has_pending_chat_ids(&state));
     }
 
     #[test]

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -669,13 +669,17 @@ impl MessengerProvider for SlackClient {
     }
 
     async fn send_message(&self, params: SendMessageParams) -> Result<MessengerMessage> {
+        let thread_ts = params
+            .thread_id
+            .clone()
+            .or_else(|| params.reply_to_id.clone());
         let mut form = vec![
             ("channel", params.chat_id.clone()),
             ("text", params.text.clone()),
             ("unfurl_links", "false".to_string()),
             ("unfurl_media", "false".to_string()),
         ];
-        if let Some(thread_id) = params.thread_id.as_ref() {
+        if let Some(thread_id) = thread_ts.as_ref() {
             form.push(("thread_ts", thread_id.clone()));
         }
 
@@ -688,7 +692,7 @@ impl MessengerProvider for SlackClient {
             user: None,
             username: None,
             bot_id: None,
-            thread_ts: params.thread_id.clone(),
+            thread_ts: thread_ts.clone(),
             parent_user_id: None,
             subtype: None,
             edited: None,
@@ -698,7 +702,7 @@ impl MessengerProvider for SlackClient {
         });
 
         if message.thread_ts.is_none() {
-            message.thread_ts = params.thread_id;
+            message.thread_ts = thread_ts;
         }
 
         self.map_message(
@@ -1224,6 +1228,39 @@ mod tests {
         assert_eq!(result.chat_id, "C123");
         assert_eq!(result.text, "hello world");
         assert_eq!(result.author.name, "Devboy");
+    }
+
+    #[tokio::test]
+    async fn send_message_uses_reply_to_id_as_thread_ts_when_thread_id_missing() {
+        let server = MockServer::start();
+        let post_message = server.mock(|when, then| {
+            when.method(POST).path("/chat.postMessage");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "channel": "C123",
+                "ts": "1710000100.000200",
+                "message": {
+                    "ts": "1710000100.000200",
+                    "text": "reply message"
+                }
+            }));
+        });
+
+        let result = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .send_message(SendMessageParams {
+                chat_id: "C123".to_string(),
+                text: "reply message".to_string(),
+                thread_id: None,
+                reply_to_id: Some("1710000000.000100".to_string()),
+                attachments: vec![],
+            })
+            .await
+            .unwrap();
+
+        post_message.assert_calls(1);
+        assert_eq!(result.thread_id.as_deref(), Some("1710000000.000100"));
+        assert_eq!(result.reply_to_id.as_deref(), Some("1710000000.000100"));
     }
 
     #[tokio::test]

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -1,0 +1,282 @@
+use async_trait::async_trait;
+use devboy_core::{
+    Error, GetChatsParams, GetMessagesParams, MessengerChat, MessengerMessage, MessengerProvider,
+    ProviderResult, Result, SearchMessagesParams, SendMessageParams,
+};
+use reqwest::header::HeaderMap;
+use serde::Deserialize;
+use tracing::debug;
+
+use crate::DEFAULT_SLACK_API_URL;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlackAuthInfo {
+    pub user_id: String,
+    pub user_name: Option<String>,
+    pub team_id: String,
+    pub team_name: String,
+    pub bot_id: Option<String>,
+    pub url: Option<String>,
+    pub scopes: Vec<String>,
+    pub missing_scopes: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SlackClient {
+    token: String,
+    base_url: String,
+    http: reqwest::Client,
+    required_scopes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackAuthTestResponse {
+    ok: bool,
+    error: Option<String>,
+    url: Option<String>,
+    team: Option<String>,
+    user: Option<String>,
+    #[serde(rename = "team_id")]
+    team_id: Option<String>,
+    #[serde(rename = "user_id")]
+    user_id: Option<String>,
+    #[serde(rename = "bot_id")]
+    bot_id: Option<String>,
+}
+
+impl SlackClient {
+    pub fn new(token: impl Into<String>) -> Self {
+        Self {
+            token: token.into(),
+            base_url: DEFAULT_SLACK_API_URL.to_string(),
+            http: reqwest::Client::new(),
+            required_scopes: devboy_core::default_slack_required_scopes(),
+        }
+    }
+
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into().trim_end_matches('/').to_string();
+        self
+    }
+
+    pub fn with_required_scopes(mut self, required_scopes: Vec<String>) -> Self {
+        self.required_scopes = required_scopes;
+        self
+    }
+
+    pub fn required_scopes(&self) -> &[String] {
+        &self.required_scopes
+    }
+
+    pub async fn auth_info(&self) -> Result<SlackAuthInfo> {
+        let url = format!("{}/auth.test", self.base_url);
+        debug!(url, "slack auth.test request");
+
+        let response = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|e| Error::Network(e.to_string()))?;
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), text));
+        }
+
+        let payload: SlackAuthTestResponse = response
+            .json()
+            .await
+            .map_err(|e| Error::InvalidData(e.to_string()))?;
+
+        if !payload.ok {
+            let message = payload
+                .error
+                .unwrap_or_else(|| "unknown_slack_error".to_string());
+            return Err(match message.as_str() {
+                "invalid_auth" | "not_authed" => Error::Unauthorized(message),
+                "missing_scope" => Error::Forbidden(message),
+                _ => Error::Api {
+                    status: 200,
+                    message,
+                },
+            });
+        }
+
+        let scopes = parse_scopes(&headers);
+        let missing_scopes = self
+            .required_scopes
+            .iter()
+            .filter(|scope| !scopes.iter().any(|actual| actual == *scope))
+            .cloned()
+            .collect();
+
+        Ok(SlackAuthInfo {
+            user_id: payload.user_id.unwrap_or_default(),
+            user_name: payload.user,
+            team_id: payload.team_id.unwrap_or_default(),
+            team_name: payload.team.unwrap_or_default(),
+            bot_id: payload.bot_id,
+            url: payload.url,
+            scopes,
+            missing_scopes,
+        })
+    }
+
+    pub async fn ensure_healthy(&self) -> Result<SlackAuthInfo> {
+        let info = self.auth_info().await?;
+        if info.missing_scopes.is_empty() {
+            Ok(info)
+        } else {
+            Err(Error::Forbidden(format!(
+                "Slack token is missing required scopes: {}",
+                info.missing_scopes.join(", ")
+            )))
+        }
+    }
+}
+
+#[async_trait]
+impl MessengerProvider for SlackClient {
+    fn provider_name(&self) -> &'static str {
+        "slack"
+    }
+
+    async fn get_chats(&self, _params: GetChatsParams) -> Result<ProviderResult<MessengerChat>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "get_chats".to_string(),
+        })
+    }
+
+    async fn get_messages(
+        &self,
+        _params: GetMessagesParams,
+    ) -> Result<ProviderResult<MessengerMessage>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "get_messages".to_string(),
+        })
+    }
+
+    async fn search_messages(
+        &self,
+        _params: SearchMessagesParams,
+    ) -> Result<ProviderResult<MessengerMessage>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "search_messages".to_string(),
+        })
+    }
+
+    async fn send_message(&self, params: SendMessageParams) -> Result<MessengerMessage> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: format!("send_message to {}", params.chat_id),
+        })
+    }
+}
+
+fn parse_scopes(headers: &HeaderMap) -> Vec<String> {
+    headers
+        .get("x-oauth-scopes")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|scope| !scope.is_empty())
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::Method::POST;
+    use httpmock::MockServer;
+
+    #[tokio::test]
+    async fn auth_info_reads_identity_and_scopes() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/auth.test");
+            then.status(200)
+                .header(
+                    "x-oauth-scopes",
+                    "channels:read, channels:history, chat:write, users:read",
+                )
+                .json_body(serde_json::json!({
+                    "ok": true,
+                    "url": "https://example.slack.com/",
+                    "team": "Example",
+                    "user": "devboy",
+                    "team_id": "T123",
+                    "user_id": "U123",
+                    "bot_id": "B123"
+                }));
+        });
+
+        let info = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .auth_info()
+            .await
+            .unwrap();
+
+        assert_eq!(info.team_name, "Example");
+        assert_eq!(info.user_id, "U123");
+        assert!(info.missing_scopes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ensure_healthy_fails_when_scopes_missing() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/auth.test");
+            then.status(200)
+                .header("x-oauth-scopes", "channels:read")
+                .json_body(serde_json::json!({
+                    "ok": true,
+                    "team": "Example",
+                    "team_id": "T123",
+                    "user_id": "U123"
+                }));
+        });
+
+        let error = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .ensure_healthy()
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("missing required scopes"));
+    }
+
+    #[tokio::test]
+    async fn messenger_methods_are_scaffolded_as_unsupported() {
+        let client = SlackClient::new("xoxb-test");
+
+        let err = client
+            .get_chats(GetChatsParams::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::ProviderUnsupported { .. }));
+
+        let err = client
+            .send_message(SendMessageParams {
+                chat_id: "C123".to_string(),
+                text: "hello".to_string(),
+                thread_id: None,
+                reply_to_id: None,
+                attachments: vec![devboy_core::MessageAttachment::default()],
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::ProviderUnsupported { .. }));
+    }
+}

--- a/crates/plugins/api/slack/src/lib.rs
+++ b/crates/plugins/api/slack/src/lib.rs
@@ -1,0 +1,12 @@
+//! Slack provider implementation for devboy-tools.
+//!
+//! This crate provides Slack bot-token connectivity and messenger provider
+//! foundations. Messenger tool methods are scaffolded here and implemented
+//! separately from connection/auth setup.
+
+mod client;
+
+pub use client::{SlackAuthInfo, SlackClient};
+
+/// Default Slack Web API base URL.
+pub const DEFAULT_SLACK_API_URL: &str = "https://slack.com/api";


### PR DESCRIPTION
               
  - add devboy-slack crate with Slack auth, chat listing, message history, thread replies, search, send message, user caching, mrkdwn normalization, cursor pagination, and request throttling                                              
  - add MCP messenger tools: get_messenger_chats, get_chat_messages, search_chat_messages, send_message                   
  - add Slack config, CLI test flow, env/context wiring, and doctor checks                                                
  - scope Slack providers to the active context so use_context isolates messenger tools correctly 

closes #84                         
                                                                                                            