### PR TITLE
fix(clickup): always re-fetch task after PUT to return fresh state (#117)

### DIFF
--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -991,13 +991,11 @@ impl IssueProvider for ClickUpClient {
                     }
                 }
             }
-
-            // Re-fetch task to get updated tags
-            let updated_task: ClickUpTask = self.get(&url).await?;
-            return Ok(map_task(&updated_task));
         }
 
-        Ok(map_task(&task))
+        // Always re-fetch after PUT — ClickUp returns stale status in PUT response (#117)
+        let updated_task: ClickUpTask = self.get(&url).await?;
+        Ok(map_task(&updated_task))
     }
 
     async fn set_custom_fields(&self, issue_key: &str, fields: &[serde_json::Value]) -> Result<()> {
@@ -2418,6 +2416,11 @@ mod tests {
                 then.status(200).json_body(sample_task_json());
             });
 
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(sample_task_json());
+            });
+
             let client = create_test_client(&server);
             let issue = client
                 .update_issue(
@@ -2439,6 +2442,15 @@ mod tests {
 
             server.mock(|when, then| {
                 when.method(PUT)
+                    .path("/task/DEV-42")
+                    .query_param("custom_task_ids", "true")
+                    .query_param("team_id", "9876");
+                then.status(200)
+                    .json_body(sample_task_with_custom_id_json());
+            });
+
+            server.mock(|when, then| {
+                when.method(GET)
                     .path("/task/DEV-42")
                     .query_param("custom_task_ids", "true")
                     .query_param("team_id", "9876");
@@ -2484,6 +2496,11 @@ mod tests {
                 then.status(200).json_body(sample_task_json());
             });
 
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(sample_task_json());
+            });
+
             let client = create_test_client(&server);
             let result = client
                 .update_issue(
@@ -2496,6 +2513,63 @@ mod tests {
                 .await;
 
             assert!(result.is_ok());
+        }
+
+        /// Regression test for #117: PUT response returns stale status,
+        /// but re-fetched GET response reflects the actual closed state.
+        #[tokio::test]
+        async fn test_update_issue_state_refetch_returns_fresh_state() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345");
+                then.status(200).json_body(serde_json::json!({
+                    "statuses": [
+                        {"status": "to do", "type": "open"},
+                        {"status": "complete", "type": "closed"}
+                    ]
+                }));
+            });
+
+            // PUT returns stale "open" status (ClickUp behavior)
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/task/abc123")
+                    .body_includes("\"status\":\"complete\"");
+                then.status(200).json_body(sample_task_json()); // status.type = "open"
+            });
+
+            // GET returns the updated "closed" status
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "abc123",
+                    "name": "Test Task",
+                    "status": {
+                        "status": "complete",
+                        "type": "closed"
+                    },
+                    "tags": [{"name": "bug"}],
+                    "assignees": [{"id": 1, "username": "dev1"}],
+                    "url": "https://app.clickup.com/t/abc123",
+                    "date_created": "1704067200000",
+                    "date_updated": "1704153600000"
+                }));
+            });
+
+            let client = create_test_client(&server);
+            let issue = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        state: Some("closed".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(issue.state, "closed");
         }
 
         #[tokio::test]
@@ -2516,6 +2590,11 @@ mod tests {
                 when.method(PUT)
                     .path("/task/abc123")
                     .body_includes("\"status\":\"to do\"");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
                 then.status(200).json_body(sample_task_json());
             });
 
@@ -2542,6 +2621,11 @@ mod tests {
                 when.method(PUT)
                     .path("/task/abc123")
                     .body_includes("\"status\":\"in progress\"");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
                 then.status(200).json_body(sample_task_json());
             });
 
@@ -2894,6 +2978,14 @@ mod tests {
                     .query_param("custom_task_ids", "true")
                     .query_param("team_id", "9876")
                     .body_includes("\"parent\":\"parent_native_id\"");
+                then.status(200).json_body(updated_task.clone());
+            });
+
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/task/DEV-601")
+                    .query_param("custom_task_ids", "true")
+                    .query_param("team_id", "9876");
                 then.status(200).json_body(updated_task);
             });
 

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -993,9 +993,19 @@ impl IssueProvider for ClickUpClient {
             }
         }
 
-        // Always re-fetch after PUT — ClickUp returns stale status in PUT response (#117)
-        let updated_task: ClickUpTask = self.get(&url).await?;
-        Ok(map_task(&updated_task))
+        // Re-fetch after PUT because ClickUp can return stale status in the PUT response (#117),
+        // but do not fail the whole update if the refresh itself is transiently unavailable.
+        match self.get::<ClickUpTask>(&url).await {
+            Ok(updated_task) => Ok(map_task(&updated_task)),
+            Err(e) => {
+                warn!(
+                    issue_key = key,
+                    error = %e,
+                    "Task updated successfully, but failed to re-fetch fresh state; falling back to PUT response"
+                );
+                Ok(map_task(&task))
+            }
+        }
     }
 
     async fn set_custom_fields(&self, issue_key: &str, fields: &[serde_json::Value]) -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes #117 — `update_issue` returned stale `state: open` after ClickUp status change.

**Root cause:** ClickUp's PUT `/task/{id}` response returns stale status data. The code only re-fetched via GET when labels were updated, but returned the stale PUT response otherwise.

**Fix:** Always re-fetch the task via GET after a successful PUT, ensuring the response reflects the actual server state.

## Changes

- `client.rs`: Removed early return in the labels branch; moved GET re-fetch after the tags block so it always executes
- Updated 6 existing tests to include GET mock for the re-fetch
- Added regression test `test_update_issue_state_refetch_returns_fresh_state` that simulates stale PUT + fresh GET and asserts `state == "closed"`

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — applied
- [x] `cargo test -p devboy-clickup` — 84 passed, 0 failed

Closes #117