### PR TITLE
feat(assets): Phase 1 — devboy-assets crate with cache, index, rotation (#121)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [
     "crates/devboy-core",
     "crates/devboy-storage",
+    "crates/devboy-assets",
     "crates/devboy-executor",
     "crates/devboy-mcp",
     "crates/devboy-cli",
@@ -65,6 +66,10 @@ mockall = "0.13"
 insta = { version = "1.41", features = ["json", "yaml"] }
 httpmock = "0.8"
 tempfile = "3.15"
+
+# Asset management
+sha2 = "0.10"
+uuid = { version = "1.11", features = ["v4", "serde"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ tempfile = "3.15"
 
 # Asset management
 sha2 = "0.10"
-uuid = { version = "1.11", features = ["v4", "serde"] }
 
 [profile.release]
 lto = true

--- a/crates/devboy-assets/Cargo.toml
+++ b/crates/devboy-assets/Cargo.toml
@@ -21,8 +21,5 @@ sha2.workspace = true
 # Atomic file writes for the index
 tempfile.workspace = true
 
-[dev-dependencies]
-tempfile.workspace = true
-
 [lints]
 workspace = true

--- a/crates/devboy-assets/Cargo.toml
+++ b/crates/devboy-assets/Cargo.toml
@@ -11,21 +11,17 @@ authors.workspace = true
 devboy-core = { path = "../devboy-core" }
 
 thiserror.workspace = true
-anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
-tokio = { workspace = true, features = ["fs", "io-util", "sync", "rt"] }
 toml.workspace = true
 dirs.workspace = true
 
 sha2.workspace = true
-uuid.workspace = true
 # Atomic file writes for the index
 tempfile.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "io-util"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/devboy-assets/Cargo.toml
+++ b/crates/devboy-assets/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "devboy-assets"
+description = "Asset management (cache, rotation, index) for devboy-tools"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+devboy-core = { path = "../devboy-core" }
+
+thiserror.workspace = true
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util", "sync", "rt"] }
+toml.workspace = true
+dirs.workspace = true
+
+sha2.workspace = true
+uuid.workspace = true
+# Atomic file writes for the index
+tempfile.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "io-util"] }
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/devboy-assets/src/cache.rs
+++ b/crates/devboy-assets/src/cache.rs
@@ -63,7 +63,12 @@ impl CacheManager {
     pub fn path_for(&self, context: &AssetContext, asset_id: &str, filename: &str) -> PathBuf {
         let safe_id = sanitize_component(asset_id);
         let safe_name = sanitize_filename(filename);
-        let leaf = format!("{safe_id}-{safe_name}");
+        // Append a short hash of the *raw* (pre-sanitization) asset_id so
+        // that two IDs differing only in characters collapsed by
+        // sanitization (e.g. `a/b` → `a_b` vs `a?b` → `a_b`) never map
+        // to the same on-disk path.
+        let id_hash = &sha256_hex(asset_id.as_bytes())[..8];
+        let leaf = format!("{safe_id}-{id_hash}-{safe_name}");
         let dir = self.dir_for(context);
         dir.join(leaf)
     }
@@ -496,11 +501,32 @@ mod tests {
     }
 
     #[test]
-    fn path_for_prefixes_asset_id() {
+    fn path_for_prefixes_asset_id_and_hash() {
         let tmp = tempdir().unwrap();
         let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
         let ctx = AssetContext::Issue { key: "k".into() };
         let path = cache.path_for(&ctx, "abc123", "report.log");
-        assert!(path.to_string_lossy().ends_with("abc123-report.log"));
+        let leaf = path.file_name().unwrap().to_string_lossy();
+        // Format: {sanitized_id}-{8-char hash}-{sanitized_filename}
+        assert!(leaf.starts_with("abc123-"), "unexpected leaf: {leaf}");
+        assert!(leaf.ends_with("-report.log"), "unexpected leaf: {leaf}");
+        // The hash is 8 hex chars between the id and filename.
+        let parts: Vec<&str> = leaf.splitn(3, '-').collect();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[1].len(), 8, "hash should be 8 hex chars");
+    }
+
+    #[test]
+    fn path_for_avoids_collision_on_sanitized_ids() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let ctx = AssetContext::Issue { key: "k".into() };
+        // These two IDs sanitize to the same string but differ pre-sanitization.
+        let p1 = cache.path_for(&ctx, "a/b", "f.txt");
+        let p2 = cache.path_for(&ctx, "a?b", "f.txt");
+        assert_ne!(
+            p1, p2,
+            "different raw IDs must produce different paths even when sanitized form matches"
+        );
     }
 }

--- a/crates/devboy-assets/src/cache.rs
+++ b/crates/devboy-assets/src/cache.rs
@@ -77,8 +77,8 @@ impl CacheManager {
                 .join(DIR_ISSUE_COMMENTS)
                 .join(sanitize_key(key))
                 .join(sanitize_key(comment_id)),
-            AssetContext::MergeRequest { id } => {
-                self.root.join(DIR_MERGE_REQUESTS).join(sanitize_key(id))
+            AssetContext::MergeRequest { mr_id } => {
+                self.root.join(DIR_MERGE_REQUESTS).join(sanitize_key(mr_id))
             }
             AssetContext::MrComment { mr_id, note_id } => self
                 .root
@@ -369,7 +369,7 @@ mod tests {
         });
         assert!(issue_dir.ends_with("issues/DEV-1"));
 
-        let mr_dir = cache.dir_for(&AssetContext::MergeRequest { id: "42".into() });
+        let mr_dir = cache.dir_for(&AssetContext::MergeRequest { mr_id: "42".into() });
         assert!(mr_dir.ends_with("merge-requests/42"));
 
         let kb_dir = cache.dir_for(&AssetContext::KbPage {

--- a/crates/devboy-assets/src/cache.rs
+++ b/crates/devboy-assets/src/cache.rs
@@ -178,8 +178,14 @@ pub struct StoredFile {
 ///   `root` for any absolute RHS).
 /// - Paths containing `..` components are rejected — we never generate
 ///   them, so anything with traversal came from outside the crate.
-/// - Any other path must, after joining, still start with `root` when both
-///   sides are canonicalized lexically.
+/// - Lexical containment: the joined path's components must start with
+///   the root's components.
+/// - **Symlink guard**: when the resolved path exists on disk, both
+///   `root` and the resolved path are [`canonicalize`]d so that any
+///   symlink within the cache directory is dereferenced. The
+///   canonicalized resolved path must still start with the canonicalized
+///   root; if it doesn't (e.g. a symlink inside the cache dir points
+///   outside), the path is rejected.
 ///
 /// Returns `None` when the path is unsafe; callers drop the index entry
 /// instead of touching the filesystem.
@@ -195,10 +201,9 @@ pub fn resolve_under_root(root: &Path, relative: &Path) -> Option<PathBuf> {
         }
     }
     let joined = root.join(relative);
-    // Lexical containment check: the joined path's components must start
-    // with the root's components. We do not canonicalize because the file
-    // may legitimately be missing (stale entry) and `canonicalize` would
-    // fail in that case.
+
+    // Lexical containment — fast path for non-existent files (stale
+    // entries) where canonicalize would fail.
     let root_components: Vec<_> = root.components().collect();
     let joined_components: Vec<_> = joined.components().collect();
     if joined_components.len() < root_components.len() {
@@ -209,6 +214,17 @@ pub fn resolve_under_root(root: &Path, relative: &Path) -> Option<PathBuf> {
             return None;
         }
     }
+
+    // Symlink guard — when both paths exist, canonicalize to resolve
+    // any intermediate symlinks and re-verify containment so a symlink
+    // inside the cache dir that points outside can't be followed.
+    if joined.exists()
+        && let (Ok(canon_root), Ok(canon_target)) = (root.canonicalize(), joined.canonicalize())
+        && !canon_target.starts_with(&canon_root)
+    {
+        return None;
+    }
+
     Some(joined)
 }
 

--- a/crates/devboy-assets/src/cache.rs
+++ b/crates/devboy-assets/src/cache.rs
@@ -1,0 +1,311 @@
+//! Filesystem-level cache manager.
+//!
+//! Responsibilities:
+//!
+//! - Deterministically map [`AssetContext`] values to on-disk paths
+//! - Store / load / delete file blobs
+//! - Compute SHA-256 checksums
+//!
+//! The cache manager is unaware of the index — the higher-level
+//! [`crate::manager::AssetManager`] combines the two. This split keeps the
+//! filesystem concerns testable in isolation.
+
+use devboy_core::asset::AssetContext;
+use sha2::{Digest, Sha256};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use crate::error::{AssetError, Result};
+
+/// Directory name used under the cache root for issue attachments.
+pub const DIR_ISSUES: &str = "issues";
+/// Directory name used for issue comment attachments.
+pub const DIR_ISSUE_COMMENTS: &str = "issue-comments";
+/// Directory name used for merge request attachments.
+pub const DIR_MERGE_REQUESTS: &str = "merge-requests";
+/// Directory name used for MR note/comment attachments.
+pub const DIR_MR_COMMENTS: &str = "mr-comments";
+/// Directory name used for messenger chat attachments.
+pub const DIR_CHATS: &str = "chats";
+/// Directory name used for knowledge base attachments.
+pub const DIR_KB: &str = "kb";
+
+/// Manages the physical cache directory layout and file I/O.
+#[derive(Debug, Clone)]
+pub struct CacheManager {
+    root: PathBuf,
+}
+
+impl CacheManager {
+    /// Create a new manager rooted at `root`. The directory is created if
+    /// it does not already exist.
+    pub fn new(root: PathBuf) -> Result<Self> {
+        std::fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    /// Absolute path to the cache root.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Compute the on-disk path for an asset given its context and filename.
+    ///
+    /// Layout:
+    /// ```text
+    /// {root}/{context_dir}/{context_id}/{asset_id}-{safe_filename}
+    /// ```
+    ///
+    /// `asset_id` is prefixed onto the filename to prevent collisions when
+    /// two attachments share a name within the same context.
+    pub fn path_for(&self, context: &AssetContext, asset_id: &str, filename: &str) -> PathBuf {
+        let safe = sanitize_filename(filename);
+        let leaf = format!("{asset_id}-{safe}");
+        let dir = self.dir_for(context);
+        dir.join(leaf)
+    }
+
+    /// Directory for a given context (relative to the cache root, joined).
+    pub fn dir_for(&self, context: &AssetContext) -> PathBuf {
+        match context {
+            AssetContext::Issue { key } => self.root.join(DIR_ISSUES).join(sanitize_key(key)),
+            AssetContext::IssueComment { key, comment_id } => self
+                .root
+                .join(DIR_ISSUE_COMMENTS)
+                .join(sanitize_key(key))
+                .join(sanitize_key(comment_id)),
+            AssetContext::MergeRequest { id } => {
+                self.root.join(DIR_MERGE_REQUESTS).join(sanitize_key(id))
+            }
+            AssetContext::MrComment { mr_id, note_id } => self
+                .root
+                .join(DIR_MR_COMMENTS)
+                .join(sanitize_key(mr_id))
+                .join(sanitize_key(note_id)),
+            AssetContext::Chat {
+                chat_id,
+                message_id,
+            } => self
+                .root
+                .join(DIR_CHATS)
+                .join(sanitize_key(chat_id))
+                .join(sanitize_key(message_id)),
+            AssetContext::KbPage { page_id } => self.root.join(DIR_KB).join(sanitize_key(page_id)),
+        }
+    }
+
+    /// Store bytes for an asset and return the absolute path where they were
+    /// written along with the SHA-256 checksum.
+    ///
+    /// Parent directories are created as needed. Writes go through a temp
+    /// file + rename so partial writes are never observable.
+    pub fn store(
+        &self,
+        context: &AssetContext,
+        asset_id: &str,
+        filename: &str,
+        data: &[u8],
+    ) -> Result<StoredFile> {
+        let path = self.path_for(context, asset_id, filename);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let parent = path
+            .parent()
+            .ok_or_else(|| AssetError::cache_dir(format!("no parent for {path:?}")))?;
+
+        let mut tmp = tempfile::NamedTempFile::new_in(parent)
+            .map_err(|e| AssetError::cache_dir(format!("temp file: {e}")))?;
+        tmp.write_all(data)?;
+        tmp.flush()?;
+        tmp.persist(&path)
+            .map_err(|e| AssetError::cache_dir(format!("persist file: {e}")))?;
+
+        let checksum = sha256_hex(data);
+
+        Ok(StoredFile {
+            path,
+            size: data.len() as u64,
+            checksum_sha256: checksum,
+        })
+    }
+
+    /// Read a file from the cache by absolute path. Returns `NotFound`
+    /// if the file is missing (via [`AssetError::Io`]).
+    pub fn load(&self, absolute: &Path) -> Result<Vec<u8>> {
+        Ok(std::fs::read(absolute)?)
+    }
+
+    /// Delete a file from the cache. Missing files are treated as success
+    /// so that retries / idempotent deletes work as expected.
+    pub fn delete(&self, absolute: &Path) -> Result<()> {
+        match std::fs::remove_file(absolute) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(AssetError::Io(e)),
+        }
+    }
+
+    /// Check whether a file exists in the cache.
+    pub fn exists(&self, absolute: &Path) -> bool {
+        absolute.is_file()
+    }
+}
+
+/// Metadata returned from [`CacheManager::store`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredFile {
+    /// Absolute path where the file was written.
+    pub path: PathBuf,
+    /// Size in bytes.
+    pub size: u64,
+    /// SHA-256 checksum in lower-case hex.
+    pub checksum_sha256: String,
+}
+
+/// Compute SHA-256 of a byte slice, returned as lower-case hex.
+pub fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// Restrict a filename to characters that are safe to write on any FS.
+/// Non-ASCII letters / digits are replaced with `_`.
+fn sanitize_filename(name: &str) -> String {
+    let trimmed = name.trim().trim_matches('/');
+    let base = trimmed.rsplit('/').next().unwrap_or(trimmed);
+    let mut out = String::with_capacity(base.len());
+    for ch in base.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' || ch == '_' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        "unnamed".to_string()
+    } else {
+        out
+    }
+}
+
+/// Same rules as [`sanitize_filename`] but applied to context keys.
+fn sanitize_key(key: &str) -> String {
+    sanitize_filename(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use devboy_core::asset::AssetContext;
+    use tempfile::tempdir;
+
+    #[test]
+    fn sha256_matches_known_vector() {
+        // Well-known test vector for an empty input.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_traversal_and_bad_chars() {
+        assert_eq!(sanitize_filename("../../etc/passwd"), "passwd");
+        assert_eq!(sanitize_filename("hello world!.png"), "hello_world_.png");
+        assert_eq!(sanitize_filename("/"), "unnamed");
+        assert_eq!(sanitize_filename("привет.txt"), "______.txt");
+    }
+
+    #[test]
+    fn dir_for_layouts() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+
+        let issue_dir = cache.dir_for(&AssetContext::Issue {
+            key: "DEV-1".into(),
+        });
+        assert!(issue_dir.ends_with("issues/DEV-1"));
+
+        let mr_dir = cache.dir_for(&AssetContext::MergeRequest { id: "42".into() });
+        assert!(mr_dir.ends_with("merge-requests/42"));
+
+        let kb_dir = cache.dir_for(&AssetContext::KbPage {
+            page_id: "p1".into(),
+        });
+        assert!(kb_dir.ends_with("kb/p1"));
+    }
+
+    #[test]
+    fn store_load_delete_roundtrip() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+        let payload = b"hello world";
+        let stored = cache.store(&ctx, "asset-1", "hello.txt", payload).unwrap();
+
+        assert_eq!(stored.size, payload.len() as u64);
+        assert_eq!(stored.checksum_sha256, sha256_hex(payload));
+        assert!(cache.exists(&stored.path));
+
+        let loaded = cache.load(&stored.path).unwrap();
+        assert_eq!(loaded, payload);
+
+        cache.delete(&stored.path).unwrap();
+        assert!(!cache.exists(&stored.path));
+
+        // Second delete is a no-op, not an error.
+        cache.delete(&stored.path).unwrap();
+    }
+
+    #[test]
+    fn store_creates_nested_directories() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+
+        let ctx = AssetContext::MrComment {
+            mr_id: "42".into(),
+            note_id: "7".into(),
+        };
+        let stored = cache.store(&ctx, "a1", "x.bin", b"x").unwrap();
+        let rel = stored.path.strip_prefix(tmp.path()).unwrap();
+        assert!(rel.to_string_lossy().contains("mr-comments/42/7"));
+    }
+
+    #[test]
+    fn store_rejects_nothing_and_handles_empty_file() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let ctx = AssetContext::Issue { key: "k".into() };
+        let stored = cache.store(&ctx, "id", "empty", &[]).unwrap();
+        assert_eq!(stored.size, 0);
+        assert_eq!(
+            stored.checksum_sha256,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn path_for_prefixes_asset_id() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let ctx = AssetContext::Issue { key: "k".into() };
+        let path = cache.path_for(&ctx, "abc123", "report.log");
+        assert!(path.to_string_lossy().ends_with("abc123-report.log"));
+    }
+}

--- a/crates/devboy-assets/src/cache.rs
+++ b/crates/devboy-assets/src/cache.rs
@@ -60,6 +60,14 @@ impl CacheManager {
     /// path component — any directory separators or `..` sequences in the
     /// inputs are replaced with `_`, so calling `path_for` with hostile
     /// input can never escape the per-context directory.
+    ///
+    /// An 8-character SHA-256 prefix of the raw asset_id is embedded in
+    /// the filename to avoid collisions between IDs that differ only in
+    /// characters collapsed by sanitization. 8 hex chars = 32 bits gives
+    /// ~4 billion buckets — collision probability via birthday paradox is
+    /// negligible for a rotated local cache (< 0.0001% with 100 files per
+    /// context). We intentionally keep the hash short to stay well within
+    /// the 255-char filename limit on ext4 / NTFS / APFS.
     pub fn path_for(&self, context: &AssetContext, asset_id: &str, filename: &str) -> PathBuf {
         let safe_id = sanitize_component(asset_id);
         let safe_name = sanitize_filename(filename);
@@ -115,13 +123,10 @@ impl CacheManager {
         data: &[u8],
     ) -> Result<StoredFile> {
         let path = self.path_for(context, asset_id, filename);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
         let parent = path
             .parent()
             .ok_or_else(|| AssetError::cache_dir(format!("no parent for {path:?}")))?;
+        std::fs::create_dir_all(parent)?;
 
         let mut tmp = tempfile::NamedTempFile::new_in(parent)
             .map_err(|e| AssetError::cache_dir(format!("temp file: {e}")))?;

--- a/crates/devboy-assets/src/cache.rs
+++ b/crates/devboy-assets/src/cache.rs
@@ -284,7 +284,19 @@ mod tests {
         };
         let stored = cache.store(&ctx, "a1", "x.bin", b"x").unwrap();
         let rel = stored.path.strip_prefix(tmp.path()).unwrap();
-        assert!(rel.to_string_lossy().contains("mr-comments/42/7"));
+
+        // Use path components so the assertion is agnostic to the OS path
+        // separator (`/` on Unix, `\` on Windows).
+        let components: Vec<_> = rel
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            components
+                .windows(3)
+                .any(|w| w == ["mr-comments", "42", "7"]),
+            "unexpected path components: {components:?}",
+        );
     }
 
     #[test]

--- a/crates/devboy-assets/src/cache.rs
+++ b/crates/devboy-assets/src/cache.rs
@@ -56,11 +56,14 @@ impl CacheManager {
     /// {root}/{context_dir}/{context_id}/{asset_id}-{safe_filename}
     /// ```
     ///
-    /// `asset_id` is prefixed onto the filename to prevent collisions when
-    /// two attachments share a name within the same context.
+    /// Both `asset_id` and `filename` are sanitized before becoming a single
+    /// path component — any directory separators or `..` sequences in the
+    /// inputs are replaced with `_`, so calling `path_for` with hostile
+    /// input can never escape the per-context directory.
     pub fn path_for(&self, context: &AssetContext, asset_id: &str, filename: &str) -> PathBuf {
-        let safe = sanitize_filename(filename);
-        let leaf = format!("{asset_id}-{safe}");
+        let safe_id = sanitize_component(asset_id);
+        let safe_name = sanitize_filename(filename);
+        let leaf = format!("{safe_id}-{safe_name}");
         let dir = self.dir_for(context);
         dir.join(leaf)
     }
@@ -178,17 +181,44 @@ pub fn sha256_hex(data: &[u8]) -> String {
 }
 
 /// Restrict a filename to characters that are safe to write on any FS.
-/// Non-ASCII letters / digits are replaced with `_`.
+///
+/// The input is first stripped of anything before the final `/` or `\` to
+/// prevent traversal via `../` or Windows `..\\`. The remaining basename is
+/// then passed through [`sanitize_component`] so the result is always a
+/// single, FS-safe path component.
 fn sanitize_filename(name: &str) -> String {
-    let trimmed = name.trim().trim_matches('/');
-    let base = trimmed.rsplit('/').next().unwrap_or(trimmed);
-    let mut out = String::with_capacity(base.len());
-    for ch in base.chars() {
+    let trimmed = name.trim();
+    let after_fwd = trimmed.rsplit('/').next().unwrap_or(trimmed);
+    let base = after_fwd.rsplit('\\').next().unwrap_or(after_fwd);
+    sanitize_component(base)
+}
+
+/// Sanitize an arbitrary string into a single path component.
+///
+/// Used for both filenames and opaque identifiers (asset ids, context
+/// keys). Rules:
+///
+/// - Keep ASCII alphanumerics, `.`, `-`, `_`
+/// - Replace everything else — including `/`, `\`, and any non-ASCII
+///   character — with `_`
+/// - Reject lone / repeated `..` segments by never letting them survive
+///   (the individual `.` characters remain, but the full traversal form
+///   `..` becomes part of a longer, harmless name)
+/// - Return the sentinel `"unnamed"` for empty / whitespace-only input
+fn sanitize_component(value: &str) -> String {
+    let trimmed = value.trim();
+    let mut out = String::with_capacity(trimmed.len());
+    for ch in trimmed.chars() {
         if ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' || ch == '_' {
             out.push(ch);
         } else {
             out.push('_');
         }
+    }
+    // A bare `..` (or any all-dot string) can still be interpreted as a
+    // traversal; neutralize it by replacing every `.` with `_` in that case.
+    if out.chars().all(|c| c == '.') && !out.is_empty() {
+        return out.replace('.', "_");
     }
     if out.is_empty() {
         "unnamed".to_string()
@@ -197,9 +227,9 @@ fn sanitize_filename(name: &str) -> String {
     }
 }
 
-/// Same rules as [`sanitize_filename`] but applied to context keys.
+/// Same rules as [`sanitize_component`] but named for clarity at call sites.
 fn sanitize_key(key: &str) -> String {
-    sanitize_filename(key)
+    sanitize_component(key)
 }
 
 #[cfg(test)]
@@ -227,6 +257,61 @@ mod tests {
         assert_eq!(sanitize_filename("hello world!.png"), "hello_world_.png");
         assert_eq!(sanitize_filename("/"), "unnamed");
         assert_eq!(sanitize_filename("привет.txt"), "______.txt");
+    }
+
+    #[test]
+    fn sanitize_handles_windows_separators() {
+        assert_eq!(
+            sanitize_filename("..\\..\\Windows\\System32\\cmd.exe"),
+            "cmd.exe",
+        );
+    }
+
+    #[test]
+    fn sanitize_neutralizes_dot_only_names() {
+        assert_eq!(sanitize_component(".."), "__");
+        assert_eq!(sanitize_component("..."), "___");
+        assert_eq!(sanitize_component("."), "_");
+    }
+
+    #[test]
+    fn path_for_blocks_asset_id_traversal() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let ctx = AssetContext::Issue { key: "k".into() };
+
+        // Hostile asset id trying to escape the issue directory.
+        let path = cache.path_for(&ctx, "../../escape", "file.txt");
+        let rel = path.strip_prefix(tmp.path()).unwrap();
+        let components: Vec<_> = rel
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect();
+        // The hostile id becomes a single sanitized segment; it never introduces
+        // a `..` component.
+        assert!(
+            !components.iter().any(|c| c == ".." || c.contains('/')),
+            "unexpected components: {components:?}",
+        );
+        assert!(path.starts_with(tmp.path()));
+    }
+
+    #[test]
+    fn store_with_hostile_ids_stays_under_cache_root() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let ctx = AssetContext::Issue {
+            key: "../../root".into(),
+        };
+
+        let stored = cache
+            .store(&ctx, "../../../etc", "../passwd", b"secret")
+            .unwrap();
+        assert!(
+            stored.path.starts_with(tmp.path()),
+            "path escaped cache root: {:?}",
+            stored.path
+        );
     }
 
     #[test]

--- a/crates/devboy-assets/src/cache.rs
+++ b/crates/devboy-assets/src/cache.rs
@@ -167,6 +167,51 @@ pub struct StoredFile {
     pub checksum_sha256: String,
 }
 
+/// Validate that a cached-asset `local_path` stays under `root` and return
+/// the absolute path on success.
+///
+/// The index is trusted to hold **relative** paths produced by
+/// [`CacheManager::store`]. This helper defends against corrupted or
+/// tampered `index.json` entries that try to point elsewhere:
+///
+/// - Absolute paths are rejected (because `PathBuf::join` would discard
+///   `root` for any absolute RHS).
+/// - Paths containing `..` components are rejected — we never generate
+///   them, so anything with traversal came from outside the crate.
+/// - Any other path must, after joining, still start with `root` when both
+///   sides are canonicalized lexically.
+///
+/// Returns `None` when the path is unsafe; callers drop the index entry
+/// instead of touching the filesystem.
+pub fn resolve_under_root(root: &Path, relative: &Path) -> Option<PathBuf> {
+    if relative.is_absolute() {
+        return None;
+    }
+    for component in relative.components() {
+        match component {
+            std::path::Component::ParentDir => return None,
+            std::path::Component::Prefix(_) | std::path::Component::RootDir => return None,
+            _ => {}
+        }
+    }
+    let joined = root.join(relative);
+    // Lexical containment check: the joined path's components must start
+    // with the root's components. We do not canonicalize because the file
+    // may legitimately be missing (stale entry) and `canonicalize` would
+    // fail in that case.
+    let root_components: Vec<_> = root.components().collect();
+    let joined_components: Vec<_> = joined.components().collect();
+    if joined_components.len() < root_components.len() {
+        return None;
+    }
+    for (a, b) in root_components.iter().zip(joined_components.iter()) {
+        if a != b {
+            return None;
+        }
+    }
+    Some(joined)
+}
+
 /// Compute SHA-256 of a byte slice, returned as lower-case hex.
 pub fn sha256_hex(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
@@ -394,6 +439,43 @@ mod tests {
         assert_eq!(
             stored.checksum_sha256,
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn resolve_under_root_accepts_relative_paths() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let rel = PathBuf::from("issues/DEV-1/screen.png");
+        let abs = resolve_under_root(root, &rel).unwrap();
+        assert!(abs.starts_with(root));
+        assert!(abs.ends_with("issues/DEV-1/screen.png"));
+    }
+
+    #[test]
+    fn resolve_under_root_rejects_absolute() {
+        let tmp = tempdir().unwrap();
+        let abs = PathBuf::from("/etc/passwd");
+        assert!(resolve_under_root(tmp.path(), &abs).is_none());
+    }
+
+    #[test]
+    fn resolve_under_root_rejects_parent_dir() {
+        let tmp = tempdir().unwrap();
+        let traversal = PathBuf::from("../../etc/passwd");
+        assert!(resolve_under_root(tmp.path(), &traversal).is_none());
+
+        let nested = PathBuf::from("issues/../../etc/passwd");
+        assert!(resolve_under_root(tmp.path(), &nested).is_none());
+    }
+
+    #[test]
+    fn resolve_under_root_accepts_empty_and_single_segment() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        assert_eq!(
+            resolve_under_root(root, &PathBuf::from("a.txt")).unwrap(),
+            root.join("a.txt"),
         );
     }
 

--- a/crates/devboy-assets/src/cache.rs
+++ b/crates/devboy-assets/src/cache.rs
@@ -246,6 +246,13 @@ pub fn sha256_hex(data: &[u8]) -> String {
     let mut out = String::with_capacity(digest.len() * 2);
     for byte in digest {
         use std::fmt::Write as _;
+        // `let _ =` is intentional: `<String as fmt::Write>::write_fmt` is
+        // infallible — its `write_str` impl is just `self.push_str(s); Ok(())`
+        // (see https://doc.rust-lang.org/std/string/struct.String.html#impl-Write-for-String).
+        // The only theoretical failure is OOM, which aborts the process
+        // rather than returning `Err`. We suppress the `#[must_use]` lint
+        // with `let _ =` instead of `.unwrap()` to avoid emitting a dead
+        // panic path for an unreachable case.
         let _ = write!(out, "{byte:02x}");
     }
     out

--- a/crates/devboy-assets/src/config.rs
+++ b/crates/devboy-assets/src/config.rs
@@ -19,10 +19,10 @@ pub const DEFAULT_MAX_FILE_AGE: &str = "7d";
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum EvictionPolicy {
-    /// Least-recently-used (based on `last_accessed` in the index).
+    /// Least-recently-used (based on `last_accessed_ms` in the index).
     #[default]
     Lru,
-    /// First-in-first-out (based on `created_at`).
+    /// First-in-first-out (based on `downloaded_at_ms` in the index).
     Fifo,
     /// Do not evict anything — useful for tests or when an external janitor
     /// is managing cache size.
@@ -196,18 +196,24 @@ pub fn parse_duration(input: &str) -> Result<Duration> {
         .parse()
         .map_err(|_| AssetError::config(format!("invalid duration number: {number_part}")))?;
 
-    let seconds = match unit_part.to_ascii_lowercase().as_str() {
-        "s" => number,
-        "m" => number * 60,
-        "h" => number * 3600,
-        "d" => number * 86_400,
-        "w" => number * 604_800,
+    let multiplier: u64 = match unit_part.to_ascii_lowercase().as_str() {
+        "s" => 1,
+        "m" => 60,
+        "h" => 3_600,
+        "d" => 86_400,
+        "w" => 604_800,
         other => {
             return Err(AssetError::config(format!(
                 "unknown duration unit: {other}"
             )));
         }
     };
+
+    // Use checked_mul so comically large inputs surface as a config error
+    // instead of silently wrapping in release builds.
+    let seconds = number
+        .checked_mul(multiplier)
+        .ok_or_else(|| AssetError::config(format!("duration overflows u64 seconds: {input}",)))?;
 
     Ok(Duration::from_secs(seconds))
 }
@@ -282,6 +288,15 @@ mod tests {
         assert!(parse_duration("10").is_err(), "missing unit");
         assert!(parse_duration("abc").is_err());
         assert!(parse_duration("1y").is_err(), "years not supported");
+    }
+
+    #[test]
+    fn duration_detects_overflow() {
+        // u64::MAX weeks is guaranteed to overflow: 604_800 * MAX >> u64::MAX.
+        let huge = format!("{}w", u64::MAX);
+        let err = parse_duration(&huge).unwrap_err();
+        assert!(matches!(err, AssetError::Config(_)));
+        assert!(err.to_string().contains("overflows"));
     }
 
     #[test]

--- a/crates/devboy-assets/src/config.rs
+++ b/crates/devboy-assets/src/config.rs
@@ -67,9 +67,22 @@ pub struct ResolvedAssetConfig {
 impl AssetConfig {
     /// Parse and validate the configuration, applying defaults where needed.
     pub fn resolve(&self) -> Result<ResolvedAssetConfig> {
-        let cache_dir = match self.cache_dir.as_deref() {
+        let raw_dir = match self.cache_dir.as_deref() {
             Some(path) => expand_path(path),
             None => default_cache_dir()?,
+        };
+        // Ensure the resolved path is always absolute. A relative path
+        // would make the cache location depend on the process working
+        // directory and violate the documented contract on
+        // `ResolvedAssetConfig::cache_dir`.
+        let cache_dir = if raw_dir.is_relative() {
+            std::env::current_dir()
+                .map_err(|e| {
+                    AssetError::cache_dir(format!("cannot resolve relative cache_dir: {e}"))
+                })?
+                .join(raw_dir)
+        } else {
+            raw_dir
         };
 
         let max_cache_size = parse_size(

--- a/crates/devboy-assets/src/config.rs
+++ b/crates/devboy-assets/src/config.rs
@@ -1,0 +1,354 @@
+//! Configuration for the asset cache subsystem.
+//!
+//! Mirrors the `[assets]` section of `devboy.toml` and provides human-readable
+//! parsers for sizes (e.g. `"1Gi"`) and durations (e.g. `"7d"`).
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::error::{AssetError, Result};
+
+/// Default cache size limit: 1 GiB.
+pub const DEFAULT_MAX_CACHE_SIZE: &str = "1Gi";
+
+/// Default maximum file age before LRU eviction kicks in: 7 days.
+pub const DEFAULT_MAX_FILE_AGE: &str = "7d";
+
+/// Eviction strategy applied by the rotator when the cache is over budget.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum EvictionPolicy {
+    /// Least-recently-used (based on `last_accessed` in the index).
+    #[default]
+    Lru,
+    /// First-in-first-out (based on `created_at`).
+    Fifo,
+    /// Do not evict anything — useful for tests or when an external janitor
+    /// is managing cache size.
+    None,
+}
+
+/// Raw configuration as loaded from `devboy.toml`.
+///
+/// Use [`AssetConfig::resolve`] to produce a validated [`ResolvedAssetConfig`]
+/// with absolute paths and parsed sizes / durations.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AssetConfig {
+    /// Custom cache directory. If unset, falls back to
+    /// `dirs::cache_dir()/devboy-tools/assets`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_dir: Option<String>,
+    /// Maximum cache size in human-readable form, e.g. `"1Gi"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_cache_size: Option<String>,
+    /// Maximum age for an unaccessed file before it becomes eligible for
+    /// eviction, e.g. `"7d"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_file_age: Option<String>,
+    /// Eviction policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eviction_policy: Option<EvictionPolicy>,
+}
+
+/// Fully validated asset configuration with parsed values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedAssetConfig {
+    /// Absolute path to the cache directory.
+    pub cache_dir: PathBuf,
+    /// Hard limit on total cache size in bytes.
+    pub max_cache_size: u64,
+    /// Maximum age for an unaccessed file before eviction is allowed.
+    pub max_file_age: Duration,
+    /// Eviction policy.
+    pub eviction_policy: EvictionPolicy,
+}
+
+impl AssetConfig {
+    /// Parse and validate the configuration, applying defaults where needed.
+    pub fn resolve(&self) -> Result<ResolvedAssetConfig> {
+        let cache_dir = match self.cache_dir.as_deref() {
+            Some(path) => expand_path(path),
+            None => default_cache_dir()?,
+        };
+
+        let max_cache_size = parse_size(
+            self.max_cache_size
+                .as_deref()
+                .unwrap_or(DEFAULT_MAX_CACHE_SIZE),
+        )?;
+
+        let max_file_age =
+            parse_duration(self.max_file_age.as_deref().unwrap_or(DEFAULT_MAX_FILE_AGE))?;
+
+        Ok(ResolvedAssetConfig {
+            cache_dir,
+            max_cache_size,
+            max_file_age,
+            eviction_policy: self.eviction_policy.unwrap_or_default(),
+        })
+    }
+}
+
+/// Default cache directory used when the user did not configure one.
+pub fn default_cache_dir() -> Result<PathBuf> {
+    let base = dirs::cache_dir()
+        .ok_or_else(|| AssetError::cache_dir("unable to determine OS cache directory"))?;
+    Ok(base.join("devboy-tools").join("assets"))
+}
+
+/// Expand a user-provided path — supports leading `~` and `$HOME` only.
+///
+/// We intentionally avoid pulling in a shell-expansion crate: configuration
+/// paths are authored by a human and the two cases above cover everything
+/// real users do.
+pub fn expand_path(input: &str) -> PathBuf {
+    if let Some(rest) = input.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
+    }
+    if input == "~"
+        && let Some(home) = dirs::home_dir()
+    {
+        return home;
+    }
+    if let Some(rest) = input.strip_prefix("$HOME/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
+    }
+    PathBuf::from(input)
+}
+
+// =============================================================================
+// Human-readable parsers
+// =============================================================================
+
+/// Parse a human-readable size string into a byte count.
+///
+/// Accepts:
+/// - Plain numbers: `1024` → 1024 bytes
+/// - SI: `K`, `M`, `G`, `T` (1000-based)
+/// - Binary: `Ki`, `Mi`, `Gi`, `Ti` (1024-based)
+/// - With an optional trailing `B` (e.g. `1Gi`, `1GiB`)
+/// - Case-insensitive; whitespace between digits and unit is ignored
+pub fn parse_size(input: &str) -> Result<u64> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(AssetError::config("size value is empty"));
+    }
+
+    let (number_part, unit_part) = split_value_and_unit(trimmed);
+    let number: f64 = number_part
+        .parse()
+        .map_err(|_| AssetError::config(format!("invalid size number: {number_part}")))?;
+
+    if number < 0.0 {
+        return Err(AssetError::config(format!("negative size: {input}")));
+    }
+
+    // Normalize: strip trailing B/b and lowercase
+    let mut unit = unit_part.to_ascii_lowercase();
+    if unit.ends_with('b') && unit != "b" {
+        unit.pop();
+    }
+    if unit == "b" {
+        unit.clear();
+    }
+
+    let multiplier: f64 = match unit.as_str() {
+        "" => 1.0,
+        "k" => 1_000.0,
+        "m" => 1_000_000.0,
+        "g" => 1_000_000_000.0,
+        "t" => 1_000_000_000_000.0,
+        "ki" => 1024.0,
+        "mi" => 1024f64.powi(2),
+        "gi" => 1024f64.powi(3),
+        "ti" => 1024f64.powi(4),
+        other => {
+            return Err(AssetError::config(format!("unknown size unit: {other}")));
+        }
+    };
+
+    Ok((number * multiplier) as u64)
+}
+
+/// Parse a human-readable duration such as `"7d"`, `"24h"`, `"30m"`, `"45s"`.
+///
+/// The suffix is required and may be one of `s`, `m`, `h`, `d`, `w`.
+/// Whitespace between the number and the suffix is allowed.
+pub fn parse_duration(input: &str) -> Result<Duration> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(AssetError::config("duration value is empty"));
+    }
+
+    let (number_part, unit_part) = split_value_and_unit(trimmed);
+    if unit_part.is_empty() {
+        return Err(AssetError::config(format!(
+            "duration requires a unit suffix (s/m/h/d/w): {input}"
+        )));
+    }
+
+    let number: u64 = number_part
+        .parse()
+        .map_err(|_| AssetError::config(format!("invalid duration number: {number_part}")))?;
+
+    let seconds = match unit_part.to_ascii_lowercase().as_str() {
+        "s" => number,
+        "m" => number * 60,
+        "h" => number * 3600,
+        "d" => number * 86_400,
+        "w" => number * 604_800,
+        other => {
+            return Err(AssetError::config(format!(
+                "unknown duration unit: {other}"
+            )));
+        }
+    };
+
+    Ok(Duration::from_secs(seconds))
+}
+
+/// Split a human-readable value string into numeric and unit parts.
+fn split_value_and_unit(input: &str) -> (&str, &str) {
+    let split_at = input
+        .find(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+        .unwrap_or(input.len());
+    let (num, rest) = input.split_at(split_at);
+    (num.trim(), rest.trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn size_parses_binary_units() {
+        assert_eq!(parse_size("1Ki").unwrap(), 1024);
+        assert_eq!(parse_size("1Mi").unwrap(), 1024 * 1024);
+        assert_eq!(parse_size("1Gi").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_size("2GiB").unwrap(), 2 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn size_parses_si_units() {
+        assert_eq!(parse_size("1K").unwrap(), 1_000);
+        assert_eq!(parse_size("5M").unwrap(), 5_000_000);
+        assert_eq!(parse_size("1G").unwrap(), 1_000_000_000);
+    }
+
+    #[test]
+    fn size_parses_plain_bytes() {
+        assert_eq!(parse_size("1024").unwrap(), 1024);
+        assert_eq!(parse_size("100B").unwrap(), 100);
+        assert_eq!(parse_size("0").unwrap(), 0);
+    }
+
+    #[test]
+    fn size_is_case_insensitive_and_whitespace_tolerant() {
+        assert_eq!(parse_size("1 gi").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_size("  2  MI ").unwrap(), 2 * 1024 * 1024);
+    }
+
+    #[test]
+    fn size_rejects_garbage() {
+        assert!(parse_size("").is_err());
+        assert!(parse_size("abc").is_err());
+        assert!(parse_size("1Zi").is_err());
+        assert!(parse_size("-1Gi").is_err());
+    }
+
+    #[test]
+    fn duration_parses_common_suffixes() {
+        assert_eq!(parse_duration("45s").unwrap(), Duration::from_secs(45));
+        assert_eq!(parse_duration("30m").unwrap(), Duration::from_secs(30 * 60));
+        assert_eq!(parse_duration("24h").unwrap(), Duration::from_secs(86_400));
+        assert_eq!(
+            parse_duration("7d").unwrap(),
+            Duration::from_secs(7 * 86_400)
+        );
+        assert_eq!(
+            parse_duration("2w").unwrap(),
+            Duration::from_secs(2 * 7 * 86_400)
+        );
+    }
+
+    #[test]
+    fn duration_rejects_invalid_input() {
+        assert!(parse_duration("").is_err());
+        assert!(parse_duration("10").is_err(), "missing unit");
+        assert!(parse_duration("abc").is_err());
+        assert!(parse_duration("1y").is_err(), "years not supported");
+    }
+
+    #[test]
+    fn expand_path_handles_tilde() {
+        let expanded = expand_path("~/foo");
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(expanded, home.join("foo"));
+
+        let plain = expand_path("/tmp/devboy");
+        assert_eq!(plain, PathBuf::from("/tmp/devboy"));
+    }
+
+    #[test]
+    fn resolve_uses_defaults_when_empty() {
+        let cfg = AssetConfig::default();
+        let resolved = cfg.resolve().unwrap();
+        assert_eq!(
+            resolved.max_cache_size,
+            parse_size(DEFAULT_MAX_CACHE_SIZE).unwrap()
+        );
+        assert_eq!(
+            resolved.max_file_age,
+            parse_duration(DEFAULT_MAX_FILE_AGE).unwrap()
+        );
+        assert_eq!(resolved.eviction_policy, EvictionPolicy::Lru);
+    }
+
+    #[test]
+    fn resolve_honors_user_values() {
+        let cfg = AssetConfig {
+            cache_dir: Some("/tmp/devboy-test".into()),
+            max_cache_size: Some("500Mi".into()),
+            max_file_age: Some("24h".into()),
+            eviction_policy: Some(EvictionPolicy::Fifo),
+        };
+        let resolved = cfg.resolve().unwrap();
+        assert_eq!(resolved.cache_dir, PathBuf::from("/tmp/devboy-test"));
+        assert_eq!(resolved.max_cache_size, 500 * 1024 * 1024);
+        assert_eq!(resolved.max_file_age, Duration::from_secs(86_400));
+        assert_eq!(resolved.eviction_policy, EvictionPolicy::Fifo);
+    }
+
+    #[test]
+    fn eviction_policy_serde() {
+        let toml_str = r#"eviction_policy = "lru""#;
+        let cfg: AssetConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.eviction_policy, Some(EvictionPolicy::Lru));
+
+        let toml_str = r#"eviction_policy = "none""#;
+        let cfg: AssetConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.eviction_policy, Some(EvictionPolicy::None));
+    }
+
+    #[test]
+    fn asset_config_toml_roundtrip() {
+        let toml_str = r#"
+cache_dir = "/tmp/custom"
+max_cache_size = "2Gi"
+max_file_age = "3d"
+eviction_policy = "lru"
+"#;
+        let cfg: AssetConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.cache_dir.as_deref(), Some("/tmp/custom"));
+        assert_eq!(cfg.max_cache_size.as_deref(), Some("2Gi"));
+
+        let resolved = cfg.resolve().unwrap();
+        assert_eq!(resolved.max_cache_size, 2 * 1024 * 1024 * 1024);
+        assert_eq!(resolved.max_file_age, Duration::from_secs(3 * 86_400));
+    }
+}

--- a/crates/devboy-assets/src/config.rs
+++ b/crates/devboy-assets/src/config.rs
@@ -144,6 +144,11 @@ pub fn parse_size(input: &str) -> Result<u64> {
         .parse()
         .map_err(|_| AssetError::config(format!("invalid size number: {number_part}")))?;
 
+    if !number.is_finite() {
+        return Err(AssetError::config(format!(
+            "non-finite size number: {input}",
+        )));
+    }
     if number < 0.0 {
         return Err(AssetError::config(format!("negative size: {input}")));
     }
@@ -172,7 +177,15 @@ pub fn parse_size(input: &str) -> Result<u64> {
         }
     };
 
-    Ok((number * multiplier) as u64)
+    // Check the result is still in range. `as u64` would otherwise clamp
+    // NaN to 0 and silently cap anything past `u64::MAX`.
+    let bytes = number * multiplier;
+    if !bytes.is_finite() || bytes < 0.0 || bytes > u64::MAX as f64 {
+        return Err(AssetError::config(format!(
+            "size overflows u64 bytes: {input}",
+        )));
+    }
+    Ok(bytes as u64)
 }
 
 /// Parse a human-readable duration such as `"7d"`, `"24h"`, `"30m"`, `"45s"`.
@@ -265,6 +278,22 @@ mod tests {
         assert!(parse_size("abc").is_err());
         assert!(parse_size("1Zi").is_err());
         assert!(parse_size("-1Gi").is_err());
+    }
+
+    #[test]
+    fn size_rejects_non_finite_values() {
+        // NaN / infinity parse as f64 but must be rejected — otherwise
+        // `as u64` would silently cast them to 0 or clamp.
+        assert!(parse_size("NaN").is_err());
+        assert!(parse_size("NaNGi").is_err());
+        assert!(parse_size("inf").is_err());
+        assert!(parse_size("infGi").is_err());
+    }
+
+    #[test]
+    fn size_rejects_overflow() {
+        // 1e30 bytes is far beyond u64::MAX (~1.8e19).
+        assert!(parse_size("1e30").is_err());
     }
 
     #[test]

--- a/crates/devboy-assets/src/config.rs
+++ b/crates/devboy-assets/src/config.rs
@@ -368,17 +368,36 @@ mod tests {
 
     #[test]
     fn resolve_honors_user_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_string_lossy().to_string();
         let cfg = AssetConfig {
-            cache_dir: Some("/tmp/devboy-test".into()),
+            cache_dir: Some(dir.clone()),
             max_cache_size: Some("500Mi".into()),
             max_file_age: Some("24h".into()),
             eviction_policy: Some(EvictionPolicy::Fifo),
         };
         let resolved = cfg.resolve().unwrap();
-        assert_eq!(resolved.cache_dir, PathBuf::from("/tmp/devboy-test"));
+        // The resolved path must be absolute and match the configured dir.
+        assert!(resolved.cache_dir.is_absolute());
+        assert_eq!(resolved.cache_dir, PathBuf::from(&dir));
         assert_eq!(resolved.max_cache_size, 500 * 1024 * 1024);
         assert_eq!(resolved.max_file_age, Duration::from_secs(86_400));
         assert_eq!(resolved.eviction_policy, EvictionPolicy::Fifo);
+    }
+
+    #[test]
+    fn resolve_absolutizes_relative_cache_dir() {
+        let cfg = AssetConfig {
+            cache_dir: Some("relative/path".into()),
+            ..Default::default()
+        };
+        let resolved = cfg.resolve().unwrap();
+        assert!(
+            resolved.cache_dir.is_absolute(),
+            "relative cache_dir should be absolutized: {:?}",
+            resolved.cache_dir,
+        );
+        assert!(resolved.cache_dir.ends_with("relative/path"));
     }
 
     #[test]

--- a/crates/devboy-assets/src/error.rs
+++ b/crates/devboy-assets/src/error.rs
@@ -1,0 +1,80 @@
+//! Error type for the asset management crate.
+//!
+//! Wraps [`devboy_core::Error`] with a few asset-specific variants. The
+//! [`From`] impls let call sites use `?` with IO, serde_json, and the core
+//! error type interchangeably.
+
+use thiserror::Error;
+
+/// Errors that can occur during asset cache operations.
+#[derive(Error, Debug)]
+pub enum AssetError {
+    /// Underlying filesystem I/O failure.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Failed to (de)serialize JSON while reading / writing the index.
+    #[error("Index serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    /// Failed to parse a human-readable size / duration in configuration.
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    /// The requested asset was not present in the cache index.
+    #[error("Asset not found: {0}")]
+    NotFound(String),
+
+    /// The cache directory was unreachable or could not be created.
+    #[error("Cache directory error: {0}")]
+    CacheDir(String),
+
+    /// Anything surfaced from [`devboy_core::Error`].
+    #[error(transparent)]
+    Core(#[from] devboy_core::Error),
+}
+
+/// Convenience alias for `Result<T, AssetError>`.
+pub type Result<T> = std::result::Result<T, AssetError>;
+
+impl AssetError {
+    /// Create a new configuration error.
+    pub fn config(msg: impl Into<String>) -> Self {
+        AssetError::Config(msg.into())
+    }
+
+    /// Create a new cache directory error.
+    pub fn cache_dir(msg: impl Into<String>) -> Self {
+        AssetError::CacheDir(msg.into())
+    }
+
+    /// Create a new not-found error.
+    pub fn not_found(id: impl Into<String>) -> Self {
+        AssetError::NotFound(id.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constructor_helpers() {
+        let e = AssetError::config("bad value");
+        assert!(matches!(e, AssetError::Config(_)));
+        assert!(format!("{e}").contains("bad value"));
+
+        let e = AssetError::cache_dir("no perms");
+        assert!(matches!(e, AssetError::CacheDir(_)));
+
+        let e = AssetError::not_found("asset-1");
+        assert!(matches!(e, AssetError::NotFound(_)));
+    }
+
+    #[test]
+    fn io_error_is_convertible() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "x");
+        let e: AssetError = io.into();
+        assert!(matches!(e, AssetError::Io(_)));
+    }
+}

--- a/crates/devboy-assets/src/error.rs
+++ b/crates/devboy-assets/src/error.rs
@@ -29,6 +29,12 @@ pub enum AssetError {
     #[error("Cache directory error: {0}")]
     CacheDir(String),
 
+    /// The in-memory index mutex was poisoned by a panic in another
+    /// thread. Callers can decide whether to recover (rebuild index) or
+    /// bubble the error up to the user.
+    #[error("Asset index mutex poisoned: {0}")]
+    Poisoned(String),
+
     /// Anything surfaced from [`devboy_core::Error`].
     #[error(transparent)]
     Core(#[from] devboy_core::Error),
@@ -51,6 +57,11 @@ impl AssetError {
     /// Create a new not-found error.
     pub fn not_found(id: impl Into<String>) -> Self {
         AssetError::NotFound(id.into())
+    }
+
+    /// Create a new poisoned-mutex error.
+    pub fn poisoned(msg: impl Into<String>) -> Self {
+        AssetError::Poisoned(msg.into())
     }
 }
 

--- a/crates/devboy-assets/src/index.rs
+++ b/crates/devboy-assets/src/index.rs
@@ -245,7 +245,18 @@ fn purge_cache_blobs(cache_dir: &Path) {
         if path.file_name().is_some_and(|n| n == INDEX_FILENAME) {
             continue;
         }
-        let result = if path.is_dir() {
+        // Use `symlink_metadata` (lstat) instead of `is_dir()` so that
+        // symlinks are never followed. A symlink pointing outside the
+        // cache root must be unlinked with `remove_file`, not chased
+        // into with `remove_dir_all`.
+        let is_real_dir = match std::fs::symlink_metadata(&path) {
+            Ok(meta) => meta.is_dir(),
+            Err(e) => {
+                tracing::warn!(?e, path = ?path, "failed to stat cached entry");
+                continue;
+            }
+        };
+        let result = if is_real_dir {
             std::fs::remove_dir_all(&path)
         } else {
             std::fs::remove_file(&path)

--- a/crates/devboy-assets/src/index.rs
+++ b/crates/devboy-assets/src/index.rs
@@ -1,0 +1,344 @@
+//! On-disk index of cached assets (`index.json`).
+//!
+//! The index is a plain JSON file persisted alongside the cache directory.
+//! It stores the metadata that must survive process restarts:
+//!
+//! - Map of `asset_id -> CachedAsset` (filename, size, checksum, context, ...)
+//! - `last_accessed` timestamps used by the LRU rotator
+//!
+//! Writes go through a temp file + rename for atomicity, so that a crash
+//! mid-write cannot leave a half-written index on disk.
+
+use devboy_core::asset::AssetContext;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::error::{AssetError, Result};
+
+/// Filename of the on-disk index, relative to the cache root.
+pub const INDEX_FILENAME: &str = "index.json";
+
+/// Current schema version — bumped when breaking changes are made.
+pub const INDEX_VERSION: u32 = 1;
+
+/// A single cached asset as persisted in the index.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CachedAsset {
+    /// Stable identifier (UUID or provider id).
+    pub id: String,
+    /// Original filename.
+    pub filename: String,
+    /// MIME type if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    /// Size in bytes.
+    pub size: u64,
+    /// Path relative to the cache root.
+    pub local_path: PathBuf,
+    /// Context the asset belongs to.
+    pub context: AssetContext,
+    /// SHA-256 checksum in hex.
+    pub checksum_sha256: String,
+    /// Remote URL at the provider, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_url: Option<String>,
+    /// UNIX epoch milliseconds — when the file was first downloaded.
+    pub downloaded_at_ms: u64,
+    /// UNIX epoch milliseconds — when the file was last accessed.
+    pub last_accessed_ms: u64,
+}
+
+/// Parameters accepted by [`CachedAsset::new`].
+///
+/// Introduced to keep the constructor below the clippy
+/// `too_many_arguments` lint threshold.
+#[derive(Debug, Clone)]
+pub struct NewCachedAsset {
+    /// Stable identifier (UUID or provider id).
+    pub id: String,
+    /// Original filename.
+    pub filename: String,
+    /// MIME type if known.
+    pub mime_type: Option<String>,
+    /// Size in bytes.
+    pub size: u64,
+    /// Path relative to the cache root.
+    pub local_path: PathBuf,
+    /// Context the asset belongs to.
+    pub context: AssetContext,
+    /// SHA-256 checksum in hex.
+    pub checksum_sha256: String,
+    /// Remote URL at the provider if any.
+    pub remote_url: Option<String>,
+}
+
+impl CachedAsset {
+    /// Convenience constructor — wraps [`NewCachedAsset`] and stamps
+    /// `downloaded_at` / `last_accessed` to the current time.
+    pub fn new(params: NewCachedAsset) -> Self {
+        let now = now_ms();
+        Self {
+            id: params.id,
+            filename: params.filename,
+            mime_type: params.mime_type,
+            size: params.size,
+            local_path: params.local_path,
+            context: params.context,
+            checksum_sha256: params.checksum_sha256,
+            remote_url: params.remote_url,
+            downloaded_at_ms: now,
+            last_accessed_ms: now,
+        }
+    }
+}
+
+/// In-memory representation of the `index.json` file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssetIndex {
+    /// Schema version.
+    pub version: u32,
+    /// All known assets keyed by id.
+    #[serde(default)]
+    pub assets: HashMap<String, CachedAsset>,
+}
+
+impl Default for AssetIndex {
+    fn default() -> Self {
+        Self {
+            version: INDEX_VERSION,
+            assets: HashMap::new(),
+        }
+    }
+}
+
+impl AssetIndex {
+    /// Create an empty index at the current schema version.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Load the index from `cache_dir/index.json`, returning an empty index
+    /// if the file does not exist.
+    ///
+    /// If the file exists but cannot be parsed, an empty index is returned
+    /// and a warning is logged — this is the first line of the integrity
+    /// check and is preferable to refusing to start.
+    pub fn load(cache_dir: &Path) -> Result<Self> {
+        let path = cache_dir.join(INDEX_FILENAME);
+        if !path.exists() {
+            return Ok(Self::empty());
+        }
+
+        let bytes = std::fs::read(&path)?;
+        match serde_json::from_slice::<Self>(&bytes) {
+            Ok(mut index) => {
+                if index.version != INDEX_VERSION {
+                    tracing::warn!(
+                        expected = INDEX_VERSION,
+                        found = index.version,
+                        "asset index version mismatch, rebuilding"
+                    );
+                    index = Self::empty();
+                }
+                Ok(index)
+            }
+            Err(err) => {
+                tracing::warn!(?err, "failed to parse asset index, starting fresh");
+                Ok(Self::empty())
+            }
+        }
+    }
+
+    /// Persist the index to `cache_dir/index.json` atomically via
+    /// temp file + rename.
+    pub fn save(&self, cache_dir: &Path) -> Result<()> {
+        std::fs::create_dir_all(cache_dir)?;
+        let path = cache_dir.join(INDEX_FILENAME);
+
+        let bytes = serde_json::to_vec_pretty(self)?;
+
+        // NamedTempFile in the same directory guarantees the final rename
+        // stays on the same filesystem.
+        let mut tmp = tempfile::NamedTempFile::new_in(cache_dir)
+            .map_err(|e| AssetError::cache_dir(format!("temp file: {e}")))?;
+        tmp.write_all(&bytes)?;
+        tmp.flush()?;
+        tmp.persist(&path)
+            .map_err(|e| AssetError::cache_dir(format!("persist index: {e}")))?;
+        Ok(())
+    }
+
+    /// Insert or replace an asset entry.
+    pub fn upsert(&mut self, asset: CachedAsset) {
+        self.assets.insert(asset.id.clone(), asset);
+    }
+
+    /// Remove an asset entry, returning the old value if any.
+    pub fn remove(&mut self, id: &str) -> Option<CachedAsset> {
+        self.assets.remove(id)
+    }
+
+    /// Look up an asset by id.
+    pub fn get(&self, id: &str) -> Option<&CachedAsset> {
+        self.assets.get(id)
+    }
+
+    /// Mutably look up an asset by id.
+    pub fn get_mut(&mut self, id: &str) -> Option<&mut CachedAsset> {
+        self.assets.get_mut(id)
+    }
+
+    /// Mark `last_accessed` on an asset as "now".
+    pub fn touch(&mut self, id: &str) -> bool {
+        if let Some(asset) = self.assets.get_mut(id) {
+            asset.last_accessed_ms = now_ms();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Total size in bytes of all tracked assets.
+    pub fn total_size(&self) -> u64 {
+        self.assets.values().map(|a| a.size).sum()
+    }
+
+    /// Number of tracked assets.
+    pub fn len(&self) -> usize {
+        self.assets.len()
+    }
+
+    /// Whether the index contains no assets.
+    pub fn is_empty(&self) -> bool {
+        self.assets.is_empty()
+    }
+}
+
+/// Current time as UNIX epoch milliseconds.
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use devboy_core::asset::AssetContext;
+    use tempfile::tempdir;
+
+    fn make_asset(id: &str, size: u64) -> CachedAsset {
+        CachedAsset::new(NewCachedAsset {
+            id: id.into(),
+            filename: format!("{id}.txt"),
+            mime_type: Some("text/plain".into()),
+            size,
+            local_path: PathBuf::from(format!("files/{id}.txt")),
+            context: AssetContext::Issue {
+                key: "DEV-1".into(),
+            },
+            checksum_sha256: "abcd".into(),
+            remote_url: None,
+        })
+    }
+
+    #[test]
+    fn upsert_get_remove() {
+        let mut index = AssetIndex::empty();
+        index.upsert(make_asset("a1", 10));
+        index.upsert(make_asset("a2", 20));
+        assert_eq!(index.len(), 2);
+        assert_eq!(index.total_size(), 30);
+
+        assert_eq!(index.get("a1").unwrap().size, 10);
+        let removed = index.remove("a1").unwrap();
+        assert_eq!(removed.id, "a1");
+        assert_eq!(index.len(), 1);
+        assert!(index.get("a1").is_none());
+    }
+
+    #[test]
+    fn touch_updates_last_accessed() {
+        let mut index = AssetIndex::empty();
+        index.upsert(make_asset("a1", 10));
+        let original = index.get("a1").unwrap().last_accessed_ms;
+
+        // Small sleep to ensure ms tick; spin-loop is enough for the test.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        assert!(index.touch("a1"));
+        assert!(index.get("a1").unwrap().last_accessed_ms > original);
+        assert!(!index.touch("missing"));
+    }
+
+    #[test]
+    fn load_missing_returns_empty() {
+        let tmp = tempdir().unwrap();
+        let index = AssetIndex::load(tmp.path()).unwrap();
+        assert!(index.is_empty());
+        assert_eq!(index.version, INDEX_VERSION);
+    }
+
+    #[test]
+    fn save_and_reload_roundtrip() {
+        let tmp = tempdir().unwrap();
+        let mut index = AssetIndex::empty();
+        index.upsert(make_asset("a1", 42));
+        index.save(tmp.path()).unwrap();
+
+        let reloaded = AssetIndex::load(tmp.path()).unwrap();
+        assert_eq!(reloaded.len(), 1);
+        assert_eq!(reloaded.get("a1").unwrap().size, 42);
+    }
+
+    #[test]
+    fn corrupt_index_falls_back_to_empty() {
+        let tmp = tempdir().unwrap();
+        std::fs::write(tmp.path().join(INDEX_FILENAME), b"not json").unwrap();
+        let index = AssetIndex::load(tmp.path()).unwrap();
+        assert!(index.is_empty(), "corrupt index should fall back to empty");
+    }
+
+    #[test]
+    fn version_mismatch_falls_back_to_empty() {
+        let tmp = tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(INDEX_FILENAME),
+            br#"{"version":999,"assets":{}}"#,
+        )
+        .unwrap();
+        let index = AssetIndex::load(tmp.path()).unwrap();
+        assert_eq!(index.version, INDEX_VERSION);
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn save_is_atomic_under_overwrite() {
+        let tmp = tempdir().unwrap();
+        let mut index = AssetIndex::empty();
+        index.upsert(make_asset("a1", 1));
+        index.save(tmp.path()).unwrap();
+
+        // Overwrite with different content; no stale temp files should linger.
+        index.upsert(make_asset("a2", 2));
+        index.save(tmp.path()).unwrap();
+
+        let reloaded = AssetIndex::load(tmp.path()).unwrap();
+        assert_eq!(reloaded.len(), 2);
+
+        // Check that no temp files are left behind.
+        let stragglers: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let name = e.file_name();
+                let name = name.to_string_lossy();
+                name != INDEX_FILENAME
+            })
+            .collect();
+        assert!(stragglers.is_empty(), "unexpected files: {stragglers:?}");
+    }
+}

--- a/crates/devboy-assets/src/index.rs
+++ b/crates/devboy-assets/src/index.rs
@@ -123,9 +123,10 @@ impl AssetIndex {
     /// Load the index from `cache_dir/index.json`, returning an empty index
     /// if the file does not exist.
     ///
-    /// If the file exists but cannot be parsed, an empty index is returned
-    /// and a warning is logged — this is the first line of the integrity
-    /// check and is preferable to refusing to start.
+    /// If the file exists but cannot be parsed (or has a version mismatch),
+    /// an empty index is returned and all non-index files under
+    /// `cache_dir` are purged so that blobs that are no longer tracked by
+    /// the index cannot accumulate indefinitely on disk.
     pub fn load(cache_dir: &Path) -> Result<Self> {
         let path = cache_dir.join(INDEX_FILENAME);
         if !path.exists() {
@@ -139,14 +140,19 @@ impl AssetIndex {
                     tracing::warn!(
                         expected = INDEX_VERSION,
                         found = index.version,
-                        "asset index version mismatch, rebuilding"
+                        "asset index version mismatch, purging cache and rebuilding"
                     );
+                    purge_cache_blobs(cache_dir);
                     index = Self::empty();
                 }
                 Ok(index)
             }
             Err(err) => {
-                tracing::warn!(?err, "failed to parse asset index, starting fresh");
+                tracing::warn!(
+                    ?err,
+                    "failed to parse asset index, purging cache and starting fresh"
+                );
+                purge_cache_blobs(cache_dir);
                 Ok(Self::empty())
             }
         }
@@ -214,6 +220,39 @@ impl AssetIndex {
     /// Whether the index contains no assets.
     pub fn is_empty(&self) -> bool {
         self.assets.is_empty()
+    }
+}
+
+/// Remove all files and subdirectories under `cache_dir` except the index
+/// file itself. Called when the index is unrecoverable (corrupt or version
+/// mismatch) so that orphaned blobs don't accumulate on disk.
+///
+/// Best-effort: individual I/O errors are logged and skipped — we would
+/// rather start with a fresh (possibly partially cleaned) cache than fail
+/// to open the manager entirely.
+fn purge_cache_blobs(cache_dir: &Path) {
+    let entries = match std::fs::read_dir(cache_dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::warn!(?e, "failed to list cache directory for purge");
+            return;
+        }
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // Keep the index file itself — it will be overwritten by the
+        // caller with an empty index.
+        if path.file_name().is_some_and(|n| n == INDEX_FILENAME) {
+            continue;
+        }
+        let result = if path.is_dir() {
+            std::fs::remove_dir_all(&path)
+        } else {
+            std::fs::remove_file(&path)
+        };
+        if let Err(e) = result {
+            tracing::warn!(?e, path = ?path, "failed to purge cached file");
+        }
     }
 }
 

--- a/crates/devboy-assets/src/lib.rs
+++ b/crates/devboy-assets/src/lib.rs
@@ -1,0 +1,26 @@
+//! Asset management for devboy-tools.
+//!
+//! This crate provides a local, on-disk cache for files downloaded from
+//! providers (issue attachments, MR uploads, messenger files, ...) together
+//! with an index of metadata, LRU rotation, and an integrity check.
+//!
+//! The public surface is centered on [`AssetManager`], which wraps a
+//! [`CacheManager`] and an on-disk [`AssetIndex`].
+//!
+//! See ADR-010 in `devboy-cloud-monorepo` for the full design.
+
+#![deny(missing_docs)]
+
+pub mod cache;
+pub mod config;
+pub mod error;
+pub mod index;
+pub mod manager;
+pub mod rotation;
+
+pub use cache::{CacheManager, StoredFile};
+pub use config::{AssetConfig, EvictionPolicy, ResolvedAssetConfig};
+pub use error::{AssetError, Result};
+pub use index::{AssetIndex, CachedAsset, NewCachedAsset};
+pub use manager::{AssetManager, ResolvedAsset, StoreRequest};
+pub use rotation::{RotationStats, Rotator};

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -84,6 +84,12 @@ impl AssetManager {
 
     /// Store a new asset, persisting the updated index and running a
     /// rotation pass. Returns the newly created [`CachedAsset`].
+    ///
+    /// If the payload is larger than the configured
+    /// [`ResolvedAssetConfig::max_cache_size`] this returns an
+    /// [`AssetError::Config`] error *without* touching the filesystem —
+    /// otherwise rotation would immediately evict the just-written file and
+    /// we'd hand back an asset id that no longer resolves.
     pub fn store(&self, request: StoreRequest<'_>) -> Result<CachedAsset> {
         let StoreRequest {
             context,
@@ -93,6 +99,16 @@ impl AssetManager {
             remote_url,
             data,
         } = request;
+
+        let size = data.len() as u64;
+        let max = self.inner.config.max_cache_size;
+        if max > 0 && size > max {
+            return Err(AssetError::config(format!(
+                "asset '{asset_id}' is {size} bytes, which exceeds the cache \
+                 budget of {max} bytes; increase `[assets] max_cache_size` or \
+                 split the file",
+            )));
+        }
 
         let stored = self.inner.cache.store(&context, asset_id, filename, data)?;
         let rel_path = stored
@@ -398,6 +414,31 @@ mod tests {
         let mgr = manager(tmp.path().to_path_buf());
         assert_eq!(mgr.index_path(), tmp.path().join(INDEX_FILENAME));
         assert_eq!(mgr.cache_dir(), tmp.path());
+    }
+
+    #[test]
+    fn store_rejects_oversized_payload() {
+        let tmp = tempdir().unwrap();
+        let cfg = ResolvedAssetConfig {
+            cache_dir: tmp.path().to_path_buf(),
+            max_cache_size: 10,
+            max_file_age: Duration::from_secs(100 * 86_400),
+            eviction_policy: EvictionPolicy::Lru,
+        };
+        let mgr = AssetManager::from_resolved(cfg).unwrap();
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+
+        let err = mgr
+            .store(store_simple(ctx, "a1", "big.bin", &[0u8; 100]))
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("exceeds the cache"), "unexpected msg: {msg}");
+
+        // Nothing should have been written or tracked.
+        assert!(mgr.list().is_empty());
+        assert_eq!(mgr.total_size(), 0);
     }
 
     #[test]

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -245,7 +245,20 @@ impl AssetManager {
                 .inner
                 .rotator
                 .rotate(&mut index, &self.inner.cache)
-                .and_then(|_| index.save(&self.inner.config.cache_dir))
+                .and_then(|_| {
+                    // Guard: if rotation evicted the asset we just stored,
+                    // roll back rather than returning metadata that
+                    // immediately misses on `get()`.
+                    if index.get(asset.id.as_str()).is_none() {
+                        return Err(AssetError::config(format!(
+                            "asset '{}' was evicted immediately after store — \
+                             the cache budget ({} bytes) is too small for this file \
+                             ({} bytes) alongside existing entries",
+                            asset.id, self.inner.config.max_cache_size, asset.size,
+                        )));
+                    }
+                    index.save(&self.inner.config.cache_dir)
+                })
             {
                 // Restore the snapshot so list()/total_size() stay
                 // consistent with what's actually on disk.

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -1,0 +1,410 @@
+//! High-level orchestrator combining the cache, index, and rotator.
+//!
+//! [`AssetManager`] is the entry point used by the rest of devboy-tools. It
+//! hides the split between the physical cache directory and the in-memory
+//! index, and enforces the rotation policy on every write.
+//!
+//! ## Concurrency
+//!
+//! The manager wraps its mutable state in a [`std::sync::Mutex`] so it can
+//! be freely cloned via an `Arc` (e.g. to be shared across tokio tasks).
+//! All on-disk writes go through the mutex, which is acceptable given the
+//! low frequency of cache mutations in the expected workload.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use devboy_core::asset::AssetContext;
+
+use crate::cache::CacheManager;
+use crate::config::{AssetConfig, ResolvedAssetConfig};
+use crate::error::{AssetError, Result};
+use crate::index::{AssetIndex, CachedAsset, INDEX_FILENAME, NewCachedAsset};
+use crate::rotation::{RotationStats, Rotator};
+
+/// Top-level asset cache.
+#[derive(Debug, Clone)]
+pub struct AssetManager {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    config: ResolvedAssetConfig,
+    cache: CacheManager,
+    rotator: Rotator,
+    state: Mutex<AssetIndex>,
+}
+
+impl AssetManager {
+    /// Build a new manager from a raw [`AssetConfig`].
+    pub fn from_config(config: AssetConfig) -> Result<Self> {
+        let resolved = config.resolve()?;
+        Self::from_resolved(resolved)
+    }
+
+    /// Build a new manager from a validated [`ResolvedAssetConfig`].
+    ///
+    /// Loads the on-disk index and runs an integrity check so that any
+    /// stale entries (referring to files that no longer exist) are dropped.
+    pub fn from_resolved(config: ResolvedAssetConfig) -> Result<Self> {
+        let cache = CacheManager::new(config.cache_dir.clone())?;
+        let rotator = Rotator::new(&config);
+        let mut index = AssetIndex::load(&config.cache_dir)?;
+        let _removed = prune_stale_entries(&mut index, &cache);
+        index.save(&config.cache_dir)?;
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                config,
+                cache,
+                rotator,
+                state: Mutex::new(index),
+            }),
+        })
+    }
+
+    /// Convenience constructor for tests and standalone usage.
+    pub fn with_root(root: PathBuf) -> Result<Self> {
+        let cfg = AssetConfig::default();
+        let mut resolved = cfg.resolve()?;
+        resolved.cache_dir = root;
+        Self::from_resolved(resolved)
+    }
+
+    /// Absolute path to the cache directory.
+    pub fn cache_dir(&self) -> &Path {
+        &self.inner.config.cache_dir
+    }
+
+    /// Full resolved configuration.
+    pub fn config(&self) -> &ResolvedAssetConfig {
+        &self.inner.config
+    }
+
+    /// Store a new asset, persisting the updated index and running a
+    /// rotation pass. Returns the newly created [`CachedAsset`].
+    pub fn store(&self, request: StoreRequest<'_>) -> Result<CachedAsset> {
+        let StoreRequest {
+            context,
+            asset_id,
+            filename,
+            mime_type,
+            remote_url,
+            data,
+        } = request;
+
+        let stored = self.inner.cache.store(&context, asset_id, filename, data)?;
+        let rel_path = stored
+            .path
+            .strip_prefix(self.inner.cache.root())
+            .map_err(|e| AssetError::cache_dir(format!("path outside cache root: {e}")))?
+            .to_path_buf();
+
+        let asset = CachedAsset::new(NewCachedAsset {
+            id: asset_id.to_string(),
+            filename: filename.to_string(),
+            mime_type,
+            size: stored.size,
+            local_path: rel_path,
+            context,
+            checksum_sha256: stored.checksum_sha256,
+            remote_url,
+        });
+
+        {
+            let mut index = self.state_lock();
+            index.upsert(asset.clone());
+            self.inner.rotator.rotate(&mut index, &self.inner.cache)?;
+            index.save(&self.inner.config.cache_dir)?;
+        }
+
+        Ok(asset)
+    }
+
+    /// Look up an asset by id and return the absolute path on disk if it
+    /// is still cached. Also touches `last_accessed` and persists the
+    /// index if the asset was found.
+    pub fn get(&self, asset_id: &str) -> Result<Option<ResolvedAsset>> {
+        let mut index = self.state_lock();
+        let Some(asset) = index.get(asset_id).cloned() else {
+            return Ok(None);
+        };
+        let abs_path = self.inner.config.cache_dir.join(&asset.local_path);
+        if !abs_path.is_file() {
+            // File vanished — drop the stale entry.
+            index.remove(asset_id);
+            index.save(&self.inner.config.cache_dir)?;
+            return Ok(None);
+        }
+        index.touch(asset_id);
+        index.save(&self.inner.config.cache_dir)?;
+        Ok(Some(ResolvedAsset {
+            asset,
+            absolute_path: abs_path,
+        }))
+    }
+
+    /// Delete an asset from the cache (both the index entry and the file).
+    /// Returns `true` if the asset was present.
+    pub fn delete(&self, asset_id: &str) -> Result<bool> {
+        let mut index = self.state_lock();
+        let Some(asset) = index.remove(asset_id) else {
+            return Ok(false);
+        };
+        let abs_path = self.inner.config.cache_dir.join(&asset.local_path);
+        self.inner.cache.delete(&abs_path)?;
+        index.save(&self.inner.config.cache_dir)?;
+        Ok(true)
+    }
+
+    /// List all assets currently tracked.
+    pub fn list(&self) -> Vec<CachedAsset> {
+        self.state_lock().assets.values().cloned().collect()
+    }
+
+    /// Total tracked bytes in the cache.
+    pub fn total_size(&self) -> u64 {
+        self.state_lock().total_size()
+    }
+
+    /// Force a rotation pass immediately.
+    pub fn rotate_now(&self) -> Result<RotationStats> {
+        let mut index = self.state_lock();
+        let stats = self.inner.rotator.rotate(&mut index, &self.inner.cache)?;
+        index.save(&self.inner.config.cache_dir)?;
+        Ok(stats)
+    }
+
+    /// Re-check index vs filesystem. Returns the number of dropped entries.
+    pub fn integrity_check(&self) -> Result<usize> {
+        let mut index = self.state_lock();
+        let removed = prune_stale_entries(&mut index, &self.inner.cache);
+        if removed > 0 {
+            index.save(&self.inner.config.cache_dir)?;
+        }
+        Ok(removed)
+    }
+
+    /// Path to the on-disk index file. Useful for diagnostics and tests.
+    pub fn index_path(&self) -> PathBuf {
+        self.inner.config.cache_dir.join(INDEX_FILENAME)
+    }
+
+    fn state_lock(&self) -> std::sync::MutexGuard<'_, AssetIndex> {
+        self.inner.state.lock().expect("asset index mutex poisoned")
+    }
+}
+
+/// Resolved lookup result — both the cached metadata and the absolute
+/// path of the file on disk.
+#[derive(Debug, Clone)]
+pub struct ResolvedAsset {
+    /// Metadata from the index.
+    pub asset: CachedAsset,
+    /// Absolute path to the file on disk.
+    pub absolute_path: PathBuf,
+}
+
+/// Parameters for [`AssetManager::store`].
+#[derive(Debug)]
+pub struct StoreRequest<'a> {
+    /// Context the asset is attached to.
+    pub context: AssetContext,
+    /// Stable id to use for the asset. Caller is responsible for uniqueness.
+    pub asset_id: &'a str,
+    /// Original filename.
+    pub filename: &'a str,
+    /// MIME type if known.
+    pub mime_type: Option<String>,
+    /// Remote URL at the provider if known.
+    pub remote_url: Option<String>,
+    /// Raw bytes to cache.
+    pub data: &'a [u8],
+}
+
+/// Drop index entries whose underlying file is missing. Returns the count
+/// of removed entries. Used by both `from_resolved` (startup check) and
+/// [`AssetManager::integrity_check`].
+fn prune_stale_entries(index: &mut AssetIndex, cache: &CacheManager) -> usize {
+    let stale: Vec<String> = index
+        .assets
+        .iter()
+        .filter_map(|(id, asset)| {
+            let abs = cache.root().join(&asset.local_path);
+            if cache.exists(&abs) {
+                None
+            } else {
+                Some(id.clone())
+            }
+        })
+        .collect();
+    let count = stale.len();
+    for id in stale {
+        index.remove(&id);
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::EvictionPolicy;
+    use devboy_core::asset::AssetContext;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    fn manager(root: PathBuf) -> AssetManager {
+        let cfg = ResolvedAssetConfig {
+            cache_dir: root,
+            max_cache_size: 10_000,
+            max_file_age: Duration::from_secs(100 * 86_400),
+            eviction_policy: EvictionPolicy::Lru,
+        };
+        AssetManager::from_resolved(cfg).unwrap()
+    }
+
+    fn store_simple<'a>(
+        context: AssetContext,
+        asset_id: &'a str,
+        filename: &'a str,
+        data: &'a [u8],
+    ) -> StoreRequest<'a> {
+        StoreRequest {
+            context,
+            asset_id,
+            filename,
+            mime_type: None,
+            remote_url: None,
+            data,
+        }
+    }
+
+    #[test]
+    fn store_get_delete_roundtrip() {
+        let tmp = tempdir().unwrap();
+        let mgr = manager(tmp.path().to_path_buf());
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+
+        let asset = mgr
+            .store(StoreRequest {
+                context: ctx.clone(),
+                asset_id: "a1",
+                filename: "file.txt",
+                mime_type: Some("text/plain".into()),
+                remote_url: None,
+                data: b"hello",
+            })
+            .unwrap();
+        assert_eq!(asset.size, 5);
+        assert_eq!(mgr.total_size(), 5);
+
+        let resolved = mgr.get("a1").unwrap().expect("asset present");
+        assert_eq!(resolved.asset.id, "a1");
+        assert!(resolved.absolute_path.is_file());
+        assert_eq!(std::fs::read(&resolved.absolute_path).unwrap(), b"hello");
+
+        assert!(mgr.delete("a1").unwrap());
+        assert!(mgr.get("a1").unwrap().is_none());
+        assert!(!mgr.delete("a1").unwrap(), "second delete is a no-op");
+        assert_eq!(mgr.total_size(), 0);
+    }
+
+    #[test]
+    fn store_persists_across_reopen() {
+        let tmp = tempdir().unwrap();
+        {
+            let mgr = manager(tmp.path().to_path_buf());
+            let ctx = AssetContext::Issue {
+                key: "DEV-1".into(),
+            };
+            mgr.store(store_simple(ctx, "a1", "x.bin", b"xyz")).unwrap();
+        }
+
+        let mgr = manager(tmp.path().to_path_buf());
+        let list = mgr.list();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "a1");
+        let resolved = mgr.get("a1").unwrap().unwrap();
+        assert_eq!(std::fs::read(&resolved.absolute_path).unwrap(), b"xyz");
+    }
+
+    #[test]
+    fn integrity_check_removes_missing_files() {
+        let tmp = tempdir().unwrap();
+        let mgr = manager(tmp.path().to_path_buf());
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+        let asset = mgr.store(store_simple(ctx, "a1", "x.bin", b"xyz")).unwrap();
+
+        // Remove the file out-of-band.
+        let abs = tmp.path().join(&asset.local_path);
+        std::fs::remove_file(&abs).unwrap();
+
+        let removed = mgr.integrity_check().unwrap();
+        assert_eq!(removed, 1);
+        assert!(mgr.list().is_empty());
+    }
+
+    #[test]
+    fn get_drops_stale_entry_and_returns_none() {
+        let tmp = tempdir().unwrap();
+        let mgr = manager(tmp.path().to_path_buf());
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+        let asset = mgr.store(store_simple(ctx, "a1", "x.bin", b"xyz")).unwrap();
+
+        std::fs::remove_file(tmp.path().join(&asset.local_path)).unwrap();
+
+        assert!(mgr.get("a1").unwrap().is_none());
+        assert!(mgr.list().is_empty());
+    }
+
+    #[test]
+    fn rotate_now_enforces_budget() {
+        let tmp = tempdir().unwrap();
+        let cfg = ResolvedAssetConfig {
+            cache_dir: tmp.path().to_path_buf(),
+            max_cache_size: 100,
+            max_file_age: Duration::from_secs(100 * 86_400),
+            eviction_policy: EvictionPolicy::Lru,
+        };
+        let mgr = AssetManager::from_resolved(cfg).unwrap();
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+
+        mgr.store(store_simple(ctx.clone(), "a", "a.bin", &[0u8; 60]))
+            .unwrap();
+        // Second store triggers rotation automatically. Both fit (60 + 60 > 100)
+        // so one of them should be evicted.
+        mgr.store(store_simple(ctx, "b", "b.bin", &[0u8; 60]))
+            .unwrap();
+        assert!(mgr.total_size() <= 100);
+        assert_eq!(mgr.list().len(), 1);
+
+        // Explicit rotate_now is a no-op now that we are within budget.
+        let stats = mgr.rotate_now().unwrap();
+        assert_eq!(stats.removed(), 0);
+    }
+
+    #[test]
+    fn index_path_points_at_cache_dir() {
+        let tmp = tempdir().unwrap();
+        let mgr = manager(tmp.path().to_path_buf());
+        assert_eq!(mgr.index_path(), tmp.path().join(INDEX_FILENAME));
+        assert_eq!(mgr.cache_dir(), tmp.path());
+    }
+
+    #[test]
+    fn with_root_uses_defaults() {
+        let tmp = tempdir().unwrap();
+        let mgr = AssetManager::with_root(tmp.path().to_path_buf()).unwrap();
+        assert_eq!(mgr.cache_dir(), tmp.path());
+        assert!(mgr.config().max_cache_size > 0);
+    }
+}

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -216,18 +216,25 @@ impl AssetManager {
         // remove the orphaned blob from disk so the cache stays
         // transactional and doesn't leak disk space.
         let mut deferred_delete: Option<PathBuf> = None;
+        // Track whether a previous entry occupied the same on-disk path.
+        // When true, CacheManager::store already overwrote the old blob
+        // in-place, so the rollback path must NOT delete stored.path —
+        // it's the only copy left and the restored snapshot still points
+        // at it.
+        let mut overwrote_same_path = false;
         let result: Result<()> = (|| {
             let mut index = self.state_lock()?;
 
-            // When re-using an existing asset_id with a different path,
-            // record the old blob for deferred deletion *after* the commit
-            // succeeds. Deleting before the commit would leave the
-            // snapshot pointing at a missing file on rollback.
-            if let Some(previous) = index.get(asset.id.as_str())
-                && previous.local_path != asset.local_path
-            {
-                deferred_delete =
-                    resolve_under_root(&self.inner.config.cache_dir, &previous.local_path);
+            if let Some(previous) = index.get(asset.id.as_str()) {
+                if previous.local_path == asset.local_path {
+                    // Same on-disk path — blob was overwritten in-place.
+                    overwrote_same_path = true;
+                } else {
+                    // Different path — record the old blob for deferred
+                    // deletion *after* the commit succeeds.
+                    deferred_delete =
+                        resolve_under_root(&self.inner.config.cache_dir, &previous.local_path);
+                }
             }
 
             // Snapshot the index so we can restore on failure.
@@ -251,11 +258,10 @@ impl AssetManager {
 
         if let Err(e) = result {
             // Roll back: remove the orphaned blob — but only when it's a
-            // truly new path. If the asset_id, context, and filename are
-            // the same as the previous entry, `CacheManager::store` wrote
-            // the replacement bytes to the *same* on-disk path. Deleting
-            // it would destroy the content that the restored snapshot
-            // still references.
+            // truly new path. If the previous entry occupied the same
+            // on-disk location, CacheManager::store already overwrote the
+            // old bytes in-place, so deleting the file would leave the
+            // restored snapshot pointing at nothing.
             //
             // Trade-off: when same-path overwrite is rolled back, the
             // file on disk contains the *new* bytes, not the original
@@ -263,9 +269,6 @@ impl AssetManager {
             // restoration (backup + restore, or write-to-temp + rename)
             // is intentionally not implemented: this is an ephemeral
             // cache and any file can be re-downloaded from the provider.
-            let overwrote_same_path = deferred_delete
-                .as_ref()
-                .is_some_and(|old| *old == stored.path);
             if !overwrote_same_path {
                 let _ = self.inner.cache.delete(&stored.path);
             }

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -256,6 +256,13 @@ impl AssetManager {
             // the replacement bytes to the *same* on-disk path. Deleting
             // it would destroy the content that the restored snapshot
             // still references.
+            //
+            // Trade-off: when same-path overwrite is rolled back, the
+            // file on disk contains the *new* bytes, not the original
+            // ones — the pre-existing content is lost. Full byte-level
+            // restoration (backup + restore, or write-to-temp + rename)
+            // is intentionally not implemented: this is an ephemeral
+            // cache and any file can be re-downloaded from the provider.
             let overwrote_same_path = deferred_delete
                 .as_ref()
                 .is_some_and(|old| *old == stored.path);

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -8,8 +8,15 @@
 //!
 //! The manager wraps its mutable state in a [`std::sync::Mutex`] so it can
 //! be freely cloned via an `Arc` (e.g. to be shared across tokio tasks).
-//! All on-disk writes go through the mutex, which is acceptable given the
-//! low frequency of cache mutations in the expected workload.
+//!
+//! The mutex serializes updates to the in-memory [`AssetIndex`] and
+//! rotation bookkeeping: every read, write, touch, rotate, and persist of
+//! the index happens inside the critical section. File I/O on the
+//! physical cache (the `CacheManager::store` / `delete` calls) runs
+//! **outside** that critical section — each asset has a unique,
+//! asset-id-prefixed path so two concurrent writes cannot collide, but
+//! callers should not assume every on-disk operation is ordered against
+//! every index update.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -163,33 +170,52 @@ impl AssetManager {
     /// Look up an asset by id and return the absolute path on disk if it
     /// is still cached. Also touches `last_accessed` and persists the
     /// index if the asset was found.
+    ///
+    /// The returned [`ResolvedAsset::asset`] reflects the *post-touch*
+    /// state, so `asset.last_accessed_ms` is the timestamp just written
+    /// to the index rather than the stale pre-touch value.
     pub fn get(&self, asset_id: &str) -> Result<Option<ResolvedAsset>> {
         let mut index = self.state_lock();
-        let Some(asset) = index.get(asset_id).cloned() else {
-            return Ok(None);
+        // Resolve the path using a borrowed lookup first — no clone yet.
+        let (abs_path, remove_stale) = match index.get(asset_id) {
+            Some(asset) => {
+                match resolve_under_root(&self.inner.config.cache_dir, &asset.local_path) {
+                    Some(abs) => (Some(abs), false),
+                    None => {
+                        tracing::warn!(
+                            asset_id,
+                            path = ?asset.local_path,
+                            "dropping index entry with unsafe local_path",
+                        );
+                        (None, true)
+                    }
+                }
+            }
+            None => return Ok(None),
         };
-        // Validate the stored path stays under the cache root before
-        // touching the filesystem. A tampered index entry with an absolute
-        // or traversing path gets dropped and reported as `None`.
-        let Some(abs_path) = resolve_under_root(&self.inner.config.cache_dir, &asset.local_path)
-        else {
-            tracing::warn!(
-                asset_id,
-                path = ?asset.local_path,
-                "dropping index entry with unsafe local_path",
-            );
+
+        if remove_stale {
             index.remove(asset_id);
             index.save(&self.inner.config.cache_dir)?;
             return Ok(None);
-        };
+        }
+        let abs_path = abs_path.expect("abs_path set when remove_stale is false");
+
         if !abs_path.is_file() {
             // File vanished — drop the stale entry.
             index.remove(asset_id);
             index.save(&self.inner.config.cache_dir)?;
             return Ok(None);
         }
+
+        // Touch first, then clone so the returned metadata carries the
+        // freshly-written `last_accessed_ms`.
         index.touch(asset_id);
         index.save(&self.inner.config.cache_dir)?;
+        let asset = index
+            .get(asset_id)
+            .cloned()
+            .expect("asset still present after touch");
         Ok(Some(ResolvedAsset {
             asset,
             absolute_path: abs_path,
@@ -517,6 +543,32 @@ mod tests {
         // Nothing should have been written or tracked.
         assert!(mgr.list().is_empty());
         assert_eq!(mgr.total_size(), 0);
+    }
+
+    #[test]
+    fn get_returns_fresh_last_accessed() {
+        let tmp = tempdir().unwrap();
+        let mgr = manager(tmp.path().to_path_buf());
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+        let stored = mgr.store(store_simple(ctx, "a1", "a.bin", b"xyz")).unwrap();
+        let stored_at = stored.last_accessed_ms;
+
+        // Wait a few ms so the touch produces a strictly newer timestamp.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        let resolved = mgr.get("a1").unwrap().expect("asset present");
+        assert!(
+            resolved.asset.last_accessed_ms > stored_at,
+            "expected ResolvedAsset to reflect the post-touch timestamp: \
+             stored={stored_at}, returned={}",
+            resolved.asset.last_accessed_ms,
+        );
+
+        // And the index value matches what `get` returned.
+        let from_list = mgr.list().into_iter().find(|a| a.id == "a1").unwrap();
+        assert_eq!(from_list.last_accessed_ms, resolved.asset.last_accessed_ms);
     }
 
     #[test]

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -24,8 +24,12 @@
 //!
 //! The only filesystem write that intentionally runs **before** the lock
 //! is acquired is the initial `CacheManager::store` inside
-//! [`AssetManager::store`], which writes the new blob through a unique
-//! per-asset path so two concurrent writes cannot collide.
+//! [`AssetManager::store`], which writes the new blob to a path derived
+//! from the caller-supplied `asset_id` and `filename`. Assuming the
+//! caller provides unique `asset_id` values (which is part of the API
+//! contract), two concurrent writes target different paths and cannot
+//! collide. Reusing the same `asset_id` concurrently is unsupported and
+//! may race on the underlying file.
 //!
 //! Because of the above, callers must not assume these methods are free
 //! from blocking filesystem work — if they are invoked from an async

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -4,19 +4,33 @@
 //! hides the split between the physical cache directory and the in-memory
 //! index, and enforces the rotation policy on every write.
 //!
-//! ## Concurrency
+//! ## Concurrency and blocking
 //!
 //! The manager wraps its mutable state in a [`std::sync::Mutex`] so it can
 //! be freely cloned via an `Arc` (e.g. to be shared across tokio tasks).
-//!
 //! The mutex serializes updates to the in-memory [`AssetIndex`] and
-//! rotation bookkeeping: every read, write, touch, rotate, and persist of
-//! the index happens inside the critical section. File I/O on the
-//! physical cache (the `CacheManager::store` / `delete` calls) runs
-//! **outside** that critical section — each asset has a unique,
-//! asset-id-prefixed path so two concurrent writes cannot collide, but
-//! callers should not assume every on-disk operation is ordered against
-//! every index update.
+//! rotation bookkeeping: reads, writes, touches, rotation, and index
+//! persistence all synchronize through the same critical section.
+//!
+//! **Several code paths also perform filesystem I/O while holding the
+//! lock**, including:
+//!
+//! - [`AssetManager::get`] — `is_file()` existence check on the target
+//!   file before returning the metadata
+//! - [`AssetManager::delete`] — `CacheManager::delete` on the target file
+//! - [`AssetManager::store`] — rotation may delete evicted files, and
+//!   `AssetIndex::save` writes `index.json` atomically (temp file + rename)
+//! - [`AssetManager::rotate_now`] — same rotation + persist path
+//!
+//! The only filesystem write that intentionally runs **before** the lock
+//! is acquired is the initial `CacheManager::store` inside
+//! [`AssetManager::store`], which writes the new blob through a unique
+//! per-asset path so two concurrent writes cannot collide.
+//!
+//! Because of the above, callers must not assume these methods are free
+//! from blocking filesystem work — if they are invoked from an async
+//! context, wrap them in `tokio::task::spawn_blocking` (or equivalent)
+//! so the executor's worker thread isn't stalled on disk I/O.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -158,7 +172,7 @@ impl AssetManager {
         });
 
         {
-            let mut index = self.state_lock();
+            let mut index = self.state_lock()?;
             index.upsert(asset.clone());
             self.inner.rotator.rotate(&mut index, &self.inner.cache)?;
             index.save(&self.inner.config.cache_dir)?;
@@ -175,7 +189,7 @@ impl AssetManager {
     /// state, so `asset.last_accessed_ms` is the timestamp just written
     /// to the index rather than the stale pre-touch value.
     pub fn get(&self, asset_id: &str) -> Result<Option<ResolvedAsset>> {
-        let mut index = self.state_lock();
+        let mut index = self.state_lock()?;
         // Resolve the path using a borrowed lookup first — no clone yet.
         let (abs_path, remove_stale) = match index.get(asset_id) {
             Some(asset) => {
@@ -225,7 +239,7 @@ impl AssetManager {
     /// Delete an asset from the cache (both the index entry and the file).
     /// Returns `true` if the asset was present.
     pub fn delete(&self, asset_id: &str) -> Result<bool> {
-        let mut index = self.state_lock();
+        let mut index = self.state_lock()?;
         let Some(asset) = index.remove(asset_id) else {
             return Ok(false);
         };
@@ -244,18 +258,25 @@ impl AssetManager {
     }
 
     /// List all assets currently tracked.
-    pub fn list(&self) -> Vec<CachedAsset> {
-        self.state_lock().assets.values().cloned().collect()
+    ///
+    /// Returns [`AssetError::Poisoned`] if the in-memory index mutex is
+    /// poisoned; callers that want a best-effort snapshot can
+    /// `.unwrap_or_default()` on the result.
+    pub fn list(&self) -> Result<Vec<CachedAsset>> {
+        Ok(self.state_lock()?.assets.values().cloned().collect())
     }
 
     /// Total tracked bytes in the cache.
-    pub fn total_size(&self) -> u64 {
-        self.state_lock().total_size()
+    ///
+    /// Returns [`AssetError::Poisoned`] if the in-memory index mutex is
+    /// poisoned.
+    pub fn total_size(&self) -> Result<u64> {
+        Ok(self.state_lock()?.total_size())
     }
 
     /// Force a rotation pass immediately.
     pub fn rotate_now(&self) -> Result<RotationStats> {
-        let mut index = self.state_lock();
+        let mut index = self.state_lock()?;
         let stats = self.inner.rotator.rotate(&mut index, &self.inner.cache)?;
         index.save(&self.inner.config.cache_dir)?;
         Ok(stats)
@@ -263,7 +284,7 @@ impl AssetManager {
 
     /// Re-check index vs filesystem. Returns the number of dropped entries.
     pub fn integrity_check(&self) -> Result<usize> {
-        let mut index = self.state_lock();
+        let mut index = self.state_lock()?;
         let removed = prune_stale_entries(&mut index, &self.inner.cache);
         if removed > 0 {
             index.save(&self.inner.config.cache_dir)?;
@@ -276,8 +297,16 @@ impl AssetManager {
         self.inner.config.cache_dir.join(INDEX_FILENAME)
     }
 
-    fn state_lock(&self) -> std::sync::MutexGuard<'_, AssetIndex> {
-        self.inner.state.lock().expect("asset index mutex poisoned")
+    /// Acquire the in-memory index lock.
+    ///
+    /// Returns [`AssetError::Poisoned`] if the mutex was poisoned by a
+    /// panic in another thread, giving callers a chance to recover or
+    /// propagate the error gracefully instead of crashing.
+    fn state_lock(&self) -> Result<std::sync::MutexGuard<'_, AssetIndex>> {
+        self.inner
+            .state
+            .lock()
+            .map_err(|e| AssetError::poisoned(e.to_string()))
     }
 }
 
@@ -392,7 +421,7 @@ mod tests {
             })
             .unwrap();
         assert_eq!(asset.size, 5);
-        assert_eq!(mgr.total_size(), 5);
+        assert_eq!(mgr.total_size().unwrap(), 5);
 
         let resolved = mgr.get("a1").unwrap().expect("asset present");
         assert_eq!(resolved.asset.id, "a1");
@@ -402,7 +431,7 @@ mod tests {
         assert!(mgr.delete("a1").unwrap());
         assert!(mgr.get("a1").unwrap().is_none());
         assert!(!mgr.delete("a1").unwrap(), "second delete is a no-op");
-        assert_eq!(mgr.total_size(), 0);
+        assert_eq!(mgr.total_size().unwrap(), 0);
     }
 
     #[test]
@@ -417,7 +446,7 @@ mod tests {
         }
 
         let mgr = manager(tmp.path().to_path_buf());
-        let list = mgr.list();
+        let list = mgr.list().unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].id, "a1");
         let resolved = mgr.get("a1").unwrap().unwrap();
@@ -439,7 +468,7 @@ mod tests {
 
         let removed = mgr.integrity_check().unwrap();
         assert_eq!(removed, 1);
-        assert!(mgr.list().is_empty());
+        assert!(mgr.list().unwrap().is_empty());
     }
 
     #[test]
@@ -454,7 +483,7 @@ mod tests {
         std::fs::remove_file(tmp.path().join(&asset.local_path)).unwrap();
 
         assert!(mgr.get("a1").unwrap().is_none());
-        assert!(mgr.list().is_empty());
+        assert!(mgr.list().unwrap().is_empty());
     }
 
     #[test]
@@ -477,8 +506,8 @@ mod tests {
         // so one of them should be evicted.
         mgr.store(store_simple(ctx, "b", "b.bin", &[0u8; 60]))
             .unwrap();
-        assert!(mgr.total_size() <= 100);
-        assert_eq!(mgr.list().len(), 1);
+        assert!(mgr.total_size().unwrap() <= 100);
+        assert_eq!(mgr.list().unwrap().len(), 1);
 
         // Explicit rotate_now is a no-op now that we are within budget.
         let stats = mgr.rotate_now().unwrap();
@@ -512,8 +541,8 @@ mod tests {
         let big = vec![0u8; 2_000_000];
         mgr.store(store_simple(ctx, "big", "big.bin", &big))
             .unwrap();
-        assert_eq!(mgr.total_size(), big.len() as u64);
-        assert_eq!(mgr.list().len(), 1);
+        assert_eq!(mgr.total_size().unwrap(), big.len() as u64);
+        assert_eq!(mgr.list().unwrap().len(), 1);
 
         // Explicit rotate_now is a no-op under the zero budget.
         let stats = mgr.rotate_now().unwrap();
@@ -541,8 +570,8 @@ mod tests {
         assert!(msg.contains("exceeds the cache"), "unexpected msg: {msg}");
 
         // Nothing should have been written or tracked.
-        assert!(mgr.list().is_empty());
-        assert_eq!(mgr.total_size(), 0);
+        assert!(mgr.list().unwrap().is_empty());
+        assert_eq!(mgr.total_size().unwrap(), 0);
     }
 
     #[test]
@@ -567,7 +596,12 @@ mod tests {
         );
 
         // And the index value matches what `get` returned.
-        let from_list = mgr.list().into_iter().find(|a| a.id == "a1").unwrap();
+        let from_list = mgr
+            .list()
+            .unwrap()
+            .into_iter()
+            .find(|a| a.id == "a1")
+            .unwrap();
         assert_eq!(from_list.last_accessed_ms, resolved.asset.last_accessed_ms);
     }
 
@@ -585,7 +619,7 @@ mod tests {
                 .unwrap();
             mgr.store(store_simple(ctx, "b", "b.bin", &[0u8; 60]))
                 .unwrap();
-            assert_eq!(mgr.total_size(), 120);
+            assert_eq!(mgr.total_size().unwrap(), 120);
         }
 
         // Re-open with a tight budget — startup rotation should trim the
@@ -597,8 +631,11 @@ mod tests {
             eviction_policy: EvictionPolicy::Lru,
         };
         let mgr = AssetManager::from_resolved(tight).unwrap();
-        assert!(mgr.total_size() <= 100, "cache still over budget on open");
-        assert_eq!(mgr.list().len(), 1);
+        assert!(
+            mgr.total_size().unwrap() <= 100,
+            "cache still over budget on open"
+        );
+        assert_eq!(mgr.list().unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -107,11 +107,25 @@ impl AssetManager {
         })
     }
 
-    /// Convenience constructor for tests and standalone usage.
+    /// Convenience constructor for tests, standalone usage, and minimal
+    /// environments (containers, CI) where `dirs::cache_dir()` may return
+    /// `None`.
+    ///
+    /// Unlike [`AssetManager::from_config`], this bypasses OS cache-dir
+    /// discovery entirely and uses sensible defaults for all other
+    /// settings (1 GiB budget, 7-day TTL, LRU eviction).
     pub fn with_root(root: PathBuf) -> Result<Self> {
-        let cfg = AssetConfig::default();
-        let mut resolved = cfg.resolve()?;
-        resolved.cache_dir = root;
+        use crate::config::{
+            DEFAULT_MAX_CACHE_SIZE, DEFAULT_MAX_FILE_AGE, EvictionPolicy, ResolvedAssetConfig,
+            parse_duration, parse_size,
+        };
+        let resolved = ResolvedAssetConfig {
+            cache_dir: root,
+            max_cache_size: parse_size(DEFAULT_MAX_CACHE_SIZE)
+                .expect("default cache size is valid"),
+            max_file_age: parse_duration(DEFAULT_MAX_FILE_AGE).expect("default file age is valid"),
+            eviction_policy: EvictionPolicy::Lru,
+        };
         Self::from_resolved(resolved)
     }
 
@@ -236,9 +250,18 @@ impl AssetManager {
         })();
 
         if let Err(e) = result {
-            // Roll back: remove the orphaned blob. Ignore any I/O error
-            // during cleanup — the primary error is more important.
-            let _ = self.inner.cache.delete(&stored.path);
+            // Roll back: remove the orphaned blob — but only when it's a
+            // truly new path. If the asset_id, context, and filename are
+            // the same as the previous entry, `CacheManager::store` wrote
+            // the replacement bytes to the *same* on-disk path. Deleting
+            // it would destroy the content that the restored snapshot
+            // still references.
+            let overwrote_same_path = deferred_delete
+                .as_ref()
+                .is_some_and(|old| *old == stored.path);
+            if !overwrote_same_path {
+                let _ = self.inner.cache.delete(&stored.path);
+            }
             return Err(e);
         }
 

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -45,13 +45,31 @@ impl AssetManager {
 
     /// Build a new manager from a validated [`ResolvedAssetConfig`].
     ///
-    /// Loads the on-disk index and runs an integrity check so that any
-    /// stale entries (referring to files that no longer exist) are dropped.
+    /// Startup flow:
+    ///
+    /// 1. Load the on-disk index (recovering an empty one if the file is
+    ///    missing or corrupt).
+    /// 2. **Integrity check** — drop entries whose file is gone or whose
+    ///    stored path resolves outside the cache root.
+    /// 3. **Rotate** — enforce `max_file_age` and `max_cache_size` on the
+    ///    loaded state so a cache that was closed over budget comes back
+    ///    up within limits before any new writes.
+    /// 4. Persist the resulting index.
     pub fn from_resolved(config: ResolvedAssetConfig) -> Result<Self> {
         let cache = CacheManager::new(config.cache_dir.clone())?;
         let rotator = Rotator::new(&config);
         let mut index = AssetIndex::load(&config.cache_dir)?;
-        let _removed = prune_stale_entries(&mut index, &cache);
+        let pruned = prune_stale_entries(&mut index, &cache);
+        let rotated = rotator.rotate(&mut index, &cache)?;
+        if pruned > 0 || rotated.removed() > 0 {
+            tracing::debug!(
+                pruned,
+                aged_out = rotated.aged_out,
+                lru_evicted = rotated.lru_evicted,
+                bytes_freed = rotated.bytes_freed,
+                "asset cache startup cleanup",
+            );
+        }
         index.save(&config.cache_dir)?;
 
         Ok(Self {
@@ -499,6 +517,36 @@ mod tests {
         // Nothing should have been written or tracked.
         assert!(mgr.list().is_empty());
         assert_eq!(mgr.total_size(), 0);
+    }
+
+    #[test]
+    fn from_resolved_rotates_on_startup() {
+        let tmp = tempdir().unwrap();
+
+        // Seed the cache with two entries under a generous budget.
+        {
+            let mgr = manager(tmp.path().to_path_buf());
+            let ctx = AssetContext::Issue {
+                key: "DEV-1".into(),
+            };
+            mgr.store(store_simple(ctx.clone(), "a", "a.bin", &[0u8; 60]))
+                .unwrap();
+            mgr.store(store_simple(ctx, "b", "b.bin", &[0u8; 60]))
+                .unwrap();
+            assert_eq!(mgr.total_size(), 120);
+        }
+
+        // Re-open with a tight budget — startup rotation should trim the
+        // cache back under the limit *before* we hand it to the caller.
+        let tight = ResolvedAssetConfig {
+            cache_dir: tmp.path().to_path_buf(),
+            max_cache_size: 100,
+            max_file_age: Duration::from_secs(100 * 86_400),
+            eviction_policy: EvictionPolicy::Lru,
+        };
+        let mgr = AssetManager::from_resolved(tight).unwrap();
+        assert!(mgr.total_size() <= 100, "cache still over budget on open");
+        assert_eq!(mgr.list().len(), 1);
     }
 
     #[test]

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -86,7 +86,7 @@ impl AssetManager {
             tracing::debug!(
                 pruned,
                 aged_out = rotated.aged_out,
-                lru_evicted = rotated.lru_evicted,
+                size_evicted = rotated.size_evicted,
                 bytes_freed = rotated.bytes_freed,
                 "asset cache startup cleanup",
             );
@@ -171,11 +171,23 @@ impl AssetManager {
             remote_url,
         });
 
-        {
+        // Index upsert + rotation + persist. If any of these steps fail
+        // the blob written above would remain on disk but not be tracked
+        // in `index.json`, causing unbounded growth. Best-effort delete
+        // on the error path keeps the cache transactional.
+        let result: Result<()> = (|| {
             let mut index = self.state_lock()?;
             index.upsert(asset.clone());
             self.inner.rotator.rotate(&mut index, &self.inner.cache)?;
             index.save(&self.inner.config.cache_dir)?;
+            Ok(())
+        })();
+
+        if let Err(e) = result {
+            // Roll back: remove the orphaned blob. Ignore any I/O error
+            // during cleanup — the primary error is more important.
+            let _ = self.inner.cache.delete(&stored.path);
+            return Err(e);
         }
 
         Ok(asset)

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, Mutex};
 
 use devboy_core::asset::AssetContext;
 
-use crate::cache::CacheManager;
+use crate::cache::{CacheManager, resolve_under_root};
 use crate::config::{AssetConfig, ResolvedAssetConfig};
 use crate::error::{AssetError, Result};
 use crate::index::{AssetIndex, CachedAsset, INDEX_FILENAME, NewCachedAsset};
@@ -90,6 +90,10 @@ impl AssetManager {
     /// [`AssetError::Config`] error *without* touching the filesystem —
     /// otherwise rotation would immediately evict the just-written file and
     /// we'd hand back an asset id that no longer resolves.
+    ///
+    /// A `max_cache_size` of `0` is treated as **unlimited**. Both this
+    /// method and [`Rotator::rotate`] share that convention so the two
+    /// cannot disagree about whether the budget is exhausted.
     pub fn store(&self, request: StoreRequest<'_>) -> Result<CachedAsset> {
         let StoreRequest {
             context,
@@ -146,7 +150,20 @@ impl AssetManager {
         let Some(asset) = index.get(asset_id).cloned() else {
             return Ok(None);
         };
-        let abs_path = self.inner.config.cache_dir.join(&asset.local_path);
+        // Validate the stored path stays under the cache root before
+        // touching the filesystem. A tampered index entry with an absolute
+        // or traversing path gets dropped and reported as `None`.
+        let Some(abs_path) = resolve_under_root(&self.inner.config.cache_dir, &asset.local_path)
+        else {
+            tracing::warn!(
+                asset_id,
+                path = ?asset.local_path,
+                "dropping index entry with unsafe local_path",
+            );
+            index.remove(asset_id);
+            index.save(&self.inner.config.cache_dir)?;
+            return Ok(None);
+        };
         if !abs_path.is_file() {
             // File vanished — drop the stale entry.
             index.remove(asset_id);
@@ -168,8 +185,16 @@ impl AssetManager {
         let Some(asset) = index.remove(asset_id) else {
             return Ok(false);
         };
-        let abs_path = self.inner.config.cache_dir.join(&asset.local_path);
-        self.inner.cache.delete(&abs_path)?;
+        if let Some(abs_path) = resolve_under_root(&self.inner.config.cache_dir, &asset.local_path)
+        {
+            self.inner.cache.delete(&abs_path)?;
+        } else {
+            tracing::warn!(
+                asset_id,
+                path = ?asset.local_path,
+                "skipping filesystem delete for unsafe local_path",
+            );
+        }
         index.save(&self.inner.config.cache_dir)?;
         Ok(true)
     }
@@ -239,21 +264,29 @@ pub struct StoreRequest<'a> {
     pub data: &'a [u8],
 }
 
-/// Drop index entries whose underlying file is missing. Returns the count
-/// of removed entries. Used by both `from_resolved` (startup check) and
+/// Drop index entries whose underlying file is missing (or whose stored
+/// path is unsafe). Returns the count of removed entries.
+///
+/// Used by both `from_resolved` (startup check) and
 /// [`AssetManager::integrity_check`].
 fn prune_stale_entries(index: &mut AssetIndex, cache: &CacheManager) -> usize {
     let stale: Vec<String> = index
         .assets
         .iter()
-        .filter_map(|(id, asset)| {
-            let abs = cache.root().join(&asset.local_path);
-            if cache.exists(&abs) {
-                None
-            } else {
-                Some(id.clone())
-            }
-        })
+        .filter_map(
+            |(id, asset)| match resolve_under_root(cache.root(), &asset.local_path) {
+                Some(abs) if cache.exists(&abs) => None,
+                Some(_) => Some(id.clone()),
+                None => {
+                    tracing::warn!(
+                        asset_id = id.as_str(),
+                        path = ?asset.local_path,
+                        "dropping index entry with unsafe local_path",
+                    );
+                    Some(id.clone())
+                }
+            },
+        )
         .collect();
     let count = stale.len();
     for id in stale {
@@ -414,6 +447,33 @@ mod tests {
         let mgr = manager(tmp.path().to_path_buf());
         assert_eq!(mgr.index_path(), tmp.path().join(INDEX_FILENAME));
         assert_eq!(mgr.cache_dir(), tmp.path());
+    }
+
+    #[test]
+    fn store_treats_zero_max_cache_size_as_unlimited() {
+        let tmp = tempdir().unwrap();
+        let cfg = ResolvedAssetConfig {
+            cache_dir: tmp.path().to_path_buf(),
+            max_cache_size: 0, // "unlimited"
+            max_file_age: Duration::from_secs(100 * 86_400),
+            eviction_policy: EvictionPolicy::Lru,
+        };
+        let mgr = AssetManager::from_resolved(cfg).unwrap();
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+
+        // Storing a multi-megabyte blob under a zero budget must succeed
+        // and stay in the cache (no rotation eviction).
+        let big = vec![0u8; 2_000_000];
+        mgr.store(store_simple(ctx, "big", "big.bin", &big))
+            .unwrap();
+        assert_eq!(mgr.total_size(), big.len() as u64);
+        assert_eq!(mgr.list().len(), 1);
+
+        // Explicit rotate_now is a no-op under the zero budget.
+        let stats = mgr.rotate_now().unwrap();
+        assert_eq!(stats.removed(), 0);
     }
 
     #[test]

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -175,17 +175,19 @@ impl AssetManager {
         // restore the in-memory index to its pre-mutation state *and*
         // remove the orphaned blob from disk so the cache stays
         // transactional and doesn't leak disk space.
+        let mut deferred_delete: Option<PathBuf> = None;
         let result: Result<()> = (|| {
             let mut index = self.state_lock()?;
 
             // When re-using an existing asset_id with a different path,
-            // delete the old blob so it doesn't become orphaned.
+            // record the old blob for deferred deletion *after* the commit
+            // succeeds. Deleting before the commit would leave the
+            // snapshot pointing at a missing file on rollback.
             if let Some(previous) = index.get(asset.id.as_str())
                 && previous.local_path != asset.local_path
-                && let Some(old_abs) =
-                    resolve_under_root(&self.inner.config.cache_dir, &previous.local_path)
             {
-                let _ = self.inner.cache.delete(&old_abs);
+                deferred_delete =
+                    resolve_under_root(&self.inner.config.cache_dir, &previous.local_path);
             }
 
             // Snapshot the index so we can restore on failure.
@@ -201,6 +203,7 @@ impl AssetManager {
                 // Restore the snapshot so list()/total_size() stay
                 // consistent with what's actually on disk.
                 *index = snapshot;
+                deferred_delete = None; // don't delete old blob on rollback
                 return Err(e);
             }
             Ok(())
@@ -211,6 +214,11 @@ impl AssetManager {
             // during cleanup — the primary error is more important.
             let _ = self.inner.cache.delete(&stored.path);
             return Err(e);
+        }
+
+        // Commit succeeded — now safe to clean up the replaced blob.
+        if let Some(old_path) = deferred_delete {
+            let _ = self.inner.cache.delete(&old_path);
         }
 
         Ok(asset)

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -140,12 +140,34 @@ impl AssetManager {
     pub fn store(&self, request: StoreRequest<'_>) -> Result<CachedAsset> {
         let StoreRequest {
             context,
-            asset_id,
+            asset_id: asset_id_opt,
             filename,
             mime_type,
             remote_url,
             data,
         } = request;
+
+        // Resolve the asset ID: caller-provided or content-addressed.
+        let asset_id_owned: String;
+        let asset_id: &str = match asset_id_opt {
+            Some(id) => {
+                let trimmed = id.trim();
+                if trimmed.is_empty() {
+                    return Err(AssetError::config("asset_id must not be empty"));
+                }
+                if trimmed.len() > MAX_ASSET_ID_LEN {
+                    return Err(AssetError::config(format!(
+                        "asset_id is {} chars, max allowed is {MAX_ASSET_ID_LEN}",
+                        trimmed.len(),
+                    )));
+                }
+                trimmed
+            }
+            None => {
+                asset_id_owned = Self::content_id(data);
+                &asset_id_owned
+            }
+        };
 
         let size = data.len() as u64;
         let max = self.inner.config.max_cache_size;
@@ -344,6 +366,24 @@ impl AssetManager {
         self.inner.config.cache_dir.join(INDEX_FILENAME)
     }
 
+    /// Compute a content-addressed asset ID from raw bytes.
+    ///
+    /// The returned string has the form `sha256:{16 hex chars}` (64-bit
+    /// prefix of the SHA-256 digest). This is the same ID that
+    /// [`AssetManager::store`] generates when `asset_id` is `None`.
+    ///
+    /// Use this to check whether a file is already cached before
+    /// downloading it:
+    ///
+    /// ```ignore
+    /// let id = AssetManager::content_id(data);
+    /// if manager.get(&id)?.is_some() { /* already cached */ }
+    /// ```
+    pub fn content_id(data: &[u8]) -> String {
+        let hash = crate::cache::sha256_hex(data);
+        format!("sha256:{}", &hash[..16])
+    }
+
     /// Acquire the in-memory index lock.
     ///
     /// Returns [`AssetError::Poisoned`] if the mutex was poisoned by a
@@ -372,8 +412,22 @@ pub struct ResolvedAsset {
 pub struct StoreRequest<'a> {
     /// Context the asset is attached to.
     pub context: AssetContext,
-    /// Stable id to use for the asset. Caller is responsible for uniqueness.
-    pub asset_id: &'a str,
+    /// Stable identifier for the asset.
+    ///
+    /// **Dual-mode:**
+    /// - `Some("att-42")` — caller-provided ID, typically the provider's
+    ///   native attachment identifier (ClickUp attachment id, Jira
+    ///   attachment id, GitLab upload URL, etc.). This enables cache-hit
+    ///   lookups when the same attachment is requested again.
+    /// - `None` — auto-generate a content-addressed ID from the SHA-256
+    ///   of `data`. The generated ID has the form `sha256:{16 hex chars}`
+    ///   and provides natural deduplication: storing the same bytes twice
+    ///   hits the same cache entry.
+    ///
+    /// Callers can also pre-compute a content ID via
+    /// [`AssetManager::content_id`] if they want to check for existence
+    /// before downloading.
+    pub asset_id: Option<&'a str>,
     /// Original filename.
     pub filename: &'a str,
     /// MIME type if known.
@@ -383,6 +437,11 @@ pub struct StoreRequest<'a> {
     /// Raw bytes to cache.
     pub data: &'a [u8],
 }
+
+/// Maximum allowed length for an asset ID (after sanitization the
+/// on-disk component will be shorter, but we reject clearly absurd
+/// inputs early).
+const MAX_ASSET_ID_LEN: usize = 200;
 
 /// Drop index entries whose underlying file is missing (or whose stored
 /// path is unsafe). Returns the count of removed entries.
@@ -441,7 +500,7 @@ mod tests {
     ) -> StoreRequest<'a> {
         StoreRequest {
             context,
-            asset_id,
+            asset_id: Some(asset_id),
             filename,
             mime_type: None,
             remote_url: None,
@@ -460,7 +519,7 @@ mod tests {
         let asset = mgr
             .store(StoreRequest {
                 context: ctx.clone(),
-                asset_id: "a1",
+                asset_id: Some("a1"),
                 filename: "file.txt",
                 mime_type: Some("text/plain".into()),
                 remote_url: None,
@@ -691,5 +750,136 @@ mod tests {
         let mgr = AssetManager::with_root(tmp.path().to_path_buf()).unwrap();
         assert_eq!(mgr.cache_dir(), tmp.path());
         assert!(mgr.config().max_cache_size > 0);
+    }
+
+    // =================================================================
+    // Dual-mode asset_id tests
+    // =================================================================
+
+    #[test]
+    fn store_auto_generates_content_addressed_id() {
+        let tmp = tempdir().unwrap();
+        let mgr = manager(tmp.path().to_path_buf());
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+
+        let asset = mgr
+            .store(StoreRequest {
+                context: ctx,
+                asset_id: None, // auto-generate
+                filename: "trace.log",
+                mime_type: None,
+                remote_url: None,
+                data: b"stack trace here",
+            })
+            .unwrap();
+
+        assert!(
+            asset.id.starts_with("sha256:"),
+            "auto-generated id should have sha256: prefix, got: {}",
+            asset.id,
+        );
+        assert_eq!(asset.id.len(), 7 + 16); // "sha256:" + 16 hex chars
+
+        // Same content → same id (dedup).
+        let expected = AssetManager::content_id(b"stack trace here");
+        assert_eq!(asset.id, expected);
+
+        // Retrievable by the generated id.
+        let resolved = mgr.get(&asset.id).unwrap().expect("should be cached");
+        assert_eq!(
+            std::fs::read(&resolved.absolute_path).unwrap(),
+            b"stack trace here",
+        );
+    }
+
+    #[test]
+    fn store_deduplicates_by_content_id() {
+        let tmp = tempdir().unwrap();
+        let mgr = manager(tmp.path().to_path_buf());
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+
+        let a = mgr
+            .store(StoreRequest {
+                context: ctx.clone(),
+                asset_id: None,
+                filename: "a.log",
+                mime_type: None,
+                remote_url: None,
+                data: b"same content",
+            })
+            .unwrap();
+
+        let b = mgr
+            .store(StoreRequest {
+                context: ctx,
+                asset_id: None,
+                filename: "b.log",
+                mime_type: None,
+                remote_url: None,
+                data: b"same content",
+            })
+            .unwrap();
+
+        // Same content → same id, single cache entry.
+        assert_eq!(a.id, b.id);
+        assert_eq!(mgr.list().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn store_rejects_empty_asset_id() {
+        let tmp = tempdir().unwrap();
+        let mgr = manager(tmp.path().to_path_buf());
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+
+        let err = mgr
+            .store(StoreRequest {
+                context: ctx,
+                asset_id: Some(""),
+                filename: "x.txt",
+                mime_type: None,
+                remote_url: None,
+                data: b"x",
+            })
+            .unwrap_err();
+        assert!(err.to_string().contains("empty"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn store_rejects_overly_long_asset_id() {
+        let tmp = tempdir().unwrap();
+        let mgr = manager(tmp.path().to_path_buf());
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+
+        let long_id = "x".repeat(MAX_ASSET_ID_LEN + 1);
+        let err = mgr
+            .store(StoreRequest {
+                context: ctx,
+                asset_id: Some(&long_id),
+                filename: "x.txt",
+                mime_type: None,
+                remote_url: None,
+                data: b"x",
+            })
+            .unwrap_err();
+        assert!(err.to_string().contains("200"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn content_id_is_deterministic() {
+        let a = AssetManager::content_id(b"hello");
+        let b = AssetManager::content_id(b"hello");
+        assert_eq!(a, b);
+        assert!(a.starts_with("sha256:"));
+
+        let c = AssetManager::content_id(b"world");
+        assert_ne!(a, c);
     }
 }

--- a/crates/devboy-assets/src/manager.rs
+++ b/crates/devboy-assets/src/manager.rs
@@ -171,15 +171,38 @@ impl AssetManager {
             remote_url,
         });
 
-        // Index upsert + rotation + persist. If any of these steps fail
-        // the blob written above would remain on disk but not be tracked
-        // in `index.json`, causing unbounded growth. Best-effort delete
-        // on the error path keeps the cache transactional.
+        // Index upsert + rotation + persist. If any step fails we must
+        // restore the in-memory index to its pre-mutation state *and*
+        // remove the orphaned blob from disk so the cache stays
+        // transactional and doesn't leak disk space.
         let result: Result<()> = (|| {
             let mut index = self.state_lock()?;
+
+            // When re-using an existing asset_id with a different path,
+            // delete the old blob so it doesn't become orphaned.
+            if let Some(previous) = index.get(asset.id.as_str())
+                && previous.local_path != asset.local_path
+                && let Some(old_abs) =
+                    resolve_under_root(&self.inner.config.cache_dir, &previous.local_path)
+            {
+                let _ = self.inner.cache.delete(&old_abs);
+            }
+
+            // Snapshot the index so we can restore on failure.
+            let snapshot = index.clone();
+
             index.upsert(asset.clone());
-            self.inner.rotator.rotate(&mut index, &self.inner.cache)?;
-            index.save(&self.inner.config.cache_dir)?;
+            if let Err(e) = self
+                .inner
+                .rotator
+                .rotate(&mut index, &self.inner.cache)
+                .and_then(|_| index.save(&self.inner.config.cache_dir))
+            {
+                // Restore the snapshot so list()/total_size() stay
+                // consistent with what's actually on disk.
+                *index = snapshot;
+                return Err(e);
+            }
             Ok(())
         })();
 

--- a/crates/devboy-assets/src/rotation.rs
+++ b/crates/devboy-assets/src/rotation.rs
@@ -70,7 +70,14 @@ impl Rotator {
         }
 
         // Phase 1 — age / TTL.
-        let cutoff_ms = now_ms().saturating_sub(self.max_file_age.as_millis() as u64);
+        //
+        // `Duration::as_millis()` returns `u128`, so very large values would
+        // silently truncate on the `as u64` cast. Clamp to `u64::MAX`
+        // explicitly — in practice that means "effectively infinite" and
+        // the saturating subtraction below yields a `cutoff_ms` of 0,
+        // disabling the TTL check.
+        let max_age_ms: u64 = self.max_file_age.as_millis().min(u128::from(u64::MAX)) as u64;
+        let cutoff_ms = now_ms().saturating_sub(max_age_ms);
         let expired: Vec<String> = index
             .assets
             .iter()
@@ -79,15 +86,14 @@ impl Rotator {
             .collect();
         for id in expired {
             if let Some(asset) = index.remove(&id) {
-                let abs = cache.root().join(&asset.local_path);
-                cache.delete(&abs)?;
+                remove_cached_file(cache, &asset, &mut stats.bytes_freed)?;
                 stats.aged_out += 1;
-                stats.bytes_freed += asset.size;
             }
         }
 
-        // Phase 2 — size budget.
-        if index.total_size() > self.max_cache_size {
+        // Phase 2 — size budget. A budget of 0 is treated as "unlimited",
+        // matching the semantics enforced in `AssetManager::store`.
+        if self.max_cache_size > 0 && index.total_size() > self.max_cache_size {
             let mut entries: Vec<CachedAsset> = index.assets.values().cloned().collect();
             self.sort_for_eviction(&mut entries);
 
@@ -96,10 +102,8 @@ impl Rotator {
                     break;
                 }
                 if let Some(removed) = index.remove(&asset.id) {
-                    let abs = cache.root().join(&removed.local_path);
-                    cache.delete(&abs)?;
+                    remove_cached_file(cache, &removed, &mut stats.bytes_freed)?;
                     stats.lru_evicted += 1;
-                    stats.bytes_freed += removed.size;
                 }
             }
         }
@@ -129,10 +133,39 @@ impl Rotator {
     /// Check whether the index is already within the configured budget.
     ///
     /// Provided as a cheap fast-path so callers can skip `rotate` when the
-    /// cache is empty / small.
+    /// cache is empty / small. A budget of 0 is treated as "unlimited".
     pub fn within_budget(&self, index: &AssetIndex, _root: &Path) -> bool {
-        index.total_size() <= self.max_cache_size
+        self.max_cache_size == 0 || index.total_size() <= self.max_cache_size
     }
+}
+
+/// Resolve and delete a cached file belonging to an index entry, bumping
+/// `bytes_freed` on success. Stale entries whose path has already been
+/// removed externally are ignored so rotation stays idempotent.
+///
+/// The resolution goes through [`crate::cache::resolve_under_root`], which
+/// validates that the target stays inside the cache directory — a safety
+/// guard against tampered `index.json` entries with absolute or traversing
+/// paths.
+fn remove_cached_file(
+    cache: &CacheManager,
+    asset: &CachedAsset,
+    bytes_freed: &mut u64,
+) -> Result<()> {
+    match crate::cache::resolve_under_root(cache.root(), &asset.local_path) {
+        Some(abs) => {
+            cache.delete(&abs)?;
+        }
+        None => {
+            tracing::warn!(
+                asset_id = asset.id.as_str(),
+                path = ?asset.local_path,
+                "skipping eviction — index entry points outside the cache root",
+            );
+        }
+    }
+    *bytes_freed += asset.size;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/devboy-assets/src/rotation.rs
+++ b/crates/devboy-assets/src/rotation.rs
@@ -28,8 +28,9 @@ use crate::index::{AssetIndex, CachedAsset, now_ms};
 pub struct RotationStats {
     /// Number of assets removed by age / TTL.
     pub aged_out: usize,
-    /// Number of assets removed by LRU size enforcement.
-    pub lru_evicted: usize,
+    /// Number of assets removed by cache-size enforcement (LRU or FIFO,
+    /// depending on the configured [`EvictionPolicy`]).
+    pub size_evicted: usize,
     /// Total bytes freed.
     pub bytes_freed: u64,
 }
@@ -37,7 +38,7 @@ pub struct RotationStats {
 impl RotationStats {
     /// Total number of assets removed.
     pub fn removed(&self) -> usize {
-        self.aged_out + self.lru_evicted
+        self.aged_out + self.size_evicted
     }
 }
 
@@ -112,7 +113,7 @@ impl Rotator {
                 if let Some(removed) = index.remove(&asset.id) {
                     current_size = current_size.saturating_sub(removed.size);
                     remove_cached_file(cache, &removed, &mut stats.bytes_freed)?;
-                    stats.lru_evicted += 1;
+                    stats.size_evicted += 1;
                 }
             }
         }
@@ -121,10 +122,17 @@ impl Rotator {
     }
 
     /// Sort entries so that the first element is the best eviction candidate.
+    ///
+    /// Rust's `slice::sort_by` is a **stable** sort, so assets with equal
+    /// keys retain their insertion order. Within the same `last_accessed_ms`
+    /// (or `downloaded_at_ms`) bucket, LRU uses a secondary tie-breaker on
+    /// descending `size` so that one large video is preferred over many
+    /// small text files. Millisecond-resolution ties are rare in practice
+    /// and the stable-sort guarantee ensures that the most recently
+    /// inserted asset is evicted last among equals.
     fn sort_for_eviction(&self, entries: &mut [CachedAsset]) {
         match self.policy {
             EvictionPolicy::Lru => {
-                // Oldest `last_accessed` first, then largest size first.
                 entries.sort_by(|a, b| {
                     a.last_accessed_ms
                         .cmp(&b.last_accessed_ms)
@@ -132,7 +140,6 @@ impl Rotator {
                 });
             }
             EvictionPolicy::Fifo => {
-                // Oldest `downloaded_at` first.
                 entries.sort_by(|a, b| a.downloaded_at_ms.cmp(&b.downloaded_at_ms));
             }
             EvictionPolicy::None => {}
@@ -268,7 +275,7 @@ mod tests {
 
         let stats = rotator.rotate(&mut index, &cache).unwrap();
         assert_eq!(stats.aged_out, 1);
-        assert_eq!(stats.lru_evicted, 0);
+        assert_eq!(stats.size_evicted, 0);
         assert!(index.get("old").is_none());
         assert!(index.get("fresh").is_some());
     }
@@ -302,7 +309,7 @@ mod tests {
 
         let stats = rotator.rotate(&mut index, &cache).unwrap();
         assert_eq!(stats.aged_out, 0);
-        assert_eq!(stats.lru_evicted, 2);
+        assert_eq!(stats.size_evicted, 2);
         assert!(index.get("a").is_none());
         assert!(index.get("b").is_none());
         assert!(index.get("c").is_some());

--- a/crates/devboy-assets/src/rotation.rs
+++ b/crates/devboy-assets/src/rotation.rs
@@ -122,13 +122,12 @@ impl Rotator {
 
     /// Sort entries so that the first element is the best eviction candidate.
     ///
-    /// Rust's `slice::sort_by` is a **stable** sort, so assets with equal
-    /// keys retain their insertion order. Within the same `last_accessed_ms`
-    /// (or `downloaded_at_ms`) bucket, LRU uses a secondary tie-breaker on
-    /// descending `size` so that one large video is preferred over many
-    /// small text files. Millisecond-resolution ties are rare in practice
-    /// and the stable-sort guarantee ensures that the most recently
-    /// inserted asset is evicted last among equals.
+    /// Sort entries so that the first element is the best eviction
+    /// candidate. A deterministic final tie-breaker on `asset.id` ensures
+    /// the order is fully reproducible even when timestamps and sizes are
+    /// equal (which can happen with rapid consecutive stores or in tests).
+    /// Without this, `HashMap::values()` iteration order would leak into
+    /// eviction decisions, making `store()` unreliable under tight budgets.
     fn sort_for_eviction(&self, entries: &mut [CachedAsset]) {
         match self.policy {
             EvictionPolicy::Lru => {
@@ -136,10 +135,15 @@ impl Rotator {
                     a.last_accessed_ms
                         .cmp(&b.last_accessed_ms)
                         .then_with(|| b.size.cmp(&a.size))
+                        .then_with(|| a.id.cmp(&b.id))
                 });
             }
             EvictionPolicy::Fifo => {
-                entries.sort_by(|a, b| a.downloaded_at_ms.cmp(&b.downloaded_at_ms));
+                entries.sort_by(|a, b| {
+                    a.downloaded_at_ms
+                        .cmp(&b.downloaded_at_ms)
+                        .then_with(|| a.id.cmp(&b.id))
+                });
             }
             EvictionPolicy::None => {}
         }

--- a/crates/devboy-assets/src/rotation.rs
+++ b/crates/devboy-assets/src/rotation.rs
@@ -14,7 +14,6 @@
 //!    is met. Within the same timestamp bucket, larger files go first so
 //!    one multi-GB video is preferred over many small logs.
 
-use std::path::Path;
 use std::time::Duration;
 
 use crate::cache::CacheManager;
@@ -148,9 +147,10 @@ impl Rotator {
 
     /// Check whether the index is already within the configured budget.
     ///
-    /// Provided as a cheap fast-path so callers can skip `rotate` when the
-    /// cache is empty / small. A budget of 0 is treated as "unlimited".
-    pub fn within_budget(&self, index: &AssetIndex, _root: &Path) -> bool {
+    /// This is an index-only check: it compares the total tracked size
+    /// against the configured limit without touching the filesystem. A
+    /// budget of 0 is treated as "unlimited".
+    pub fn within_budget(&self, index: &AssetIndex) -> bool {
         self.max_cache_size == 0 || index.total_size() <= self.max_cache_size
     }
 }
@@ -356,7 +356,7 @@ mod tests {
             Duration::from_secs(100 * 365 * 86_400),
         );
         let rotator = Rotator::new(&resolved);
-        assert!(rotator.within_budget(&index, tmp.path()));
+        assert!(rotator.within_budget(&index));
 
         index.upsert(CachedAsset::new(NewCachedAsset {
             id: "a".into(),
@@ -368,7 +368,7 @@ mod tests {
             checksum_sha256: "deadbeef".into(),
             remote_url: None,
         }));
-        assert!(rotator.within_budget(&index, tmp.path()));
+        assert!(rotator.within_budget(&index));
     }
 
     #[test]

--- a/crates/devboy-assets/src/rotation.rs
+++ b/crates/devboy-assets/src/rotation.rs
@@ -140,8 +140,10 @@ impl Rotator {
 }
 
 /// Resolve and delete a cached file belonging to an index entry, bumping
-/// `bytes_freed` on success. Stale entries whose path has already been
-/// removed externally are ignored so rotation stays idempotent.
+/// `bytes_freed` **only** when a file that actually existed was removed
+/// from disk. Stale entries whose file has already been removed externally,
+/// or whose stored path resolves outside the cache root, are dropped from
+/// the index but their size is not counted as "bytes freed".
 ///
 /// The resolution goes through [`crate::cache::resolve_under_root`], which
 /// validates that the target stays inside the cache directory — a safety
@@ -152,19 +154,23 @@ fn remove_cached_file(
     asset: &CachedAsset,
     bytes_freed: &mut u64,
 ) -> Result<()> {
-    match crate::cache::resolve_under_root(cache.root(), &asset.local_path) {
-        Some(abs) => {
-            cache.delete(&abs)?;
-        }
-        None => {
-            tracing::warn!(
-                asset_id = asset.id.as_str(),
-                path = ?asset.local_path,
-                "skipping eviction — index entry points outside the cache root",
-            );
-        }
+    let Some(abs) = crate::cache::resolve_under_root(cache.root(), &asset.local_path) else {
+        tracing::warn!(
+            asset_id = asset.id.as_str(),
+            path = ?asset.local_path,
+            "skipping eviction — index entry points outside the cache root",
+        );
+        return Ok(());
+    };
+
+    // Only count bytes we actually freed. `CacheManager::delete` is
+    // idempotent and treats `NotFound` as success, so we need to check
+    // upfront whether the file is really there.
+    let existed = cache.exists(&abs);
+    cache.delete(&abs)?;
+    if existed {
+        *bytes_freed += asset.size;
     }
-    *bytes_freed += asset.size;
     Ok(())
 }
 
@@ -374,5 +380,87 @@ mod tests {
         // The big one should be evicted first.
         assert!(index.get("big").is_none());
         assert!(index.get("small").is_some());
+    }
+
+    #[test]
+    fn bytes_freed_only_counts_existing_files() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let mut index = AssetIndex::empty();
+
+        // Real, on-disk asset — eviction should count its bytes.
+        let mut real = store_asset(&cache, "real", 100);
+        real.last_accessed_ms = 1_000;
+        index.upsert(real);
+
+        // Phantom asset — index entry exists but the file is gone. The
+        // rotator must still drop it from the index but must not count it
+        // as "freed" since there was nothing on disk to free.
+        let phantom = CachedAsset::new(NewCachedAsset {
+            id: "phantom".into(),
+            filename: "phantom.bin".into(),
+            mime_type: None,
+            size: 999,
+            local_path: PathBuf::from("issues/ghost/phantom.bin"),
+            context: AssetContext::Issue {
+                key: "ghost".into(),
+            },
+            checksum_sha256: "abcd".into(),
+            remote_url: None,
+        });
+        index.upsert(CachedAsset {
+            last_accessed_ms: 1_000,
+            ..phantom
+        });
+
+        // Budget tiny so both entries get considered; ages equal.
+        let resolved = cfg(
+            tmp.path().to_path_buf(),
+            50,
+            Duration::from_secs(100 * 365 * 86_400),
+        );
+        let rotator = Rotator::new(&resolved);
+        let stats = rotator.rotate(&mut index, &cache).unwrap();
+
+        // Both were dropped from the index…
+        assert!(index.get("real").is_none());
+        assert!(index.get("phantom").is_none());
+        // …but only the real file counted.
+        assert_eq!(stats.bytes_freed, 100);
+    }
+
+    #[test]
+    fn bytes_freed_skips_unsafe_paths() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let mut index = AssetIndex::empty();
+
+        // Tampered index entry pointing outside the cache root.
+        index.upsert(CachedAsset {
+            last_accessed_ms: 1_000,
+            ..CachedAsset::new(NewCachedAsset {
+                id: "hostile".into(),
+                filename: "passwd".into(),
+                mime_type: None,
+                size: 4096,
+                local_path: PathBuf::from("../../etc/passwd"),
+                context: AssetContext::Issue { key: "x".into() },
+                checksum_sha256: "dead".into(),
+                remote_url: None,
+            })
+        });
+
+        let resolved = cfg(
+            tmp.path().to_path_buf(),
+            1,
+            Duration::from_secs(100 * 365 * 86_400),
+        );
+        let rotator = Rotator::new(&resolved);
+        let stats = rotator.rotate(&mut index, &cache).unwrap();
+
+        // Entry dropped from the index but bytes_freed stays at 0 — we
+        // never touched the outside path.
+        assert!(index.get("hostile").is_none());
+        assert_eq!(stats.bytes_freed, 0);
     }
 }

--- a/crates/devboy-assets/src/rotation.rs
+++ b/crates/devboy-assets/src/rotation.rs
@@ -1,0 +1,345 @@
+//! LRU rotation / eviction policy for the asset cache.
+//!
+//! The rotator is stateless: every call evaluates the index and deletes
+//! whichever assets need to go based on the configured
+//! [`EvictionPolicy`] and size / age limits.
+//!
+//! Eviction priority for LRU:
+//!
+//! 1. Assets older than `max_file_age` (by `last_accessed`) are removed
+//!    unconditionally. This implements the TTL behaviour described in the
+//!    ADR.
+//! 2. If the remaining cache is still over `max_cache_size`, assets are
+//!    removed in LRU order (oldest `last_accessed` first) until the budget
+//!    is met. Within the same timestamp bucket, larger files go first so
+//!    one multi-GB video is preferred over many small logs.
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::cache::CacheManager;
+use crate::config::{EvictionPolicy, ResolvedAssetConfig};
+use crate::error::Result;
+use crate::index::{AssetIndex, CachedAsset, now_ms};
+
+/// Stats produced by a rotation pass — exposed so callers can log what
+/// happened and tests can assert on side-effects.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RotationStats {
+    /// Number of assets removed by age / TTL.
+    pub aged_out: usize,
+    /// Number of assets removed by LRU size enforcement.
+    pub lru_evicted: usize,
+    /// Total bytes freed.
+    pub bytes_freed: u64,
+}
+
+impl RotationStats {
+    /// Total number of assets removed.
+    pub fn removed(&self) -> usize {
+        self.aged_out + self.lru_evicted
+    }
+}
+
+/// Applies an [`EvictionPolicy`] to an [`AssetIndex`] + cache root.
+#[derive(Debug, Clone)]
+pub struct Rotator {
+    max_cache_size: u64,
+    max_file_age: Duration,
+    policy: EvictionPolicy,
+}
+
+impl Rotator {
+    /// Build a rotator from a resolved config.
+    pub fn new(config: &ResolvedAssetConfig) -> Self {
+        Self {
+            max_cache_size: config.max_cache_size,
+            max_file_age: config.max_file_age,
+            policy: config.eviction_policy,
+        }
+    }
+
+    /// Run a rotation pass in-place. Mutates the index and deletes files
+    /// from disk via the supplied [`CacheManager`].
+    ///
+    /// For [`EvictionPolicy::None`] this is a no-op.
+    pub fn rotate(&self, index: &mut AssetIndex, cache: &CacheManager) -> Result<RotationStats> {
+        let mut stats = RotationStats::default();
+        if matches!(self.policy, EvictionPolicy::None) {
+            return Ok(stats);
+        }
+
+        // Phase 1 — age / TTL.
+        let cutoff_ms = now_ms().saturating_sub(self.max_file_age.as_millis() as u64);
+        let expired: Vec<String> = index
+            .assets
+            .iter()
+            .filter(|(_, a)| a.last_accessed_ms < cutoff_ms)
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in expired {
+            if let Some(asset) = index.remove(&id) {
+                let abs = cache.root().join(&asset.local_path);
+                cache.delete(&abs)?;
+                stats.aged_out += 1;
+                stats.bytes_freed += asset.size;
+            }
+        }
+
+        // Phase 2 — size budget.
+        if index.total_size() > self.max_cache_size {
+            let mut entries: Vec<CachedAsset> = index.assets.values().cloned().collect();
+            self.sort_for_eviction(&mut entries);
+
+            for asset in entries {
+                if index.total_size() <= self.max_cache_size {
+                    break;
+                }
+                if let Some(removed) = index.remove(&asset.id) {
+                    let abs = cache.root().join(&removed.local_path);
+                    cache.delete(&abs)?;
+                    stats.lru_evicted += 1;
+                    stats.bytes_freed += removed.size;
+                }
+            }
+        }
+
+        Ok(stats)
+    }
+
+    /// Sort entries so that the first element is the best eviction candidate.
+    fn sort_for_eviction(&self, entries: &mut [CachedAsset]) {
+        match self.policy {
+            EvictionPolicy::Lru => {
+                // Oldest `last_accessed` first, then largest size first.
+                entries.sort_by(|a, b| {
+                    a.last_accessed_ms
+                        .cmp(&b.last_accessed_ms)
+                        .then_with(|| b.size.cmp(&a.size))
+                });
+            }
+            EvictionPolicy::Fifo => {
+                // Oldest `downloaded_at` first.
+                entries.sort_by(|a, b| a.downloaded_at_ms.cmp(&b.downloaded_at_ms));
+            }
+            EvictionPolicy::None => {}
+        }
+    }
+
+    /// Check whether the index is already within the configured budget.
+    ///
+    /// Provided as a cheap fast-path so callers can skip `rotate` when the
+    /// cache is empty / small.
+    pub fn within_budget(&self, index: &AssetIndex, _root: &Path) -> bool {
+        index.total_size() <= self.max_cache_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::CacheManager;
+    use crate::config::ResolvedAssetConfig;
+    use crate::index::{CachedAsset, NewCachedAsset};
+    use devboy_core::asset::AssetContext;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn cfg(cache_dir: PathBuf, max_size: u64, max_age: Duration) -> ResolvedAssetConfig {
+        ResolvedAssetConfig {
+            cache_dir,
+            max_cache_size: max_size,
+            max_file_age: max_age,
+            eviction_policy: EvictionPolicy::Lru,
+        }
+    }
+
+    fn store_asset(cache: &CacheManager, id: &str, size: u64) -> CachedAsset {
+        let ctx = AssetContext::Issue {
+            key: "DEV-1".into(),
+        };
+        let data = vec![0u8; size as usize];
+        let stored = cache
+            .store(&ctx, id, &format!("{id}.bin"), &data)
+            .expect("store");
+        let rel = stored
+            .path
+            .strip_prefix(cache.root())
+            .unwrap()
+            .to_path_buf();
+        CachedAsset::new(NewCachedAsset {
+            id: id.into(),
+            filename: format!("{id}.bin"),
+            mime_type: None,
+            size: stored.size,
+            local_path: rel,
+            context: ctx,
+            checksum_sha256: stored.checksum_sha256,
+            remote_url: None,
+        })
+    }
+
+    #[test]
+    fn policy_none_is_noop() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let mut index = AssetIndex::empty();
+
+        let asset = store_asset(&cache, "a1", 10);
+        index.upsert(asset);
+
+        let mut resolved = cfg(tmp.path().to_path_buf(), 0, Duration::from_secs(1));
+        resolved.eviction_policy = EvictionPolicy::None;
+        let rotator = Rotator::new(&resolved);
+
+        let stats = rotator.rotate(&mut index, &cache).unwrap();
+        assert_eq!(stats.removed(), 0);
+        assert_eq!(index.len(), 1);
+    }
+
+    #[test]
+    fn age_based_eviction() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let mut index = AssetIndex::empty();
+
+        // old asset — last accessed 10 minutes ago
+        let mut old = store_asset(&cache, "old", 5);
+        old.last_accessed_ms = now_ms() - 600_000;
+        index.upsert(old);
+
+        // fresh asset — just accessed
+        index.upsert(store_asset(&cache, "fresh", 5));
+
+        let resolved = cfg(
+            tmp.path().to_path_buf(),
+            1024 * 1024,
+            Duration::from_secs(60),
+        );
+        let rotator = Rotator::new(&resolved);
+
+        let stats = rotator.rotate(&mut index, &cache).unwrap();
+        assert_eq!(stats.aged_out, 1);
+        assert_eq!(stats.lru_evicted, 0);
+        assert!(index.get("old").is_none());
+        assert!(index.get("fresh").is_some());
+    }
+
+    #[test]
+    fn size_based_lru_eviction() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let mut index = AssetIndex::empty();
+
+        let mut a = store_asset(&cache, "a", 100);
+        a.last_accessed_ms = 1_000;
+        index.upsert(a);
+
+        let mut b = store_asset(&cache, "b", 100);
+        b.last_accessed_ms = 2_000;
+        index.upsert(b);
+
+        let mut c = store_asset(&cache, "c", 100);
+        c.last_accessed_ms = 3_000;
+        index.upsert(c);
+
+        // Budget = 150 bytes. We expect `a` and `b` to be evicted (oldest),
+        // leaving `c` (100 bytes) which fits.
+        let resolved = cfg(
+            tmp.path().to_path_buf(),
+            150,
+            Duration::from_secs(100 * 365 * 86_400),
+        );
+        let rotator = Rotator::new(&resolved);
+
+        let stats = rotator.rotate(&mut index, &cache).unwrap();
+        assert_eq!(stats.aged_out, 0);
+        assert_eq!(stats.lru_evicted, 2);
+        assert!(index.get("a").is_none());
+        assert!(index.get("b").is_none());
+        assert!(index.get("c").is_some());
+        assert!(index.total_size() <= 150);
+    }
+
+    #[test]
+    fn fifo_orders_by_download_time() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let mut index = AssetIndex::empty();
+
+        let mut a = store_asset(&cache, "a", 100);
+        a.downloaded_at_ms = 1_000;
+        a.last_accessed_ms = 9_000; // FIFO should ignore this
+        index.upsert(a);
+
+        let mut b = store_asset(&cache, "b", 100);
+        b.downloaded_at_ms = 2_000;
+        b.last_accessed_ms = 1_000;
+        index.upsert(b);
+
+        let mut resolved = cfg(
+            tmp.path().to_path_buf(),
+            150,
+            Duration::from_secs(100 * 365 * 86_400),
+        );
+        resolved.eviction_policy = EvictionPolicy::Fifo;
+        let rotator = Rotator::new(&resolved);
+
+        rotator.rotate(&mut index, &cache).unwrap();
+        // FIFO keeps `b` (newer download), evicts `a` (older download).
+        assert!(index.get("a").is_none());
+        assert!(index.get("b").is_some());
+    }
+
+    #[test]
+    fn within_budget_fast_path() {
+        let tmp = tempdir().unwrap();
+        let mut index = AssetIndex::empty();
+        let resolved = cfg(
+            tmp.path().to_path_buf(),
+            1_000,
+            Duration::from_secs(100 * 365 * 86_400),
+        );
+        let rotator = Rotator::new(&resolved);
+        assert!(rotator.within_budget(&index, tmp.path()));
+
+        index.upsert(CachedAsset::new(NewCachedAsset {
+            id: "a".into(),
+            filename: "a.bin".into(),
+            mime_type: None,
+            size: 500,
+            local_path: PathBuf::from("issues/x/a.bin"),
+            context: AssetContext::Issue { key: "x".into() },
+            checksum_sha256: "deadbeef".into(),
+            remote_url: None,
+        }));
+        assert!(rotator.within_budget(&index, tmp.path()));
+    }
+
+    #[test]
+    fn age_ties_prefer_larger_files() {
+        let tmp = tempdir().unwrap();
+        let cache = CacheManager::new(tmp.path().to_path_buf()).unwrap();
+        let mut index = AssetIndex::empty();
+
+        let mut small = store_asset(&cache, "small", 10);
+        small.last_accessed_ms = 1_000;
+        index.upsert(small);
+
+        let mut big = store_asset(&cache, "big", 1_000);
+        big.last_accessed_ms = 1_000;
+        index.upsert(big);
+
+        // Budget tiny so at least one has to go; ties → larger first.
+        let resolved = cfg(
+            tmp.path().to_path_buf(),
+            100,
+            Duration::from_secs(100 * 365 * 86_400),
+        );
+        let rotator = Rotator::new(&resolved);
+        rotator.rotate(&mut index, &cache).unwrap();
+        // The big one should be evicted first.
+        assert!(index.get("big").is_none());
+        assert!(index.get("small").is_some());
+    }
+}

--- a/crates/devboy-assets/src/rotation.rs
+++ b/crates/devboy-assets/src/rotation.rs
@@ -120,8 +120,6 @@ impl Rotator {
         Ok(stats)
     }
 
-    /// Sort entries so that the first element is the best eviction candidate.
-    ///
     /// Sort entries so that the first element is the best eviction
     /// candidate. A deterministic final tie-breaker on `asset.id` ensures
     /// the order is fully reproducible even when timestamps and sizes are

--- a/crates/devboy-assets/src/rotation.rs
+++ b/crates/devboy-assets/src/rotation.rs
@@ -93,15 +93,24 @@ impl Rotator {
 
         // Phase 2 — size budget. A budget of 0 is treated as "unlimited",
         // matching the semantics enforced in `AssetManager::store`.
-        if self.max_cache_size > 0 && index.total_size() > self.max_cache_size {
+        //
+        // We track a running `current_size` instead of recomputing
+        // `index.total_size()` on every iteration: the naive version is
+        // O(n²) because each call re-sums every remaining asset, and a
+        // large cache can pay that cost repeatedly during a single
+        // eviction pass. Subtracting removed sizes keeps the loop
+        // O(n log n) dominated by the sort.
+        let mut current_size = index.total_size();
+        if self.max_cache_size > 0 && current_size > self.max_cache_size {
             let mut entries: Vec<CachedAsset> = index.assets.values().cloned().collect();
             self.sort_for_eviction(&mut entries);
 
             for asset in entries {
-                if index.total_size() <= self.max_cache_size {
+                if current_size <= self.max_cache_size {
                     break;
                 }
                 if let Some(removed) = index.remove(&asset.id) {
+                    current_size = current_size.saturating_sub(removed.size);
                     remove_cached_file(cache, &removed, &mut stats.bytes_freed)?;
                     stats.lru_evicted += 1;
                 }

--- a/crates/devboy-core/src/asset.rs
+++ b/crates/devboy-core/src/asset.rs
@@ -157,13 +157,20 @@ pub struct AssetMeta {
 }
 
 /// Input data for uploading a new asset.
-#[derive(Debug, Clone)]
+///
+/// This type is part of the public `devboy_core::asset` API and is
+/// (de)serializable so it can cross crate and MCP tool boundaries. File
+/// bytes go through serde's default `Vec<u8>` encoding, which is a JSON
+/// array of numbers — MCP tools typically base64-encode the payload in a
+/// wrapper struct rather than serializing this type directly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssetInput {
     /// Filename to use on the provider side.
     pub filename: String,
     /// Raw file bytes.
     pub data: Vec<u8>,
     /// Optional MIME type hint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
 }
 
@@ -425,6 +432,179 @@ mod tests {
         assert_eq!(input.filename, "a.png");
         assert_eq!(input.data, vec![1, 2, 3]);
         assert_eq!(input.mime_type.as_deref(), Some("image/png"));
+    }
+
+    #[test]
+    fn asset_input_serde_roundtrip() {
+        let input = AssetInput::new("x.bin", vec![0, 1, 2]).with_mime_type("application/octet");
+        let json = serde_json::to_string(&input).unwrap();
+        let back: AssetInput = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.filename, "x.bin");
+        assert_eq!(back.data, vec![0, 1, 2]);
+        assert_eq!(back.mime_type.as_deref(), Some("application/octet"));
+
+        // mime_type omitted when None — the shape stays small on the wire.
+        let without_mime = AssetInput::new("y.txt", vec![]);
+        let json = serde_json::to_string(&without_mime).unwrap();
+        assert!(!json.contains("mime_type"), "unexpected field: {json}");
+    }
+
+    #[test]
+    fn asset_meta_serde_roundtrip() {
+        let mut meta = AssetMeta {
+            id: "a1".into(),
+            filename: "screen.png".into(),
+            mime_type: Some("image/png".into()),
+            size: Some(1234),
+            url: Some("https://x/y".into()),
+            created_at: Some("2026-04-11T00:00:00Z".into()),
+            author: Some("alice".into()),
+            cached: true,
+            local_path: Some("/tmp/cache/a1.png".into()),
+            checksum_sha256: Some("deadbeef".into()),
+            analysis: None,
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: AssetMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, back);
+
+        // With analysis attached.
+        meta.analysis = Some(AssetAnalysis {
+            summary: "1 error".into(),
+            content_kind: ContentKind::Text,
+            extractable_text: Some("ERROR line".into()),
+            key_findings: vec!["panic".into()],
+            metadata: HashMap::new(),
+            semantic: None,
+        });
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: AssetMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, back);
+    }
+
+    #[test]
+    fn asset_meta_skips_empty_optionals_when_serialized() {
+        let meta = AssetMeta {
+            id: "a1".into(),
+            filename: "x".into(),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        // `cached` defaults to false and we don't add skip_serializing_if
+        // for it, but optional fields should not appear.
+        assert!(!json.contains("mime_type"));
+        assert!(!json.contains("analysis"));
+        assert!(!json.contains("author"));
+    }
+
+    #[test]
+    fn asset_capabilities_serde_roundtrip() {
+        let caps = AssetCapabilities {
+            issue: ContextCapabilities::full(),
+            issue_comment: ContextCapabilities::read_only(),
+            merge_request: ContextCapabilities {
+                upload: true,
+                download: true,
+                delete: false,
+                list: true,
+                max_file_size: Some(10_485_760),
+                allowed_types: vec!["image/*".into()],
+            },
+            mr_comment: ContextCapabilities::default(),
+        };
+        let json = serde_json::to_string(&caps).unwrap();
+        let back: AssetCapabilities = serde_json::from_str(&json).unwrap();
+        assert_eq!(caps, back);
+    }
+
+    #[test]
+    fn asset_analysis_with_semantic_serde_roundtrip() {
+        let mut metadata = HashMap::new();
+        metadata.insert("line_count".into(), serde_json::json!(5432));
+        let analysis = AssetAnalysis {
+            summary: "error log with 12 ERRORs".into(),
+            content_kind: ContentKind::Text,
+            extractable_text: Some("ERROR at line 147".into()),
+            key_findings: vec!["12 ERROR lines".into(), "race condition suspected".into()],
+            metadata,
+            semantic: Some(SemanticAnalysis {
+                summary: "Redis connection drops under load.".into(),
+                findings: vec!["timeout after 30s".into()],
+                prompt_used: "find db errors".into(),
+                model: "claude-sonnet-4".into(),
+                cached: false,
+            }),
+        };
+        let json = serde_json::to_string(&analysis).unwrap();
+        let back: AssetAnalysis = serde_json::from_str(&json).unwrap();
+        assert_eq!(analysis, back);
+    }
+
+    #[test]
+    fn content_kind_serde() {
+        for kind in [
+            ContentKind::Text,
+            ContentKind::Image,
+            ContentKind::Video,
+            ContentKind::Document,
+            ContentKind::Data,
+            ContentKind::Binary,
+        ] {
+            let json = serde_json::to_string(&kind).unwrap();
+            let back: ContentKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(kind, back);
+        }
+    }
+
+    #[test]
+    fn asset_context_kind_serde() {
+        for kind in [
+            AssetContextKind::Issue,
+            AssetContextKind::IssueComment,
+            AssetContextKind::MergeRequest,
+            AssetContextKind::MrComment,
+            AssetContextKind::Chat,
+            AssetContextKind::KbPage,
+        ] {
+            let json = serde_json::to_string(&kind).unwrap();
+            let back: AssetContextKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(kind, back);
+        }
+    }
+
+    #[test]
+    fn asset_context_all_variants_roundtrip() {
+        let variants = vec![
+            AssetContext::Issue {
+                key: "DEV-1".into(),
+            },
+            AssetContext::IssueComment {
+                key: "DEV-1".into(),
+                comment_id: "c1".into(),
+            },
+            AssetContext::MergeRequest { id: "42".into() },
+            AssetContext::MrComment {
+                mr_id: "42".into(),
+                note_id: "n1".into(),
+            },
+            AssetContext::Chat {
+                chat_id: "C1".into(),
+                message_id: "m1".into(),
+            },
+            AssetContext::KbPage {
+                page_id: "p1".into(),
+            },
+        ];
+        for ctx in variants {
+            let json = serde_json::to_string(&ctx).unwrap();
+            let back: AssetContext = serde_json::from_str(&json).unwrap();
+            assert_eq!(ctx, back);
+
+            // Also exercise `kind()` / `slug()` for every variant so the
+            // match arms stay covered.
+            assert!(!ctx.slug().is_empty());
+            let _ = ctx.kind();
+        }
     }
 
     #[test]

--- a/crates/devboy-core/src/asset.rs
+++ b/crates/devboy-core/src/asset.rs
@@ -35,8 +35,10 @@ pub enum AssetContext {
     },
     /// Attachment on a merge request / pull request body.
     MergeRequest {
-        /// MR / PR identifier.
-        id: String,
+        /// MR / PR identifier. Named `mr_id` for consistency with
+        /// [`AssetContext::MrComment`] so JSON-wire field names are the
+        /// same across both variants.
+        mr_id: String,
     },
     /// Attachment on a comment/note of a merge request.
     MrComment {
@@ -72,7 +74,7 @@ impl AssetContext {
             AssetContext::IssueComment { key, comment_id } => {
                 format!("issue:{key}:comment:{comment_id}")
             }
-            AssetContext::MergeRequest { id } => format!("mr:{id}"),
+            AssetContext::MergeRequest { mr_id } => format!("mr:{mr_id}"),
             AssetContext::MrComment { mr_id, note_id } => format!("mr:{mr_id}:note:{note_id}"),
             AssetContext::Chat {
                 chat_id,
@@ -363,7 +365,7 @@ mod tests {
         };
         assert_eq!(issue.slug(), "issue:DEV-123");
 
-        let mr = AssetContext::MergeRequest { id: "42".into() };
+        let mr = AssetContext::MergeRequest { mr_id: "42".into() };
         assert_eq!(mr.slug(), "mr:42");
 
         let mr_note = AssetContext::MrComment {
@@ -397,7 +399,7 @@ mod tests {
             AssetContextKind::Issue,
         );
         assert_eq!(
-            AssetContext::MergeRequest { id: "1".into() }.kind(),
+            AssetContext::MergeRequest { mr_id: "1".into() }.kind(),
             AssetContextKind::MergeRequest,
         );
     }
@@ -582,7 +584,7 @@ mod tests {
                 key: "DEV-1".into(),
                 comment_id: "c1".into(),
             },
-            AssetContext::MergeRequest { id: "42".into() },
+            AssetContext::MergeRequest { mr_id: "42".into() },
             AssetContext::MrComment {
                 mr_id: "42".into(),
                 note_id: "n1".into(),

--- a/crates/devboy-core/src/asset.rs
+++ b/crates/devboy-core/src/asset.rs
@@ -1,0 +1,445 @@
+//! Asset management types for file attachments and content analysis.
+//!
+//! These types are shared across the provider layer and the `devboy-assets`
+//! crate, providing a unified abstraction for working with attached files
+//! (screenshots, logs, configs, etc.) across different providers.
+//!
+//! See ADR-010 for the full design rationale.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// =============================================================================
+// AssetContext
+// =============================================================================
+
+/// Context to which an asset is attached.
+///
+/// Different providers support attachments in different contexts — an issue
+/// body, an issue comment, a merge request, etc. This enum captures all the
+/// supported targets in a provider-agnostic way.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AssetContext {
+    /// Attachment on an issue body/description.
+    Issue {
+        /// Issue key (e.g. "DEV-123", "gitlab#42").
+        key: String,
+    },
+    /// Attachment on a comment under an issue.
+    IssueComment {
+        /// Issue key.
+        key: String,
+        /// Comment identifier within the issue.
+        comment_id: String,
+    },
+    /// Attachment on a merge request / pull request body.
+    MergeRequest {
+        /// MR / PR identifier.
+        id: String,
+    },
+    /// Attachment on a comment/note of a merge request.
+    MrComment {
+        /// MR / PR identifier.
+        mr_id: String,
+        /// Note / comment identifier.
+        note_id: String,
+    },
+    /// Attachment from a messenger chat (Slack, Telegram, etc.).
+    Chat {
+        /// Chat identifier.
+        chat_id: String,
+        /// Message identifier.
+        message_id: String,
+    },
+    /// Attachment from a knowledge base page (Confluence, etc.).
+    KbPage {
+        /// Page identifier.
+        page_id: String,
+    },
+}
+
+impl AssetContext {
+    /// Short string form used for cache directory layout and logging.
+    ///
+    /// Examples:
+    /// - `issue:DEV-123`
+    /// - `mr:42`
+    /// - `chat:C0123ABC:msg42`
+    pub fn slug(&self) -> String {
+        match self {
+            AssetContext::Issue { key } => format!("issue:{key}"),
+            AssetContext::IssueComment { key, comment_id } => {
+                format!("issue:{key}:comment:{comment_id}")
+            }
+            AssetContext::MergeRequest { id } => format!("mr:{id}"),
+            AssetContext::MrComment { mr_id, note_id } => format!("mr:{mr_id}:note:{note_id}"),
+            AssetContext::Chat {
+                chat_id,
+                message_id,
+            } => format!("chat:{chat_id}:msg:{message_id}"),
+            AssetContext::KbPage { page_id } => format!("kb:{page_id}"),
+        }
+    }
+
+    /// Kind of the context (category used in enrichment and capabilities).
+    pub fn kind(&self) -> AssetContextKind {
+        match self {
+            AssetContext::Issue { .. } => AssetContextKind::Issue,
+            AssetContext::IssueComment { .. } => AssetContextKind::IssueComment,
+            AssetContext::MergeRequest { .. } => AssetContextKind::MergeRequest,
+            AssetContext::MrComment { .. } => AssetContextKind::MrComment,
+            AssetContext::Chat { .. } => AssetContextKind::Chat,
+            AssetContext::KbPage { .. } => AssetContextKind::KbPage,
+        }
+    }
+}
+
+/// Category of an [`AssetContext`] — used for capability lookup.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum AssetContextKind {
+    /// Issue body / description.
+    Issue,
+    /// Comment on an issue.
+    IssueComment,
+    /// Merge request / pull request body.
+    MergeRequest,
+    /// Comment / note on a merge request.
+    MrComment,
+    /// Messenger chat message.
+    Chat,
+    /// Knowledge base page.
+    KbPage,
+}
+
+// =============================================================================
+// AssetMeta / AssetInput
+// =============================================================================
+
+/// Metadata describing an asset — used for listings and enriched responses.
+///
+/// This type intentionally does NOT contain the file bytes; use
+/// [`AssetInput`] for uploads or a dedicated download method to fetch content.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AssetMeta {
+    /// Stable identifier for the asset within devboy (UUID or provider id).
+    pub id: String,
+    /// Original filename.
+    pub filename: String,
+    /// MIME type (best-effort; may be `None` for unknown binaries).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    /// File size in bytes if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    /// Remote URL at the provider (if available).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Creation timestamp (ISO 8601).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    /// Username / display name of the uploader if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    /// Whether the file is currently present in the local cache.
+    #[serde(default)]
+    pub cached: bool,
+    /// Absolute local path if the file is cached locally.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_path: Option<String>,
+    /// SHA-256 checksum of the content if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checksum_sha256: Option<String>,
+    /// Result of analysis (Levels 1-2 built-in or Level 3 semantic).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub analysis: Option<AssetAnalysis>,
+}
+
+/// Input data for uploading a new asset.
+#[derive(Debug, Clone)]
+pub struct AssetInput {
+    /// Filename to use on the provider side.
+    pub filename: String,
+    /// Raw file bytes.
+    pub data: Vec<u8>,
+    /// Optional MIME type hint.
+    pub mime_type: Option<String>,
+}
+
+impl AssetInput {
+    /// Create a new input descriptor.
+    pub fn new(filename: impl Into<String>, data: Vec<u8>) -> Self {
+        Self {
+            filename: filename.into(),
+            data,
+            mime_type: None,
+        }
+    }
+
+    /// Attach a MIME type hint to the input.
+    pub fn with_mime_type(mut self, mime_type: impl Into<String>) -> Self {
+        self.mime_type = Some(mime_type.into());
+        self
+    }
+}
+
+// =============================================================================
+// Capabilities
+// =============================================================================
+
+/// Per-provider capability matrix for asset operations.
+///
+/// Each provider declares which CRUD operations it supports for each
+/// context kind. The values are used by the enricher to generate
+/// `asset_capabilities` entries in tool schemas so that agents can see in
+/// advance what operations are available.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AssetCapabilities {
+    /// Capabilities for issue bodies.
+    #[serde(default)]
+    pub issue: ContextCapabilities,
+    /// Capabilities for issue comments.
+    #[serde(default)]
+    pub issue_comment: ContextCapabilities,
+    /// Capabilities for merge request bodies.
+    #[serde(default)]
+    pub merge_request: ContextCapabilities,
+    /// Capabilities for merge request notes/comments.
+    #[serde(default)]
+    pub mr_comment: ContextCapabilities,
+}
+
+impl AssetCapabilities {
+    /// Return the capabilities for a given context kind.
+    ///
+    /// Chat / KB contexts are out of scope for the initial provider set —
+    /// they return a shared empty capability set.
+    pub fn for_kind(&self, kind: AssetContextKind) -> &ContextCapabilities {
+        match kind {
+            AssetContextKind::Issue => &self.issue,
+            AssetContextKind::IssueComment => &self.issue_comment,
+            AssetContextKind::MergeRequest => &self.merge_request,
+            AssetContextKind::MrComment => &self.mr_comment,
+            AssetContextKind::Chat | AssetContextKind::KbPage => empty_context_capabilities(),
+        }
+    }
+}
+
+/// Shared sentinel used for unsupported context kinds.
+fn empty_context_capabilities() -> &'static ContextCapabilities {
+    static EMPTY: std::sync::OnceLock<ContextCapabilities> = std::sync::OnceLock::new();
+    EMPTY.get_or_init(ContextCapabilities::default)
+}
+
+/// CRUD capabilities for a single context kind.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ContextCapabilities {
+    /// Whether uploading new attachments is supported.
+    #[serde(default)]
+    pub upload: bool,
+    /// Whether downloading attachments is supported.
+    #[serde(default)]
+    pub download: bool,
+    /// Whether deleting attachments is supported.
+    #[serde(default)]
+    pub delete: bool,
+    /// Whether listing attachments is supported.
+    #[serde(default)]
+    pub list: bool,
+    /// Max file size in bytes, if the provider advertises a limit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_file_size: Option<u64>,
+    /// Allowed MIME type patterns (e.g. `image/*`). Empty means any.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_types: Vec<String>,
+}
+
+impl ContextCapabilities {
+    /// Convenience: all operations enabled with no type restrictions.
+    pub fn full() -> Self {
+        Self {
+            upload: true,
+            download: true,
+            delete: true,
+            list: true,
+            max_file_size: None,
+            allowed_types: Vec::new(),
+        }
+    }
+
+    /// Convenience: read-only (download + list).
+    pub fn read_only() -> Self {
+        Self {
+            upload: false,
+            download: true,
+            delete: false,
+            list: true,
+            max_file_size: None,
+            allowed_types: Vec::new(),
+        }
+    }
+}
+
+// =============================================================================
+// AssetAnalysis
+// =============================================================================
+
+/// Result of analyzing an asset through the processor pipeline.
+///
+/// Produced by Levels 1-2 (built-in processors, no LLM) and optionally
+/// enriched by Level 3 (semantic LLM analysis).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AssetAnalysis {
+    /// Short human-readable summary for the agent (1-3 sentences).
+    pub summary: String,
+    /// Category of the content.
+    pub content_kind: ContentKind,
+    /// Text extracted from the file if applicable (logs, configs).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extractable_text: Option<String>,
+    /// Key findings produced by built-in heuristics.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub key_findings: Vec<String>,
+    /// Additional metadata (dimensions, duration, line counts, ...).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, serde_json::Value>,
+    /// Level 3 semantic analysis result, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic: Option<SemanticAnalysis>,
+}
+
+/// Result of a Level 3 semantic (LLM-based) analysis.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SemanticAnalysis {
+    /// Summary produced by the LLM.
+    pub summary: String,
+    /// Key findings identified by the LLM.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub findings: Vec<String>,
+    /// Prompt used for the analysis (for caching and debugging).
+    pub prompt_used: String,
+    /// Model identifier used (e.g. "claude-sonnet-4").
+    pub model: String,
+    /// Whether this result was served from cache.
+    #[serde(default)]
+    pub cached: bool,
+}
+
+/// High-level kind of content stored in an asset.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ContentKind {
+    /// Text-based content (logs, plain text, source code).
+    Text,
+    /// Raster or vector image.
+    Image,
+    /// Video file.
+    Video,
+    /// Document file (PDF, DOCX, ...).
+    Document,
+    /// Structured data (CSV, XLSX, JSON, YAML).
+    Data,
+    /// Binary content of an unknown kind.
+    #[default]
+    Binary,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_context_slug_formats() {
+        let issue = AssetContext::Issue {
+            key: "DEV-123".into(),
+        };
+        assert_eq!(issue.slug(), "issue:DEV-123");
+
+        let mr = AssetContext::MergeRequest { id: "42".into() };
+        assert_eq!(mr.slug(), "mr:42");
+
+        let mr_note = AssetContext::MrComment {
+            mr_id: "42".into(),
+            note_id: "7".into(),
+        };
+        assert_eq!(mr_note.slug(), "mr:42:note:7");
+
+        let issue_comment = AssetContext::IssueComment {
+            key: "DEV-1".into(),
+            comment_id: "99".into(),
+        };
+        assert_eq!(issue_comment.slug(), "issue:DEV-1:comment:99");
+
+        let chat = AssetContext::Chat {
+            chat_id: "C0123".into(),
+            message_id: "m5".into(),
+        };
+        assert_eq!(chat.slug(), "chat:C0123:msg:m5");
+
+        let kb = AssetContext::KbPage {
+            page_id: "p7".into(),
+        };
+        assert_eq!(kb.slug(), "kb:p7");
+    }
+
+    #[test]
+    fn asset_context_kind_maps_correctly() {
+        assert_eq!(
+            AssetContext::Issue { key: "x".into() }.kind(),
+            AssetContextKind::Issue,
+        );
+        assert_eq!(
+            AssetContext::MergeRequest { id: "1".into() }.kind(),
+            AssetContextKind::MergeRequest,
+        );
+    }
+
+    #[test]
+    fn capabilities_full_and_read_only() {
+        let full = ContextCapabilities::full();
+        assert!(full.upload && full.download && full.delete && full.list);
+
+        let ro = ContextCapabilities::read_only();
+        assert!(!ro.upload && ro.download && !ro.delete && ro.list);
+    }
+
+    #[test]
+    fn asset_capabilities_for_kind() {
+        let caps = AssetCapabilities {
+            issue: ContextCapabilities::full(),
+            merge_request: ContextCapabilities::read_only(),
+            ..Default::default()
+        };
+
+        assert!(caps.for_kind(AssetContextKind::Issue).upload);
+        assert!(!caps.for_kind(AssetContextKind::MergeRequest).upload);
+        assert!(caps.for_kind(AssetContextKind::MergeRequest).download);
+        // Out-of-scope kinds fall back to empty caps.
+        assert!(!caps.for_kind(AssetContextKind::Chat).download);
+    }
+
+    #[test]
+    fn asset_input_builder() {
+        let input = AssetInput::new("a.png", vec![1, 2, 3]).with_mime_type("image/png");
+        assert_eq!(input.filename, "a.png");
+        assert_eq!(input.data, vec![1, 2, 3]);
+        assert_eq!(input.mime_type.as_deref(), Some("image/png"));
+    }
+
+    #[test]
+    fn asset_context_serde_roundtrip() {
+        let ctx = AssetContext::IssueComment {
+            key: "DEV-5".into(),
+            comment_id: "42".into(),
+        };
+        let json = serde_json::to_string(&ctx).unwrap();
+        let back: AssetContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(ctx, back);
+    }
+
+    #[test]
+    fn content_kind_default_is_binary() {
+        assert_eq!(ContentKind::default(), ContentKind::Binary);
+    }
+}

--- a/crates/devboy-core/src/asset.rs
+++ b/crates/devboy-core/src/asset.rs
@@ -62,7 +62,11 @@ pub enum AssetContext {
 }
 
 impl AssetContext {
-    /// Short string form used for cache directory layout and logging.
+    /// Short colon-separated string for logging and debugging.
+    ///
+    /// **Note:** The cache directory layout is handled by
+    /// `devboy_assets::CacheManager::dir_for` / `path_for` — this method
+    /// is intentionally *not* used for on-disk paths.
     ///
     /// Examples:
     /// - `issue:DEV-123`

--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -22,6 +22,7 @@
 //! }
 //! ```
 
+pub mod asset;
 pub mod config;
 pub mod enricher;
 pub mod error;
@@ -50,6 +51,12 @@ pub use types::{
 // Re-export enricher traits and utilities
 pub use enricher::{PropertySchema, ToolEnricher, ToolSchema, sanitize_field_name};
 pub use tool_category::ToolCategory;
+
+// Re-export asset management types
+pub use asset::{
+    AssetAnalysis, AssetCapabilities, AssetContext, AssetContextKind, AssetInput, AssetMeta,
+    ContentKind, ContextCapabilities, SemanticAnalysis,
+};
 
 // Re-export config types
 pub use config::{


### PR DESCRIPTION
## Summary

Phase 1 of the Asset Management feature (epic #120). Adds the foundational infrastructure that later phases (provider CRUD, MCP tools, processor pipeline, semantic analysis) will build on.

Closes #121.

## What's included

### Shared types in \`devboy-core::asset\`

- \`AssetContext\` — tagged enum for every place an asset can live (issue, issue comment, MR, MR note, chat, KB page).
- \`AssetMeta\` / \`AssetInput\` — listing metadata and upload input.
- \`AssetCapabilities\` + \`ContextCapabilities\` — per-context CRUD flags, used by providers to declare what they support (so agents can adapt before making unsupported calls).
- \`AssetAnalysis\` + \`SemanticAnalysis\` + \`ContentKind\` — result types for the three-level processor pipeline introduced in Phase 4 / Phase 5.

### New crate: \`devboy-assets\`

| Module | Responsibility |
|--------|----------------|
| \`config\` | \`[assets]\` TOML section, human-readable size (\`1Gi\`) and duration (\`7d\`) parsers, sensible defaults |
| \`index\` | \`index.json\` with atomic writes (temp file + rename) and version-gated recovery on corruption / schema mismatch |
| \`cache\` | Deterministic per-context directory layout, filename sanitization, SHA-256 checksums |
| \`rotation\` | TTL eviction + LRU size budget with FIFO / None alternatives; within a timestamp tie, larger files go first |
| \`manager\` | Top-level \`AssetManager\` combining everything; startup integrity check + rotate-on-every-store |
| \`error\` | \`AssetError\` wrapping \`devboy_core::Error\` with IO / JSON / config variants |

### Design highlights

- **Everything is ephemeral.** If the cache is lost, files can always be re-downloaded from the provider, so we don't bother with durable storage. This keeps the scope tight and lets the consumer (OSS CLI or the cloud API) layer persistence on top if it wants to.
- **Rotate on every store.** The rotator is cheap and stateless; running it after each write keeps the cache trivially within budget without a background task.
- **Split between core and assets.** Provider crates only depend on \`devboy-core::asset\` and never pull in cache code, so they stay fast to compile and easy to test.
- **Builder-style \`StoreRequest\` / \`NewCachedAsset\`.** Keeps constructors under the clippy \`too_many_arguments\` threshold and gives us room to add fields without breaking callers.

## Tests

\`cargo test -p devboy-assets -p devboy-core\` — 48 unit tests, all green. Highlights:

- Round-trip and atomic-save stress tests for the index.
- Store/load/delete roundtrips with checksum verification.
- LRU + FIFO + age-based rotation with size ties preferring larger files.
- Integrity check drops missing files and persists the cleanup.
- Manager re-open persistence across process boundaries (simulated via two \`AssetManager::from_resolved\` calls on the same dir).

## Coverage

\`cargo llvm-cov --package devboy-assets --package devboy-core --summary-only\`

| Module | Line coverage |
|--------|---------------|
| devboy-assets/src/cache.rs | 90.23% |
| devboy-assets/src/config.rs | 97.03% |
| devboy-assets/src/error.rs | 100.00% |
| devboy-assets/src/index.rs | 97.16% |
| devboy-assets/src/manager.rs | 97.66% |
| devboy-assets/src/rotation.rs | 98.58% |
| devboy-core/src/asset.rs | 95.42% |
| **Total (workspace)** | **92.89%** |

All new modules are above the project's 90% target.

## Lints

- \`cargo fmt --all -- --check\` — clean
- \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- Workspace-wide \`cargo build\` — clean

## Not in this PR

These are covered by later Phase issues and intentionally excluded to keep the diff focused:

- Provider trait extensions (\`delete_attachment\`, \`get_issue_attachments\`, \`asset_capabilities\`) — see #122
- \`upload_asset\` / \`get_assets\` / \`download_asset\` / \`delete_asset\` / \`replace_asset\` MCP tools + enrichment — see #123
- Level 1-2 built-in processors (text, config, image meta, CSV, PDF) — see #124
- Level 3 semantic analysis via configurable LLM endpoint — see #125

## Related

- Epic: #120
- Subtask: #121
- ADRs: \`ADR-010-asset-management.md\` and \`ADR-011-asset-management-cloud-integration.md\` in meteora/devboy-cloud-monorepo