### PR TITLE
feat(providers): Phase 2 — asset CRUD for ClickUp, Jira, GitLab, GitHub (#122)

### DIFF
--- a/crates/devboy-assets/src/cache.rs
+++ b/crates/devboy-assets/src/cache.rs
@@ -30,6 +30,16 @@ pub const DIR_CHATS: &str = "chats";
 /// Directory name used for knowledge base attachments.
 pub const DIR_KB: &str = "kb";
 
+/// Maximum length for the sanitized asset ID component in a cache
+/// filename. Together with the 8-char hash and `MAX_NAME_LEN`, the
+/// total leaf stays well under the 255-byte filesystem limit.
+const MAX_ID_LEN: usize = 80;
+
+/// Maximum length for the sanitized filename component.
+const MAX_NAME_LEN: usize = 120;
+
+// Layout: {safe_id}-{8_hash}-{safe_name} + 2 dashes = MAX_ID_LEN + 8 + MAX_NAME_LEN + 2 = 210 < 255
+
 /// Manages the physical cache directory layout and file I/O.
 #[derive(Debug, Clone)]
 pub struct CacheManager {
@@ -69,8 +79,8 @@ impl CacheManager {
     /// context). We intentionally keep the hash short to stay well within
     /// the 255-char filename limit on ext4 / NTFS / APFS.
     pub fn path_for(&self, context: &AssetContext, asset_id: &str, filename: &str) -> PathBuf {
-        let safe_id = sanitize_component(asset_id);
-        let safe_name = sanitize_filename(filename);
+        let safe_id = truncate_component(&sanitize_component(asset_id), MAX_ID_LEN);
+        let safe_name = truncate_component(&sanitize_filename(filename), MAX_NAME_LEN);
         // Append a short hash of the *raw* (pre-sanitization) asset_id so
         // that two IDs differing only in characters collapsed by
         // sanitization (e.g. `a/b` → `a_b` vs `a?b` → `a_b`) never map
@@ -308,6 +318,19 @@ fn sanitize_component(value: &str) -> String {
 /// Same rules as [`sanitize_component`] but named for clarity at call sites.
 fn sanitize_key(key: &str) -> String {
     sanitize_component(key)
+}
+
+/// Truncate a string to at most `max_len` bytes on a char boundary.
+fn truncate_component(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        return s.to_string();
+    }
+    // Find a char boundary at or before max_len.
+    let mut end = max_len;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
 }
 
 #[cfg(test)]

--- a/crates/devboy-core/src/asset.rs
+++ b/crates/devboy-core/src/asset.rs
@@ -373,10 +373,11 @@ pub enum ContentKind {
 /// attachments directly into issue / MR bodies and comments rather than
 /// exposing a dedicated attachments API.
 ///
-/// Only URLs that look like downloadable attachments are returned — bare
-/// links to HTML pages (e.g. `https://example.com/`) are kept, but the
-/// caller can filter further if desired. The extracted `filename` is
-/// derived from the markdown alt text / link text when available and
+/// **No filtering is applied** — every `[text](url)` and `![alt](url)`
+/// reference is returned, including plain web links. Callers that only
+/// want downloadable files should filter by scheme, host, or file
+/// extension as appropriate for their provider. The extracted `filename`
+/// is derived from the markdown alt text / link text when available and
 /// falls back to the final path segment of the URL.
 pub fn parse_markdown_attachments(markdown: &str) -> Vec<MarkdownAttachment> {
     let mut out: Vec<MarkdownAttachment> = Vec::new();

--- a/crates/devboy-core/src/asset.rs
+++ b/crates/devboy-core/src/asset.rs
@@ -422,9 +422,15 @@ pub fn parse_markdown_attachments(markdown: &str) -> Vec<MarkdownAttachment> {
             .trim();
         // Strip optional title: `[foo](url "title")`
         let url = match url_raw.split_once(char::is_whitespace) {
-            Some((head, _tail)) => head.trim().to_string(),
-            None => url_raw.to_string(),
+            Some((head, _tail)) => head.trim(),
+            None => url_raw,
         };
+        // Handle angle-bracket wrapped URLs: `[text](<url>)`
+        let url = url
+            .strip_prefix('<')
+            .and_then(|s| s.strip_suffix('>'))
+            .unwrap_or(url)
+            .to_string();
 
         if !url.is_empty() && seen.insert(url.clone()) {
             let filename = if !text.is_empty() && !looks_like_url(&text) {
@@ -843,5 +849,20 @@ mod tests {
     fn markdown_empty_and_plain_text() {
         assert!(parse_markdown_attachments("").is_empty());
         assert!(parse_markdown_attachments("no links here at all").is_empty());
+    }
+
+    #[test]
+    fn markdown_strips_angle_bracket_urls() {
+        let md = "[spec](<https://example.com/spec.pdf>)";
+        let attachments = parse_markdown_attachments(md);
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0].url, "https://example.com/spec.pdf");
+        assert_eq!(attachments[0].filename, "spec");
+
+        // Image variant
+        let md = "![shot](<https://cdn.example.com/img.png>)";
+        let attachments = parse_markdown_attachments(md);
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0].url, "https://cdn.example.com/img.png");
     }
 }

--- a/crates/devboy-core/src/asset.rs
+++ b/crates/devboy-core/src/asset.rs
@@ -358,6 +358,158 @@ pub enum ContentKind {
     Binary,
 }
 
+// =============================================================================
+// Markdown parsing helpers
+// =============================================================================
+
+/// Extract attachments embedded in a markdown string.
+///
+/// Recognizes both image syntax (`![alt](url)`) and link syntax
+/// (`[text](url)`). The result is deduplicated by URL and returned in the
+/// order the references appear in the source. Inputs without any markdown
+/// links produce an empty vector.
+///
+/// This helper is used by providers like GitLab and GitHub that embed
+/// attachments directly into issue / MR bodies and comments rather than
+/// exposing a dedicated attachments API.
+///
+/// Only URLs that look like downloadable attachments are returned — bare
+/// links to HTML pages (e.g. `https://example.com/`) are kept, but the
+/// caller can filter further if desired. The extracted `filename` is
+/// derived from the markdown alt text / link text when available and
+/// falls back to the final path segment of the URL.
+pub fn parse_markdown_attachments(markdown: &str) -> Vec<MarkdownAttachment> {
+    let mut out: Vec<MarkdownAttachment> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    let bytes = markdown.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        // Look for `[` (link) or `![` (image).
+        let is_image = i + 1 < bytes.len() && bytes[i] == b'!' && bytes[i + 1] == b'[';
+        let is_link = bytes[i] == b'[';
+        if !is_image && !is_link {
+            i += 1;
+            continue;
+        }
+
+        let text_start = if is_image { i + 2 } else { i + 1 };
+        let Some(text_end_rel) = find_matching(&bytes[text_start..], b'[', b']') else {
+            i += 1;
+            continue;
+        };
+        let text_end = text_start + text_end_rel;
+
+        // Must be immediately followed by `(`.
+        if text_end + 1 >= bytes.len() || bytes[text_end + 1] != b'(' {
+            i = text_end + 1;
+            continue;
+        }
+        let url_start = text_end + 2;
+        let Some(url_end_rel) = find_matching(&bytes[url_start..], b'(', b')') else {
+            i = text_end + 1;
+            continue;
+        };
+        let url_end = url_start + url_end_rel;
+
+        let text = std::str::from_utf8(&bytes[text_start..text_end])
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let url_raw = std::str::from_utf8(&bytes[url_start..url_end])
+            .unwrap_or("")
+            .trim();
+        // Strip optional title: `[foo](url "title")`
+        let url = match url_raw.split_once(char::is_whitespace) {
+            Some((head, _tail)) => head.trim().to_string(),
+            None => url_raw.to_string(),
+        };
+
+        if !url.is_empty() && seen.insert(url.clone()) {
+            let filename = if !text.is_empty() && !looks_like_url(&text) {
+                text
+            } else {
+                filename_from_url(&url)
+            };
+            out.push(MarkdownAttachment {
+                filename,
+                url,
+                is_image,
+            });
+        }
+
+        i = url_end + 1;
+    }
+
+    out
+}
+
+/// A single attachment reference found in a markdown document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownAttachment {
+    /// Best-effort filename (from alt text or URL path).
+    pub filename: String,
+    /// Absolute or relative URL as written in the markdown.
+    pub url: String,
+    /// `true` if the reference was an image (`![]()`), `false` for a link.
+    pub is_image: bool,
+}
+
+/// Find the index of the matching `close` byte for an open character, with
+/// simple bracket/parenthesis nesting support. Returns `None` if unmatched.
+fn find_matching(bytes: &[u8], open: u8, close: u8) -> Option<usize> {
+    let mut depth: usize = 1;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
+        if c == open {
+            depth += 1;
+        } else if c == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Cheap heuristic — is a string "a URL" (we use this to decide whether the
+/// link text is informative enough to be used as a filename).
+fn looks_like_url(s: &str) -> bool {
+    s.starts_with("http://") || s.starts_with("https://") || s.starts_with("www.")
+}
+
+/// Derive a filename from the final path segment of a URL. Query strings
+/// and fragments are stripped. Returns `"attachment"` if nothing sensible
+/// can be extracted (e.g. the URL has no path beyond the host).
+pub fn filename_from_url(url: &str) -> String {
+    let no_query = url.split_once('?').map(|(p, _)| p).unwrap_or(url);
+    let no_frag = no_query.split_once('#').map(|(p, _)| p).unwrap_or(no_query);
+
+    // Strip scheme + host so that `https://x/` does not incorrectly surface
+    // the host `x` as a filename. We only look at the path portion.
+    let path = match no_frag.split_once("://") {
+        Some((_scheme, rest)) => rest.split_once('/').map(|(_host, p)| p).unwrap_or(""),
+        None => no_frag,
+    };
+
+    let last = path
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .unwrap_or("");
+    if last.is_empty() {
+        "attachment".to_string()
+    } else {
+        last.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -627,5 +779,68 @@ mod tests {
     #[test]
     fn content_kind_default_is_binary() {
         assert_eq!(ContentKind::default(), ContentKind::Binary);
+    }
+
+    #[test]
+    fn filename_from_url_strips_query_and_fragment() {
+        assert_eq!(
+            filename_from_url("https://x/y/z/report.log?token=abc#top"),
+            "report.log"
+        );
+        assert_eq!(filename_from_url("https://x/"), "attachment");
+        assert_eq!(filename_from_url(""), "attachment");
+    }
+
+    #[test]
+    fn markdown_parses_image_and_link_syntax() {
+        let md = "Hello ![screenshot](https://cdn.example.com/a/b/screen.png) and \
+                  a [log](https://cdn.example.com/run-42.log).";
+        let attachments = parse_markdown_attachments(md);
+        assert_eq!(attachments.len(), 2);
+        assert_eq!(attachments[0].filename, "screenshot");
+        assert_eq!(attachments[0].url, "https://cdn.example.com/a/b/screen.png");
+        assert!(attachments[0].is_image);
+        assert_eq!(attachments[1].filename, "log");
+        assert!(!attachments[1].is_image);
+    }
+
+    #[test]
+    fn markdown_deduplicates_by_url() {
+        let md = "![a](https://x/1.png) and again ![b](https://x/1.png)";
+        let attachments = parse_markdown_attachments(md);
+        assert_eq!(attachments.len(), 1);
+        // The first reference wins.
+        assert_eq!(attachments[0].filename, "a");
+    }
+
+    #[test]
+    fn markdown_handles_titles_and_spaces() {
+        let md = "[spec](https://x/spec.pdf \"Specification\")";
+        let attachments = parse_markdown_attachments(md);
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0].url, "https://x/spec.pdf");
+        assert_eq!(attachments[0].filename, "spec");
+    }
+
+    #[test]
+    fn markdown_ignores_unmatched_brackets() {
+        let md = "Unclosed [foo( and then a good ![g](https://x/g.png)";
+        let attachments = parse_markdown_attachments(md);
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0].url, "https://x/g.png");
+    }
+
+    #[test]
+    fn markdown_falls_back_to_url_when_text_is_url() {
+        let md = "[https://x/a.png](https://x/a.png)";
+        let attachments = parse_markdown_attachments(md);
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0].filename, "a.png");
+    }
+
+    #[test]
+    fn markdown_empty_and_plain_text() {
+        assert!(parse_markdown_attachments("").is_empty());
+        assert!(parse_markdown_attachments("no links here at all").is_empty());
     }
 }

--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -55,7 +55,8 @@ pub use tool_category::ToolCategory;
 // Re-export asset management types
 pub use asset::{
     AssetAnalysis, AssetCapabilities, AssetContext, AssetContextKind, AssetInput, AssetMeta,
-    ContentKind, ContextCapabilities, SemanticAnalysis,
+    ContentKind, ContextCapabilities, MarkdownAttachment, SemanticAnalysis, filename_from_url,
+    parse_markdown_attachments,
 };
 
 // Re-export config types

--- a/crates/devboy-core/src/provider.rs
+++ b/crates/devboy-core/src/provider.rs
@@ -5,6 +5,7 @@
 
 use async_trait::async_trait;
 
+use crate::asset::{AssetCapabilities, AssetMeta};
 use crate::error::{Error, Result};
 use crate::types::{
     Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, Discussion, FileDiff,
@@ -93,6 +94,51 @@ pub trait IssueProvider: Send + Sync {
         })
     }
 
+    /// List attachments currently attached to an issue (body + comments).
+    ///
+    /// Returns provider-agnostic [`AssetMeta`] values. Default returns
+    /// ProviderUnsupported; providers that can parse or fetch their own
+    /// attachment listings override this.
+    async fn get_issue_attachments(&self, _issue_key: &str) -> Result<Vec<AssetMeta>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "get_issue_attachments".to_string(),
+        })
+    }
+
+    /// Download the raw bytes of an attachment belonging to an issue.
+    ///
+    /// `asset_id` is the provider-specific identifier returned from
+    /// [`IssueProvider::get_issue_attachments`] (ClickUp attachment id,
+    /// Jira attachment id, GitLab upload URL, etc.).
+    async fn download_attachment(&self, _issue_key: &str, _asset_id: &str) -> Result<Vec<u8>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "download_attachment".to_string(),
+        })
+    }
+
+    /// Delete an attachment from an issue.
+    ///
+    /// Not all providers expose a delete endpoint for attachments (ClickUp
+    /// doesn't, GitLab file uploads are immutable) — the default returns
+    /// `ProviderUnsupported` and callers can consult [`asset_capabilities`]
+    /// beforehand.
+    async fn delete_attachment(&self, _issue_key: &str, _asset_id: &str) -> Result<()> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "delete_attachment".to_string(),
+        })
+    }
+
+    /// Describe which asset operations this provider supports for each
+    /// context. Used by the enricher to surface per-provider capabilities
+    /// in tool schemas so agents can adapt their behaviour before making
+    /// calls that would fail with `ProviderUnsupported`.
+    fn asset_capabilities(&self) -> AssetCapabilities {
+        AssetCapabilities::default()
+    }
+
     /// Set custom fields on an issue. Each entry: {"id": "field_id", "value": <value>}.
     /// Default is no-op — override in providers that support custom fields (e.g., ClickUp).
     async fn set_custom_fields(
@@ -178,6 +224,30 @@ pub trait MergeRequestProvider: Send + Sync {
         Err(Error::ProviderUnsupported {
             provider: self.provider_name().to_string(),
             operation: "get_releases".to_string(),
+        })
+    }
+
+    /// List attachments on a merge request (body + discussions).
+    async fn get_mr_attachments(&self, _mr_key: &str) -> Result<Vec<AssetMeta>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "get_mr_attachments".to_string(),
+        })
+    }
+
+    /// Download an attachment from a merge request.
+    async fn download_mr_attachment(&self, _mr_key: &str, _asset_id: &str) -> Result<Vec<u8>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "download_mr_attachment".to_string(),
+        })
+    }
+
+    /// Delete an attachment from a merge request.
+    async fn delete_mr_attachment(&self, _mr_key: &str, _asset_id: &str) -> Result<()> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "delete_mr_attachment".to_string(),
         })
     }
 }

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -2,17 +2,18 @@
 
 use async_trait::async_trait;
 use devboy_core::{
-    Comment, CreateIssueInput, Error, Issue, IssueFilter, IssueLink, IssueProvider, IssueRelations,
-    IssueStatus, MergeRequestProvider, PipelineProvider, Provider, ProviderResult, Result,
-    SortInfo, SortOrder, UpdateIssueInput, User,
+    AssetCapabilities, AssetMeta, Comment, ContextCapabilities, CreateIssueInput, Error, Issue,
+    IssueFilter, IssueLink, IssueProvider, IssueRelations, IssueStatus, MergeRequestProvider,
+    PipelineProvider, Provider, ProviderResult, Result, SortInfo, SortOrder, UpdateIssueInput,
+    User,
 };
 use tracing::{debug, warn};
 
 use crate::DEFAULT_CLICKUP_URL;
 use crate::types::{
-    ClickUpComment, ClickUpCommentList, ClickUpLinkedTask, ClickUpListInfo, ClickUpPriority,
-    ClickUpTask, ClickUpTaskList, ClickUpUser, CreateCommentRequest, CreateCommentResponse,
-    CreateTaskRequest, UpdateTaskRequest,
+    ClickUpAttachment, ClickUpComment, ClickUpCommentList, ClickUpLinkedTask, ClickUpListInfo,
+    ClickUpPriority, ClickUpTask, ClickUpTaskList, ClickUpUser, CreateCommentRequest,
+    CreateCommentResponse, CreateTaskRequest, UpdateTaskRequest,
 };
 
 /// Maximum number of tasks per page in ClickUp API.
@@ -481,6 +482,43 @@ fn map_comment(cu_comment: &ClickUpComment) -> Comment {
         created_at: map_timestamp(&cu_comment.date),
         updated_at: None,
         position: None,
+    }
+}
+
+/// Map a ClickUp attachment payload to the provider-agnostic [`AssetMeta`].
+fn map_clickup_attachment(raw: &ClickUpAttachment) -> AssetMeta {
+    let filename = raw
+        .title
+        .clone()
+        .or_else(|| {
+            raw.url
+                .as_deref()
+                .map(devboy_core::asset::filename_from_url)
+        })
+        .unwrap_or_else(|| format!("attachment-{}", raw.id));
+
+    let size = match raw.size.as_ref() {
+        Some(serde_json::Value::Number(n)) => n.as_u64(),
+        Some(serde_json::Value::String(s)) => s.parse::<u64>().ok(),
+        _ => None,
+    };
+
+    let created_at = raw.date.as_deref().and_then(epoch_ms_to_iso8601);
+
+    let author = raw.user.as_ref().map(|u| u.username.clone());
+
+    AssetMeta {
+        id: raw.id.clone(),
+        filename,
+        mime_type: raw.mimetype.clone(),
+        size,
+        url: raw.url.clone(),
+        created_at,
+        author,
+        cached: false,
+        local_path: None,
+        checksum_sha256: None,
+        analysis: None,
     }
 }
 
@@ -1126,6 +1164,76 @@ impl IssueProvider for ClickUpClient {
         Ok(download_url)
     }
 
+    async fn get_issue_attachments(&self, issue_key: &str) -> Result<Vec<AssetMeta>> {
+        let url = self.task_url(issue_key)?;
+        let task: ClickUpTask = self.get(&url).await?;
+        Ok(task
+            .attachments
+            .iter()
+            .map(map_clickup_attachment)
+            .collect())
+    }
+
+    async fn download_attachment(&self, issue_key: &str, asset_id: &str) -> Result<Vec<u8>> {
+        // ClickUp does not expose an "attachment by id" endpoint: the
+        // download URL lives on the task payload. Fetch the task, look up
+        // the attachment, and download from its URL using our authenticated
+        // client.
+        let url = self.task_url(issue_key)?;
+        let task: ClickUpTask = self.get(&url).await?;
+        let attachment = task
+            .attachments
+            .iter()
+            .find(|a| a.id == asset_id)
+            .ok_or_else(|| {
+                Error::NotFound(format!(
+                    "attachment '{asset_id}' not found on task {issue_key}",
+                ))
+            })?;
+        let download_url = attachment.url.as_deref().ok_or_else(|| {
+            Error::InvalidData(format!(
+                "attachment '{asset_id}' on task {issue_key} has no URL",
+            ))
+        })?;
+
+        let response = self
+            .client
+            .get(download_url)
+            .header("Authorization", &self.token)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
+        Ok(bytes.to_vec())
+    }
+
+    fn asset_capabilities(&self) -> AssetCapabilities {
+        // ClickUp supports upload / download / list on issue (task) bodies.
+        // There is no public delete attachment endpoint, so `delete` stays
+        // false for every context.
+        AssetCapabilities {
+            issue: ContextCapabilities {
+                upload: true,
+                download: true,
+                delete: false,
+                list: true,
+                max_file_size: None,
+                allowed_types: Vec::new(),
+            },
+            ..Default::default()
+        }
+    }
+
     async fn get_statuses(&self) -> Result<ProviderResult<IssueStatus>> {
         let url = format!("{}/list/{}", self.base_url, self.list_id);
         let list_info: ClickUpListInfo = self.get(&url).await?;
@@ -1421,6 +1529,7 @@ mod tests {
             subtasks: None,
             dependencies: None,
             linked_tasks: None,
+            attachments: Vec::new(),
         };
 
         let issue = map_task(&task);
@@ -1467,6 +1576,7 @@ mod tests {
             subtasks: None,
             dependencies: None,
             linked_tasks: None,
+            attachments: Vec::new(),
         };
 
         let issue = map_task(&task);
@@ -1496,6 +1606,7 @@ mod tests {
             subtasks: None,
             dependencies: None,
             linked_tasks: None,
+            attachments: Vec::new(),
         };
 
         let issue = map_task(&task);
@@ -1571,6 +1682,91 @@ mod tests {
         let user = map_user_required(None);
         assert_eq!(user.id, "unknown");
         assert_eq!(user.username, "unknown");
+    }
+
+    #[test]
+    fn test_map_clickup_attachment_all_fields() {
+        let raw = ClickUpAttachment {
+            id: "att-1".into(),
+            title: Some("report.log".into()),
+            url: Some("https://attachments.clickup.com/abc/report.log".into()),
+            size: Some(serde_json::json!("2048")),
+            extension: Some("log".into()),
+            mimetype: Some("text/plain".into()),
+            date: Some("1704067200000".into()),
+            user: Some(ClickUpUser {
+                id: 7,
+                username: "uploader".into(),
+                email: None,
+                profile_picture: None,
+            }),
+        };
+        let meta = map_clickup_attachment(&raw);
+        assert_eq!(meta.id, "att-1");
+        assert_eq!(meta.filename, "report.log");
+        assert_eq!(meta.mime_type.as_deref(), Some("text/plain"));
+        assert_eq!(meta.size, Some(2048));
+        assert_eq!(
+            meta.url.as_deref(),
+            Some("https://attachments.clickup.com/abc/report.log")
+        );
+        assert_eq!(meta.author.as_deref(), Some("uploader"));
+        assert_eq!(meta.created_at, Some("2024-01-01T00:00:00Z".to_string()));
+        assert!(!meta.cached);
+    }
+
+    #[test]
+    fn test_map_clickup_attachment_minimal_falls_back_to_url() {
+        let raw = ClickUpAttachment {
+            id: "att-2".into(),
+            title: None,
+            url: Some("https://cdn/a/b/screen.png?token=x".into()),
+            size: Some(serde_json::json!(4096)),
+            extension: None,
+            mimetype: None,
+            date: None,
+            user: None,
+        };
+        let meta = map_clickup_attachment(&raw);
+        // Filename falls back to the last path segment, query stripped.
+        assert_eq!(meta.filename, "screen.png");
+        assert_eq!(meta.size, Some(4096));
+        assert!(meta.created_at.is_none());
+        assert!(meta.author.is_none());
+    }
+
+    #[test]
+    fn test_map_clickup_attachment_missing_everything() {
+        let raw = ClickUpAttachment {
+            id: "att-3".into(),
+            title: None,
+            url: None,
+            size: None,
+            extension: None,
+            mimetype: None,
+            date: None,
+            user: None,
+        };
+        let meta = map_clickup_attachment(&raw);
+        // When title and URL are missing the fallback uses the attachment id.
+        assert_eq!(meta.filename, "attachment-att-3");
+        assert!(meta.url.is_none());
+        assert!(meta.size.is_none());
+    }
+
+    #[test]
+    fn test_clickup_asset_capabilities() {
+        let client =
+            ClickUpClient::with_base_url("https://api.clickup.com/api/v2", "12345", "token");
+        let caps = client.asset_capabilities();
+        assert!(caps.issue.upload);
+        assert!(caps.issue.download);
+        assert!(caps.issue.list);
+        assert!(!caps.issue.delete, "ClickUp has no delete attachment API");
+        assert!(
+            !caps.merge_request.upload,
+            "ClickUp does not track merge requests",
+        );
     }
 
     #[test]
@@ -1677,6 +1873,7 @@ mod tests {
             subtasks: None,
             dependencies: None,
             linked_tasks: None,
+            attachments: Vec::new(),
         };
 
         let issue = map_task(&task);
@@ -1706,6 +1903,7 @@ mod tests {
             subtasks: None,
             dependencies: None,
             linked_tasks: None,
+            attachments: Vec::new(),
         };
 
         let issue = map_task(&task);
@@ -1735,6 +1933,7 @@ mod tests {
             subtasks: None,
             dependencies: None,
             linked_tasks: None,
+            attachments: Vec::new(),
         };
 
         let issue = map_task(&task);
@@ -1765,6 +1964,7 @@ mod tests {
             subtasks: None,
             dependencies: None,
             linked_tasks: None,
+            attachments: Vec::new(),
         };
 
         let task = ClickUpTask {
@@ -1790,6 +1990,7 @@ mod tests {
             subtasks: Some(vec![subtask]),
             dependencies: None,
             linked_tasks: None,
+            attachments: Vec::new(),
         };
 
         let issue = map_task(&task);
@@ -1824,6 +2025,7 @@ mod tests {
             subtasks: None,
             dependencies: None,
             linked_tasks: None,
+            attachments: Vec::new(),
         };
 
         let issue = map_task(&task);
@@ -3365,6 +3567,135 @@ mod tests {
                 .items;
             assert_eq!(issues.len(), 1);
             assert_eq!(issues[0].title, "Backlog task");
+        }
+
+        #[tokio::test]
+        async fn test_get_issue_attachments_maps_all_fields() {
+            let server = MockServer::start();
+
+            let task_json = serde_json::json!({
+                "id": "abc123",
+                "name": "Test",
+                "status": {"status": "open", "type": "open"},
+                "tags": [], "assignees": [],
+                "url": "https://app.clickup.com/t/abc123",
+                "date_created": "1704067200000",
+                "date_updated": "1704067200000",
+                "attachments": [
+                    {
+                        "id": "att-1",
+                        "title": "screen.png",
+                        "url": "https://attachments.clickup.com/abc/screen.png",
+                        "size": "12345",
+                        "extension": "png",
+                        "mimetype": "image/png",
+                        "date": "1704067200000",
+                        "user": {"id": 7, "username": "uploader"}
+                    }
+                ]
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(task_json);
+            });
+
+            let client = create_test_client(&server);
+            let assets = client.get_issue_attachments("CU-abc123").await.unwrap();
+            assert_eq!(assets.len(), 1);
+            let a = &assets[0];
+            assert_eq!(a.id, "att-1");
+            assert_eq!(a.filename, "screen.png");
+            assert_eq!(a.mime_type.as_deref(), Some("image/png"));
+            assert_eq!(a.size, Some(12345));
+            assert_eq!(a.author.as_deref(), Some("uploader"));
+        }
+
+        #[tokio::test]
+        async fn test_get_issue_attachments_empty_when_none() {
+            let server = MockServer::start();
+
+            let task_json = serde_json::json!({
+                "id": "abc123",
+                "name": "Test",
+                "status": {"status": "open", "type": "open"},
+                "tags": [], "assignees": [],
+                "url": "https://app.clickup.com/t/abc123",
+                "date_created": "1704067200000",
+                "date_updated": "1704067200000"
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(task_json);
+            });
+
+            let client = create_test_client(&server);
+            let assets = client.get_issue_attachments("CU-abc123").await.unwrap();
+            assert!(assets.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_download_attachment_fetches_bytes() {
+            let server = MockServer::start();
+
+            let task_json = serde_json::json!({
+                "id": "abc123",
+                "name": "Test",
+                "status": {"status": "open", "type": "open"},
+                "tags": [], "assignees": [],
+                "url": "https://app.clickup.com/t/abc123",
+                "date_created": "1704067200000",
+                "date_updated": "1704067200000",
+                "attachments": [
+                    {
+                        "id": "att-1",
+                        "title": "log.txt",
+                        "url": format!("{}/download/att-1", server.base_url()),
+                    }
+                ]
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(task_json);
+            });
+            server.mock(|when, then| {
+                when.method(GET).path("/download/att-1");
+                then.status(200).body("hello world");
+            });
+
+            let client = create_test_client(&server);
+            let bytes = client
+                .download_attachment("CU-abc123", "att-1")
+                .await
+                .unwrap();
+            assert_eq!(bytes, b"hello world");
+        }
+
+        #[tokio::test]
+        async fn test_download_attachment_not_found() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "abc123", "name": "Test",
+                    "status": {"status": "open", "type": "open"},
+                    "tags": [], "assignees": [],
+                    "url": "https://app.clickup.com/t/abc123",
+                    "date_created": "1704067200000",
+                    "date_updated": "1704067200000",
+                    "attachments": []
+                }));
+            });
+
+            let client = create_test_client(&server);
+            let err = client
+                .download_attachment("CU-abc123", "missing")
+                .await
+                .unwrap_err();
+            assert!(matches!(err, Error::NotFound(_)));
         }
     }
 }

--- a/crates/plugins/api/clickup/src/types.rs
+++ b/crates/plugins/api/clickup/src/types.rs
@@ -60,6 +60,40 @@ pub struct ClickUpTask {
     /// Linked tasks (non-dependency relationships).
     #[serde(default)]
     pub linked_tasks: Option<Vec<ClickUpLinkedTask>>,
+    /// Attachments uploaded to the task.
+    ///
+    /// The ClickUp API returns this under `attachments` on the task object.
+    /// It may be absent for older tasks or tasks without uploads.
+    #[serde(default)]
+    pub attachments: Vec<ClickUpAttachment>,
+}
+
+/// ClickUp task attachment entry as returned on the task payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClickUpAttachment {
+    /// Attachment id.
+    pub id: String,
+    /// File title / original filename.
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Direct download URL.
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Size in bytes (API sometimes returns a string).
+    #[serde(default)]
+    pub size: Option<serde_json::Value>,
+    /// File extension (e.g. "png").
+    #[serde(default)]
+    pub extension: Option<String>,
+    /// MIME type.
+    #[serde(default)]
+    pub mimetype: Option<String>,
+    /// Creation timestamp (epoch ms as string in ClickUp's responses).
+    #[serde(default)]
+    pub date: Option<String>,
+    /// Author display info, if present.
+    #[serde(default)]
+    pub user: Option<ClickUpUser>,
 }
 
 /// ClickUp task status.

--- a/crates/plugins/api/github/src/client.rs
+++ b/crates/plugins/api/github/src/client.rs
@@ -2,11 +2,12 @@
 
 use async_trait::async_trait;
 use devboy_core::{
-    CodePosition, Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput,
-    Discussion, Error, FailedJob, FileDiff, GetPipelineInput, Issue, IssueFilter, IssueProvider,
-    JobLogMode, JobLogOptions, JobLogOutput, MergeRequest, MergeRequestProvider, MrFilter,
-    PipelineInfo, PipelineJob, PipelineProvider, PipelineStage, PipelineStatus, PipelineSummary,
-    Provider, ProviderResult, Result, UpdateIssueInput, User,
+    AssetCapabilities, AssetMeta, CodePosition, Comment, ContextCapabilities, CreateCommentInput,
+    CreateIssueInput, CreateMergeRequestInput, Discussion, Error, FailedJob, FileDiff,
+    GetPipelineInput, Issue, IssueFilter, IssueProvider, JobLogMode, JobLogOptions, JobLogOutput,
+    MergeRequest, MergeRequestProvider, MrFilter, PipelineInfo, PipelineJob, PipelineProvider,
+    PipelineStage, PipelineStatus, PipelineSummary, Provider, ProviderResult, Result,
+    UpdateIssueInput, User, parse_markdown_attachments,
 };
 use serde::Deserialize;
 use tracing::{debug, warn};
@@ -440,6 +441,71 @@ impl IssueProvider for GitHubClient {
         Ok(map_comment(&gh_comment))
     }
 
+    async fn get_issue_attachments(&self, issue_key: &str) -> Result<Vec<AssetMeta>> {
+        // GitHub does not expose an attachment API for issues; we parse the
+        // issue body and all comment bodies for markdown-embedded files.
+        let issue = self.get_issue(issue_key).await?;
+        let comments = self.get_comments(issue_key).await?;
+
+        let mut attachments: Vec<AssetMeta> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut collect = |source: &str| {
+            for att in parse_markdown_attachments(source) {
+                if seen.insert(att.url.clone()) {
+                    attachments.push(markdown_to_meta(&att));
+                }
+            }
+        };
+        if let Some(body) = issue.description.as_deref() {
+            collect(body);
+        }
+        for comment in &comments.items {
+            collect(&comment.body);
+        }
+        Ok(attachments)
+    }
+
+    async fn download_attachment(&self, _issue_key: &str, asset_id: &str) -> Result<Vec<u8>> {
+        // GitHub's user-content CDN (e.g. `user-images.githubusercontent.com`)
+        // serves attachment bytes anonymously — but we still attach our
+        // normal auth headers so repo-local hosts work too.
+        let response = self
+            .request(reqwest::Method::GET, asset_id)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
+        Ok(bytes.to_vec())
+    }
+
+    fn asset_capabilities(&self) -> AssetCapabilities {
+        // GitHub has no public file upload API for issues / PRs (files are
+        // only uploaded through the web UI to a CDN). We support download
+        // and list via markdown parsing; upload / delete stay false.
+        let caps = ContextCapabilities {
+            upload: false,
+            download: true,
+            delete: false,
+            list: true,
+            max_file_size: None,
+            allowed_types: Vec::new(),
+        };
+        AssetCapabilities {
+            issue: caps.clone(),
+            issue_comment: caps.clone(),
+            merge_request: caps.clone(),
+            mr_comment: caps,
+        }
+    }
+
     fn provider_name(&self) -> &'static str {
         "github"
     }
@@ -708,8 +774,71 @@ impl MergeRequestProvider for GitHubClient {
         Ok(map_pull_request(&gh_pr))
     }
 
+    async fn get_mr_attachments(&self, mr_key: &str) -> Result<Vec<AssetMeta>> {
+        // PR body + discussions, same strategy as issues.
+        let mr = self.get_merge_request(mr_key).await?;
+        let discussions = self.get_discussions(mr_key).await?;
+
+        let mut attachments: Vec<AssetMeta> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut collect = |source: &str| {
+            for att in parse_markdown_attachments(source) {
+                if seen.insert(att.url.clone()) {
+                    attachments.push(markdown_to_meta(&att));
+                }
+            }
+        };
+        if let Some(body) = mr.description.as_deref() {
+            collect(body);
+        }
+        for discussion in &discussions.items {
+            for comment in &discussion.comments {
+                collect(&comment.body);
+            }
+        }
+        Ok(attachments)
+    }
+
+    async fn download_mr_attachment(&self, _mr_key: &str, asset_id: &str) -> Result<Vec<u8>> {
+        let response = self
+            .request(reqwest::Method::GET, asset_id)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
+        Ok(bytes.to_vec())
+    }
+
     fn provider_name(&self) -> &'static str {
         "github"
+    }
+}
+
+/// Convert a parsed markdown attachment into an [`AssetMeta`] record.
+///
+/// GitHub has no stable attachment id — the URL itself doubles as both the
+/// lookup key and the download target.
+fn markdown_to_meta(att: &devboy_core::MarkdownAttachment) -> AssetMeta {
+    AssetMeta {
+        id: att.url.clone(),
+        filename: att.filename.clone(),
+        mime_type: None,
+        size: None,
+        url: Some(att.url.clone()),
+        created_at: None,
+        author: None,
+        cached: false,
+        local_path: None,
+        checksum_sha256: None,
+        analysis: None,
     }
 }
 
@@ -2532,6 +2661,76 @@ mod tests {
             assert!(result.content.contains("Line 3"));
             assert!(!result.content.contains("Line 1"));
             assert!(!result.content.contains("Line 4"));
+        }
+
+        // =================================================================
+        // Attachment tests (Phase 2)
+        // =================================================================
+
+        #[tokio::test]
+        async fn test_get_issue_attachments_parses_body_and_comments() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/repos/owner/repo/issues/42");
+                then.status(200).json_body(serde_json::json!({
+                    "id": 1,
+                    "number": 42,
+                    "title": "bug",
+                    "body": "Error: ![screen](https://user-images.githubusercontent.com/1/screen.png)",
+                    "state": "open",
+                    "html_url": "https://github.com/owner/repo/issues/42",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "updated_at": "2024-01-02T00:00:00Z"
+                }));
+            });
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/repos/owner/repo/issues/42/comments");
+                then.status(200).json_body(serde_json::json!([
+                    {
+                        "id": 10,
+                        "body": "Log [here](https://user-images.githubusercontent.com/1/log.txt)",
+                        "html_url": "https://github.com/owner/repo/issues/42#issuecomment-10",
+                        "created_at": "2024-01-03T00:00:00Z",
+                        "updated_at": "2024-01-03T00:00:00Z"
+                    }
+                ]));
+            });
+
+            let client = create_test_client(&server);
+            let attachments = client.get_issue_attachments("gh#42").await.unwrap();
+            assert_eq!(attachments.len(), 2);
+            assert_eq!(attachments[0].filename, "screen");
+            assert_eq!(attachments[1].filename, "here");
+        }
+
+        #[tokio::test]
+        async fn test_download_attachment_fetches_url() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/cdn/file.txt");
+                then.status(200).body("github-bytes");
+            });
+
+            let client = create_test_client(&server);
+            let url = format!("{}/cdn/file.txt", server.base_url());
+            let bytes = client.download_attachment("gh#42", &url).await.unwrap();
+            assert_eq!(bytes, b"github-bytes");
+        }
+
+        #[tokio::test]
+        async fn test_github_asset_capabilities() {
+            let server = MockServer::start();
+            let client = create_test_client(&server);
+            let caps = client.asset_capabilities();
+            assert!(!caps.issue.upload, "GitHub has no public upload API");
+            assert!(caps.issue.download);
+            assert!(caps.issue.list);
+            assert!(!caps.issue.delete);
+            assert!(!caps.merge_request.upload);
+            assert!(caps.merge_request.download);
         }
     }
 

--- a/crates/plugins/api/github/src/client.rs
+++ b/crates/plugins/api/github/src/client.rs
@@ -449,9 +449,13 @@ impl IssueProvider for GitHubClient {
 
         let mut attachments: Vec<AssetMeta> = Vec::new();
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let base = self.base_url.clone();
         let mut collect = |source: &str| {
             for att in parse_markdown_attachments(source) {
-                if seen.insert(att.url.clone()) {
+                // Only include URLs that point to known GitHub CDN /
+                // upload hosts. Ordinary markdown links (docs, issues,
+                // dashboards) must not appear as downloadable attachments.
+                if is_github_attachment_url(&base, &att.url) && seen.insert(att.url.clone()) {
                     attachments.push(markdown_to_meta(&att));
                 }
             }
@@ -758,15 +762,15 @@ impl MergeRequestProvider for GitHubClient {
     }
 
     async fn get_mr_attachments(&self, mr_key: &str) -> Result<Vec<AssetMeta>> {
-        // PR body + discussions, same strategy as issues.
         let mr = self.get_merge_request(mr_key).await?;
         let discussions = self.get_discussions(mr_key).await?;
 
         let mut attachments: Vec<AssetMeta> = Vec::new();
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let base = self.base_url.clone();
         let mut collect = |source: &str| {
             for att in parse_markdown_attachments(source) {
-                if seen.insert(att.url.clone()) {
+                if is_github_attachment_url(&base, &att.url) && seen.insert(att.url.clone()) {
                     attachments.push(markdown_to_meta(&att));
                 }
             }
@@ -876,6 +880,37 @@ fn split_scheme_host(url: &str) -> (String, String) {
     };
     let host = rest.split('/').next().unwrap_or("").to_ascii_lowercase();
     (scheme, host)
+}
+
+/// Check whether a URL looks like a real GitHub file attachment (CDN
+/// upload, user-content image, etc.) as opposed to an ordinary markdown
+/// link to a docs page, issue, or dashboard.
+///
+/// GitHub user-uploaded attachments are hosted on `githubusercontent.com`
+/// subdomains. We also accept `/assets/` paths on the configured host
+/// (GitHub Enterprise may serve uploads from the same domain).
+fn is_github_attachment_url(base_url: &str, url: &str) -> bool {
+    let (scheme, host) = split_scheme_host(url);
+    if scheme.is_empty() {
+        return false; // relative path — not a CDN upload
+    }
+    // Well-known GitHub CDN hosts for user-uploaded content.
+    if host.ends_with("githubusercontent.com") {
+        return true;
+    }
+    // On the base host: only `/assets/` paths are real uploads.
+    let (_base_scheme, base_host) = split_scheme_host(base_url);
+    if host == base_host {
+        let path = url
+            .split("://")
+            .nth(1)
+            .unwrap_or("")
+            .split_once('/')
+            .map(|(_, p)| p)
+            .unwrap_or("");
+        return path.contains("/assets/");
+    }
+    false
 }
 
 fn markdown_to_meta(att: &devboy_core::MarkdownAttachment) -> AssetMeta {

--- a/crates/plugins/api/github/src/client.rs
+++ b/crates/plugins/api/github/src/client.rs
@@ -783,9 +783,7 @@ impl MergeRequestProvider for GitHubClient {
     }
 
     async fn download_mr_attachment(&self, _mr_key: &str, asset_id: &str) -> Result<Vec<u8>> {
-        let bytes =
-            download_github_url(&self.client, &self.base_url, &self.token, asset_id).await?;
-        Ok(bytes.to_vec())
+        download_github_url(&self.client, &self.base_url, &self.token, asset_id).await
     }
 
     fn provider_name(&self) -> &'static str {
@@ -849,15 +847,14 @@ async fn download_github_url(
 
 /// Check whether a URL is a known GitHub host or matches the configured
 /// base URL (for GitHub Enterprise instances).
+///
+/// Only HTTPS URLs are trusted — a `http://github.com/...` link would
+/// send credentials over plaintext and is rejected.
 fn is_github_trusted_host(base_url: &str, url: &str) -> bool {
-    let url_host = url
-        .split("://")
-        .nth(1)
-        .unwrap_or(url)
-        .split('/')
-        .next()
-        .unwrap_or("")
-        .to_ascii_lowercase();
+    let (url_scheme, url_host) = split_scheme_host(url);
+    if url_scheme != "https" {
+        return false;
+    }
 
     // Check against well-known GitHub CDN hosts.
     for trusted in GITHUB_TRUSTED_HOSTS {
@@ -867,15 +864,18 @@ fn is_github_trusted_host(base_url: &str, url: &str) -> bool {
     }
 
     // Check against the configured base URL (GitHub Enterprise).
-    let base_host = base_url
-        .split("://")
-        .nth(1)
-        .unwrap_or(base_url)
-        .split('/')
-        .next()
-        .unwrap_or("")
-        .to_ascii_lowercase();
+    let (_base_scheme, base_host) = split_scheme_host(base_url);
     url_host == base_host
+}
+
+/// Extract (scheme, host) from a URL string, both lowercased.
+fn split_scheme_host(url: &str) -> (String, String) {
+    let (scheme, rest) = match url.split_once("://") {
+        Some((s, r)) => (s.to_ascii_lowercase(), r),
+        None => return (String::new(), String::new()),
+    };
+    let host = rest.split('/').next().unwrap_or("").to_ascii_lowercase();
+    (scheme, host)
 }
 
 fn markdown_to_meta(att: &devboy_core::MarkdownAttachment) -> AssetMeta {

--- a/crates/plugins/api/github/src/client.rs
+++ b/crates/plugins/api/github/src/client.rs
@@ -466,24 +466,7 @@ impl IssueProvider for GitHubClient {
     }
 
     async fn download_attachment(&self, _issue_key: &str, asset_id: &str) -> Result<Vec<u8>> {
-        // GitHub's user-content CDN (e.g. `user-images.githubusercontent.com`)
-        // serves attachment bytes anonymously — but we still attach our
-        // normal auth headers so repo-local hosts work too.
-        let response = self
-            .request(reqwest::Method::GET, asset_id)
-            .send()
-            .await
-            .map_err(|e| Error::Http(e.to_string()))?;
-        let status = response.status();
-        if !status.is_success() {
-            let message = response.text().await.unwrap_or_default();
-            return Err(Error::from_status(status.as_u16(), message));
-        }
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
-        Ok(bytes.to_vec())
+        download_github_url(&self.client, &self.base_url, &self.token, asset_id).await
     }
 
     fn asset_capabilities(&self) -> AssetCapabilities {
@@ -800,20 +783,8 @@ impl MergeRequestProvider for GitHubClient {
     }
 
     async fn download_mr_attachment(&self, _mr_key: &str, asset_id: &str) -> Result<Vec<u8>> {
-        let response = self
-            .request(reqwest::Method::GET, asset_id)
-            .send()
-            .await
-            .map_err(|e| Error::Http(e.to_string()))?;
-        let status = response.status();
-        if !status.is_success() {
-            let message = response.text().await.unwrap_or_default();
-            return Err(Error::from_status(status.as_u16(), message));
-        }
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
+        let bytes =
+            download_github_url(&self.client, &self.base_url, &self.token, asset_id).await?;
         Ok(bytes.to_vec())
     }
 
@@ -826,6 +797,87 @@ impl MergeRequestProvider for GitHubClient {
 ///
 /// GitHub has no stable attachment id — the URL itself doubles as both the
 /// lookup key and the download target.
+/// Known GitHub-owned hosts that are safe to send auth headers to.
+const GITHUB_TRUSTED_HOSTS: &[&str] = &[
+    "github.com",
+    "api.github.com",
+    "githubusercontent.com",
+    "user-images.githubusercontent.com",
+    "raw.githubusercontent.com",
+    "objects.githubusercontent.com",
+    "camo.githubusercontent.com",
+];
+
+/// Download a URL, attaching GitHub auth headers only if the host is a
+/// known GitHub domain. For cross-origin URLs (which can appear in
+/// markdown via user-supplied links) the request is made anonymously to
+/// prevent token leakage.
+async fn download_github_url(
+    client: &reqwest::Client,
+    base_url: &str,
+    token: &str,
+    url: &str,
+) -> Result<Vec<u8>> {
+    let is_trusted = is_github_trusted_host(base_url, url);
+    let mut request = client
+        .get(url)
+        .header("Accept", "application/octet-stream")
+        .header("User-Agent", "devboy-tools");
+    if is_trusted && !token.is_empty() {
+        request = request.header("Authorization", format!("Bearer {token}"));
+    } else if !is_trusted {
+        tracing::warn!(
+            url,
+            "downloading cross-origin attachment without auth headers"
+        );
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|e| Error::Http(e.to_string()))?;
+    let status = response.status();
+    if !status.is_success() {
+        let message = response.text().await.unwrap_or_default();
+        return Err(Error::from_status(status.as_u16(), message));
+    }
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
+    Ok(bytes.to_vec())
+}
+
+/// Check whether a URL is a known GitHub host or matches the configured
+/// base URL (for GitHub Enterprise instances).
+fn is_github_trusted_host(base_url: &str, url: &str) -> bool {
+    let url_host = url
+        .split("://")
+        .nth(1)
+        .unwrap_or(url)
+        .split('/')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    // Check against well-known GitHub CDN hosts.
+    for trusted in GITHUB_TRUSTED_HOSTS {
+        if url_host == *trusted || url_host.ends_with(&format!(".{trusted}")) {
+            return true;
+        }
+    }
+
+    // Check against the configured base URL (GitHub Enterprise).
+    let base_host = base_url
+        .split("://")
+        .nth(1)
+        .unwrap_or(base_url)
+        .split('/')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    url_host == base_host
+}
+
 fn markdown_to_meta(att: &devboy_core::MarkdownAttachment) -> AssetMeta {
     AssetMeta {
         id: att.url.clone(),

--- a/crates/plugins/api/gitlab/src/client.rs
+++ b/crates/plugins/api/gitlab/src/client.rs
@@ -318,27 +318,32 @@ impl GitLabClient {
     }
 }
 
-/// Check whether a URL belongs to the same origin as the configured
-/// base URL. Relative URLs and paths always count as same-origin.
+/// Check whether a URL belongs to the same origin (scheme + host) as
+/// the configured base URL. Relative URLs and paths always count as
+/// same-origin. Scheme-relative `//host/...` URLs are treated as
+/// cross-origin to avoid ambiguity.
+///
+/// This prevents sending auth headers (PRIVATE-TOKEN / proxy) over
+/// plaintext HTTP when the base URL uses HTTPS.
 fn is_same_origin(base_url: &str, url: &str) -> bool {
-    if !url.contains("://") {
+    if !url.contains("://") && !url.starts_with("//") {
         return true; // relative path
     }
-    let base_host = base_url
-        .split("://")
-        .nth(1)
-        .unwrap_or(base_url)
-        .split('/')
-        .next()
-        .unwrap_or("");
-    let url_host = url
-        .split("://")
-        .nth(1)
-        .unwrap_or(url)
-        .split('/')
-        .next()
-        .unwrap_or("");
-    base_host.eq_ignore_ascii_case(url_host)
+    let (base_scheme, base_host) = split_scheme_host(base_url);
+    let (url_scheme, url_host) = split_scheme_host(url);
+
+    base_scheme.eq_ignore_ascii_case(&url_scheme) && base_host.eq_ignore_ascii_case(&url_host)
+}
+
+/// Extract (scheme, host) from a URL string. Returns empty strings for
+/// components that cannot be parsed.
+fn split_scheme_host(url: &str) -> (String, String) {
+    let (scheme, rest) = match url.split_once("://") {
+        Some((s, r)) => (s.to_ascii_lowercase(), r),
+        None => return (String::new(), String::new()),
+    };
+    let host = rest.split('/').next().unwrap_or("").to_ascii_lowercase();
+    (scheme, host)
 }
 
 // =============================================================================

--- a/crates/plugins/api/gitlab/src/client.rs
+++ b/crates/plugins/api/gitlab/src/client.rs
@@ -713,7 +713,10 @@ impl IssueProvider for GitLabClient {
 
         let mut collect = |source: &str| {
             for att in parse_markdown_attachments(source) {
-                if seen.insert(att.url.clone()) {
+                // Only include URLs that contain `/uploads/` — GitLab
+                // project uploads always have this path segment.
+                // Ordinary links (issues, docs, MRs) are excluded.
+                if is_gitlab_upload_url(&att.url) && seen.insert(att.url.clone()) {
                     attachments.push(markdown_to_meta(&att, &self.base_url));
                 }
             }
@@ -976,7 +979,7 @@ impl MergeRequestProvider for GitLabClient {
 
         let mut collect = |source: &str| {
             for att in parse_markdown_attachments(source) {
-                if seen.insert(att.url.clone()) {
+                if is_gitlab_upload_url(&att.url) && seen.insert(att.url.clone()) {
                     attachments.push(markdown_to_meta(&att, &self.base_url));
                 }
             }
@@ -1007,6 +1010,14 @@ impl MergeRequestProvider for GitLabClient {
 /// Convert a relative GitLab upload path to an absolute URL.
 ///
 /// Pass-through for URLs that already contain a scheme.
+/// Check whether a markdown URL looks like a real GitLab project upload.
+///
+/// GitLab uploads always contain `/uploads/` in the path. Ordinary links
+/// to issues, MRs, docs pages, wikis, etc. do not.
+fn is_gitlab_upload_url(url: &str) -> bool {
+    url.contains("/uploads/")
+}
+
 fn absolutize_gitlab_url(base: &str, url_or_path: &str) -> String {
     if url_or_path.starts_with("http://") || url_or_path.starts_with("https://") {
         return url_or_path.to_string();

--- a/crates/plugins/api/gitlab/src/client.rs
+++ b/crates/plugins/api/gitlab/src/client.rs
@@ -252,7 +252,12 @@ impl GitLabClient {
             .get("full_path")
             .or_else(|| body.get("url"))
             .and_then(|v| v.as_str())
-            .unwrap_or("");
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                Error::InvalidData(
+                    "GitLab upload response contains no usable url or full_path".to_string(),
+                )
+            })?;
         Ok(absolutize_gitlab_url(&self.base_url, relative))
     }
 
@@ -279,6 +284,61 @@ impl GitLabClient {
             .await
             .map_err(|e| Error::InvalidData(format!("Failed to parse response: {}", e)))
     }
+
+    /// Download a URL that is expected to belong to this GitLab instance.
+    ///
+    /// Auth headers (`PRIVATE-TOKEN` / proxy headers) are only sent when
+    /// the URL host matches the configured `base_url`. For cross-origin
+    /// URLs (which can appear in markdown via user-supplied links) the
+    /// request is made anonymously to prevent token leakage.
+    async fn download_trusted_url(&self, url: &str) -> Result<Vec<u8>> {
+        let request = if is_same_origin(&self.base_url, url) {
+            self.request(reqwest::Method::GET, url)
+        } else {
+            tracing::warn!(
+                url,
+                "downloading cross-origin attachment without auth headers"
+            );
+            self.client.get(url)
+        };
+        let response = request
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
+        Ok(bytes.to_vec())
+    }
+}
+
+/// Check whether a URL belongs to the same origin as the configured
+/// base URL. Relative URLs and paths always count as same-origin.
+fn is_same_origin(base_url: &str, url: &str) -> bool {
+    if !url.contains("://") {
+        return true; // relative path
+    }
+    let base_host = base_url
+        .split("://")
+        .nth(1)
+        .unwrap_or(base_url)
+        .split('/')
+        .next()
+        .unwrap_or("");
+    let url_host = url
+        .split("://")
+        .nth(1)
+        .unwrap_or(url)
+        .split('/')
+        .next()
+        .unwrap_or("");
+    base_host.eq_ignore_ascii_case(url_host)
 }
 
 // =============================================================================
@@ -665,25 +725,8 @@ impl IssueProvider for GitLabClient {
     }
 
     async fn download_attachment(&self, _issue_key: &str, asset_id: &str) -> Result<Vec<u8>> {
-        // In GitLab the `asset_id` for an uploaded file is the URL itself
-        // (relative `/uploads/...` path or a full URL). Normalize to an
-        // absolute URL against the configured base and download with auth.
         let absolute = absolutize_gitlab_url(&self.base_url, asset_id);
-        let response = self
-            .request(reqwest::Method::GET, &absolute)
-            .send()
-            .await
-            .map_err(|e| Error::Http(e.to_string()))?;
-        let status = response.status();
-        if !status.is_success() {
-            let message = response.text().await.unwrap_or_default();
-            return Err(Error::from_status(status.as_u16(), message));
-        }
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
-        Ok(bytes.to_vec())
+        self.download_trusted_url(&absolute).await
     }
 
     fn asset_capabilities(&self) -> AssetCapabilities {
@@ -947,24 +990,8 @@ impl MergeRequestProvider for GitLabClient {
     }
 
     async fn download_mr_attachment(&self, _mr_key: &str, asset_id: &str) -> Result<Vec<u8>> {
-        // Same as download_attachment on the issue side — GitLab uploads
-        // are shared across issues and MRs at the project level.
         let absolute = absolutize_gitlab_url(&self.base_url, asset_id);
-        let response = self
-            .request(reqwest::Method::GET, &absolute)
-            .send()
-            .await
-            .map_err(|e| Error::Http(e.to_string()))?;
-        let status = response.status();
-        if !status.is_success() {
-            let message = response.text().await.unwrap_or_default();
-            return Err(Error::from_status(status.as_u16(), message));
-        }
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
-        Ok(bytes.to_vec())
+        self.download_trusted_url(&absolute).await
     }
 
     fn provider_name(&self) -> &'static str {

--- a/crates/plugins/api/gitlab/src/client.rs
+++ b/crates/plugins/api/gitlab/src/client.rs
@@ -2,11 +2,12 @@
 
 use async_trait::async_trait;
 use devboy_core::{
-    CodePosition, Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput,
-    Discussion, Error, FailedJob, FileDiff, GetPipelineInput, Issue, IssueFilter, IssueProvider,
-    JobLogMode, JobLogOptions, JobLogOutput, MergeRequest, MergeRequestProvider, MrFilter,
-    PipelineInfo, PipelineJob, PipelineProvider, PipelineStage, PipelineStatus, PipelineSummary,
-    Provider, ProviderResult, Result, UpdateIssueInput, User,
+    AssetCapabilities, AssetMeta, CodePosition, Comment, ContextCapabilities, CreateCommentInput,
+    CreateIssueInput, CreateMergeRequestInput, Discussion, Error, FailedJob, FileDiff,
+    GetPipelineInput, Issue, IssueFilter, IssueProvider, JobLogMode, JobLogOptions, JobLogOutput,
+    MergeRequest, MergeRequestProvider, MrFilter, PipelineInfo, PipelineJob, PipelineProvider,
+    PipelineStage, PipelineStatus, PipelineSummary, Provider, ProviderResult, Result,
+    UpdateIssueInput, User, parse_markdown_attachments,
 };
 use tracing::{debug, warn};
 
@@ -208,6 +209,51 @@ impl GitLabClient {
             total: x_total,
             has_more,
         })
+    }
+
+    /// Upload a raw file to the project's shared uploads bucket and
+    /// return an absolute download URL for the uploaded blob.
+    ///
+    /// GitLab does not expose a per-issue attachment API — instead all
+    /// uploads share a project-wide `/projects/{id}/uploads` endpoint and
+    /// get embedded into issue / MR / note bodies via a markdown snippet
+    /// that links back to that URL.
+    async fn upload_project_file(&self, filename: &str, data: &[u8]) -> Result<String> {
+        let url = self.project_url("/uploads");
+
+        let part = reqwest::multipart::Part::bytes(data.to_vec())
+            .file_name(filename.to_string())
+            .mime_str("application/octet-stream")
+            .map_err(|e| Error::Http(format!("failed to build multipart: {e}")))?;
+        let form = reqwest::multipart::Form::new().part("file", part);
+
+        let response = self
+            .request(reqwest::Method::POST, &url)
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| Error::InvalidData(format!("failed to parse upload response: {e}")))?;
+
+        // GitLab returns: { "alt": "screen", "url": "/uploads/<hash>/screen.png",
+        //                   "full_path": "/namespace/project/uploads/<hash>/screen.png",
+        //                   "markdown": "![screen](/uploads/...)" }
+        let relative = body
+            .get("full_path")
+            .or_else(|| body.get("url"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        Ok(absolutize_gitlab_url(&self.base_url, relative))
     }
 
     /// Handle response and map errors.
@@ -579,6 +625,85 @@ impl IssueProvider for GitLabClient {
         Ok(map_note(&gl_note))
     }
 
+    async fn upload_attachment(
+        &self,
+        _issue_key: &str,
+        filename: &str,
+        data: &[u8],
+    ) -> Result<String> {
+        // GitLab has no per-issue attachment endpoint. Instead we upload to
+        // the project's shared uploads bucket and return the absolute URL
+        // that can be embedded into any issue / MR / note body.
+        self.upload_project_file(filename, data).await
+    }
+
+    async fn get_issue_attachments(&self, issue_key: &str) -> Result<Vec<AssetMeta>> {
+        // GitLab does not expose an attachment listing — we reconstruct it
+        // from the markdown of the issue body and all comments.
+        let issue = self.get_issue(issue_key).await?;
+        let comments = self.get_comments(issue_key).await?;
+
+        let mut attachments: Vec<AssetMeta> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        let mut collect = |source: &str| {
+            for att in parse_markdown_attachments(source) {
+                if seen.insert(att.url.clone()) {
+                    attachments.push(markdown_to_meta(&att, &self.base_url));
+                }
+            }
+        };
+
+        if let Some(body) = issue.description.as_deref() {
+            collect(body);
+        }
+        for comment in &comments.items {
+            collect(&comment.body);
+        }
+
+        Ok(attachments)
+    }
+
+    async fn download_attachment(&self, _issue_key: &str, asset_id: &str) -> Result<Vec<u8>> {
+        // In GitLab the `asset_id` for an uploaded file is the URL itself
+        // (relative `/uploads/...` path or a full URL). Normalize to an
+        // absolute URL against the configured base and download with auth.
+        let absolute = absolutize_gitlab_url(&self.base_url, asset_id);
+        let response = self
+            .request(reqwest::Method::GET, &absolute)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
+        Ok(bytes.to_vec())
+    }
+
+    fn asset_capabilities(&self) -> AssetCapabilities {
+        // GitLab project uploads are immutable, so `delete` stays false.
+        let caps = ContextCapabilities {
+            upload: true,
+            download: true,
+            delete: false,
+            list: true,
+            max_file_size: None,
+            allowed_types: Vec::new(),
+        };
+        AssetCapabilities {
+            issue: caps.clone(),
+            issue_comment: caps.clone(),
+            merge_request: caps.clone(),
+            mr_comment: caps,
+        }
+    }
+
     fn provider_name(&self) -> &'static str {
         "gitlab"
     }
@@ -794,8 +919,91 @@ impl MergeRequestProvider for GitLabClient {
         Ok(map_merge_request(&gl_mr))
     }
 
+    async fn get_mr_attachments(&self, mr_key: &str) -> Result<Vec<AssetMeta>> {
+        let mr = self.get_merge_request(mr_key).await?;
+        let discussions = self.get_discussions(mr_key).await?;
+
+        let mut attachments: Vec<AssetMeta> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        let mut collect = |source: &str| {
+            for att in parse_markdown_attachments(source) {
+                if seen.insert(att.url.clone()) {
+                    attachments.push(markdown_to_meta(&att, &self.base_url));
+                }
+            }
+        };
+
+        if let Some(body) = mr.description.as_deref() {
+            collect(body);
+        }
+        for discussion in &discussions.items {
+            for comment in &discussion.comments {
+                collect(&comment.body);
+            }
+        }
+
+        Ok(attachments)
+    }
+
+    async fn download_mr_attachment(&self, _mr_key: &str, asset_id: &str) -> Result<Vec<u8>> {
+        // Same as download_attachment on the issue side — GitLab uploads
+        // are shared across issues and MRs at the project level.
+        let absolute = absolutize_gitlab_url(&self.base_url, asset_id);
+        let response = self
+            .request(reqwest::Method::GET, &absolute)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
+        Ok(bytes.to_vec())
+    }
+
     fn provider_name(&self) -> &'static str {
         "gitlab"
+    }
+}
+
+/// Convert a relative GitLab upload path to an absolute URL.
+///
+/// Pass-through for URLs that already contain a scheme.
+fn absolutize_gitlab_url(base: &str, url_or_path: &str) -> String {
+    if url_or_path.starts_with("http://") || url_or_path.starts_with("https://") {
+        return url_or_path.to_string();
+    }
+    let base = base.trim_end_matches('/');
+    if url_or_path.starts_with('/') {
+        format!("{base}{url_or_path}")
+    } else {
+        format!("{base}/{url_or_path}")
+    }
+}
+
+/// Convert a parsed markdown attachment into an [`AssetMeta`] record.
+fn markdown_to_meta(att: &devboy_core::MarkdownAttachment, base_url: &str) -> AssetMeta {
+    let absolute = absolutize_gitlab_url(base_url, &att.url);
+    AssetMeta {
+        // For GitLab there's no stable attachment id — the URL doubles as
+        // both the lookup key and the download target.
+        id: att.url.clone(),
+        filename: att.filename.clone(),
+        mime_type: None,
+        size: None,
+        url: Some(absolute),
+        created_at: None,
+        author: None,
+        cached: false,
+        local_path: None,
+        checksum_sha256: None,
+        analysis: None,
     }
 }
 
@@ -2257,6 +2465,114 @@ mod tests {
             assert!(result.content.contains("L3"));
             assert!(result.content.contains("L4"));
             assert!(!result.content.contains("L1"));
+        }
+
+        // =================================================================
+        // Attachment tests (Phase 2)
+        // =================================================================
+
+        #[tokio::test]
+        async fn test_upload_attachment_returns_absolute_url() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(POST).path("/api/v4/projects/123/uploads");
+                then.status(201).json_body(serde_json::json!({
+                    "alt": "screen",
+                    "url": "/uploads/abc/screen.png",
+                    "full_path": "/ns/proj/uploads/abc/screen.png",
+                    "markdown": "![screen](/uploads/abc/screen.png)"
+                }));
+            });
+
+            let client = create_test_client(&server);
+            let url = client
+                .upload_attachment("gitlab#42", "screen.png", b"data")
+                .await
+                .unwrap();
+            assert!(url.starts_with(&server.base_url()));
+            assert!(url.contains("/uploads/abc/screen.png"));
+        }
+
+        #[tokio::test]
+        async fn test_get_issue_attachments_parses_body_and_notes() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/api/v4/projects/123/issues/42");
+                then.status(200).json_body(serde_json::json!({
+                    "id": 1,
+                    "iid": 42,
+                    "title": "bug",
+                    "description": "See ![screen](/uploads/hash1/screen.png)",
+                    "state": "opened",
+                    "web_url": "https://example/gl/ns/proj/-/issues/42",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "updated_at": "2024-01-02T00:00:00Z"
+                }));
+            });
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/api/v4/projects/123/issues/42/notes");
+                then.status(200).json_body(serde_json::json!([
+                    {
+                        "id": 10,
+                        "body": "Also [log](/uploads/hash2/trace.log)",
+                        "system": false,
+                        "created_at": "2024-01-01T00:00:00Z"
+                    },
+                    {
+                        "id": 11,
+                        "body": "Duplicate ![screen](/uploads/hash1/screen.png)",
+                        "system": false,
+                        "created_at": "2024-01-02T00:00:00Z"
+                    }
+                ]));
+            });
+
+            let client = create_test_client(&server);
+            let attachments = client.get_issue_attachments("gitlab#42").await.unwrap();
+            assert_eq!(attachments.len(), 2, "duplicates should be dropped");
+            assert_eq!(attachments[0].filename, "screen");
+            assert!(
+                attachments[0]
+                    .url
+                    .as_deref()
+                    .unwrap()
+                    .contains("/uploads/hash1/screen.png")
+            );
+            assert_eq!(attachments[1].filename, "log");
+        }
+
+        #[tokio::test]
+        async fn test_download_attachment_relative_path() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/uploads/hash/file.txt");
+                then.status(200).body("hello");
+            });
+
+            let client = create_test_client(&server);
+            let bytes = client
+                .download_attachment("gitlab#42", "/uploads/hash/file.txt")
+                .await
+                .unwrap();
+            assert_eq!(bytes, b"hello");
+        }
+
+        #[tokio::test]
+        async fn test_gitlab_asset_capabilities() {
+            let server = MockServer::start();
+            let client = create_test_client(&server);
+            let caps = client.asset_capabilities();
+            assert!(caps.issue.upload);
+            assert!(caps.issue.download);
+            assert!(caps.issue.list);
+            assert!(!caps.issue.delete);
+            // GitLab uploads are shared, so MR caps match issue caps.
+            assert!(caps.merge_request.upload);
+            assert!(caps.merge_request.list);
         }
     }
 

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -130,15 +130,21 @@ impl JiraClient {
         }
     }
 
-    /// Build request with auth headers.
+    /// Build request with auth headers and JSON content type.
     ///
     /// When proxy is configured, provider's own auth is suppressed and
     /// proxy headers are added instead. The proxy handles authentication.
     fn request(&self, method: reqwest::Method, url: &str) -> reqwest::RequestBuilder {
-        let mut builder = self
-            .client
-            .request(method, url)
-            .header("Content-Type", "application/json");
+        self.request_raw(method, url)
+            .header("Content-Type", "application/json")
+    }
+
+    /// Build request with auth headers but **no** Content-Type header.
+    ///
+    /// Use this for multipart uploads where reqwest must set its own
+    /// `Content-Type: multipart/form-data; boundary=...` header.
+    fn request_raw(&self, method: reqwest::Method, url: &str) -> reqwest::RequestBuilder {
+        let mut builder = self.client.request(method, url);
 
         if let Some(headers) = &self.proxy_headers {
             for (key, value) in headers {
@@ -1357,8 +1363,11 @@ impl IssueProvider for JiraClient {
             .map_err(|e| Error::Http(format!("failed to build multipart: {e}")))?;
         let form = reqwest::multipart::Form::new().part("file", part);
 
+        // Use request_raw (no Content-Type) so reqwest can set its own
+        // multipart/form-data boundary header. self.request() sets
+        // Content-Type: application/json which conflicts with multipart.
         let response = self
-            .request(reqwest::Method::POST, &url)
+            .request_raw(reqwest::Method::POST, &url)
             // Jira requires the X-Atlassian-Token header to bypass its XSRF check
             // on file uploads: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/
             .header("X-Atlassian-Token", "no-check")

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -5,19 +5,20 @@
 
 use async_trait::async_trait;
 use devboy_core::{
-    Comment, CreateIssueInput, Error, GetUsersOptions, Issue, IssueFilter, IssueLink,
-    IssueProvider, IssueRelations, IssueStatus, MergeRequestProvider, PipelineProvider, Provider,
-    ProviderResult, Result, UpdateIssueInput, User,
+    AssetCapabilities, AssetMeta, Comment, ContextCapabilities, CreateIssueInput, Error,
+    GetUsersOptions, Issue, IssueFilter, IssueLink, IssueProvider, IssueRelations, IssueStatus,
+    MergeRequestProvider, PipelineProvider, Provider, ProviderResult, Result, UpdateIssueInput,
+    User,
 };
 use tracing::{debug, warn};
 
 use crate::types::{
     AddCommentPayload, CreateIssueFields, CreateIssueLinkPayload, CreateIssuePayload,
-    CreateIssueResponse, IssueKeyRef, IssueLinkTypeName, IssueType, JiraCloudSearchResponse,
-    JiraComment, JiraCommentsResponse, JiraIssue, JiraIssueTypeStatuses, JiraPriority,
-    JiraProjectStatus, JiraSearchResponse, JiraStatus, JiraTransition, JiraTransitionsResponse,
-    JiraUser, PriorityName, ProjectKey, TransitionId, TransitionPayload, UpdateIssueFields,
-    UpdateIssuePayload,
+    CreateIssueResponse, IssueKeyRef, IssueLinkTypeName, IssueType, JiraAttachment,
+    JiraCloudSearchResponse, JiraComment, JiraCommentsResponse, JiraIssue, JiraIssueTypeStatuses,
+    JiraPriority, JiraProjectStatus, JiraSearchResponse, JiraStatus, JiraTransition,
+    JiraTransitionsResponse, JiraUser, PriorityName, ProjectKey, TransitionId, TransitionPayload,
+    UpdateIssueFields, UpdateIssuePayload,
 };
 
 /// Jira deployment flavor.
@@ -825,6 +826,38 @@ fn map_comment(jira_comment: &JiraComment, flavor: JiraFlavor) -> Comment {
     }
 }
 
+/// Map a Jira attachment payload to the provider-agnostic [`AssetMeta`].
+fn map_jira_attachment(raw: &JiraAttachment) -> AssetMeta {
+    let filename = raw
+        .filename
+        .clone()
+        .or_else(|| {
+            raw.content
+                .as_deref()
+                .map(devboy_core::asset::filename_from_url)
+        })
+        .unwrap_or_else(|| format!("attachment-{}", raw.id));
+    let author = raw
+        .author
+        .as_ref()
+        .and_then(|u| map_user(Some(u)))
+        .map(|u| u.name.unwrap_or(u.username));
+
+    AssetMeta {
+        id: raw.id.clone(),
+        filename,
+        mime_type: raw.mime_type.clone(),
+        size: raw.size,
+        url: raw.content.clone(),
+        created_at: raw.created.clone(),
+        author,
+        cached: false,
+        local_path: None,
+        checksum_sha256: None,
+        analysis: None,
+    }
+}
+
 /// Map a unified priority string to a Jira priority name.
 fn priority_to_jira(priority: &str) -> String {
     match priority {
@@ -1310,6 +1343,117 @@ impl IssueProvider for JiraClient {
         Ok(map_relations(&issue, self.flavor, &self.instance_url))
     }
 
+    async fn upload_attachment(
+        &self,
+        issue_key: &str,
+        filename: &str,
+        data: &[u8],
+    ) -> Result<String> {
+        let jira_key = parse_jira_key(issue_key);
+        let url = format!("{}/issue/{}/attachments", self.base_url, jira_key);
+
+        let part = reqwest::multipart::Part::bytes(data.to_vec())
+            .file_name(filename.to_string())
+            .mime_str("application/octet-stream")
+            .map_err(|e| Error::Http(format!("failed to build multipart: {e}")))?;
+        let form = reqwest::multipart::Form::new().part("file", part);
+
+        let response = self
+            .request(reqwest::Method::POST, &url)
+            // Jira requires the X-Atlassian-Token header to bypass its XSRF check
+            // on file uploads: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/
+            .header("X-Atlassian-Token", "no-check")
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+
+        // Jira returns an array of attachment descriptors; we take the first.
+        let attachments: Vec<JiraAttachment> = response
+            .json()
+            .await
+            .map_err(|e| Error::InvalidData(format!("failed to parse attachment response: {e}")))?;
+        let url = attachments
+            .into_iter()
+            .next()
+            .and_then(|a| a.content)
+            .unwrap_or_default();
+        Ok(url)
+    }
+
+    async fn get_issue_attachments(&self, issue_key: &str) -> Result<Vec<AssetMeta>> {
+        let jira_key = parse_jira_key(issue_key);
+        let url = format!("{}/issue/{}?fields=attachment", self.base_url, jira_key);
+        let issue: JiraIssue = self.get(&url).await?;
+        Ok(issue
+            .fields
+            .attachment
+            .iter()
+            .map(map_jira_attachment)
+            .collect())
+    }
+
+    async fn download_attachment(&self, _issue_key: &str, asset_id: &str) -> Result<Vec<u8>> {
+        // Jira exposes attachment content by id:
+        //   GET /rest/api/{v}/attachment/content/{id}
+        let url = format!("{}/attachment/content/{}", self.base_url, asset_id);
+        let response = self
+            .request(reqwest::Method::GET, &url)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| Error::Http(format!("failed to read attachment bytes: {e}")))?;
+        Ok(bytes.to_vec())
+    }
+
+    async fn delete_attachment(&self, _issue_key: &str, asset_id: &str) -> Result<()> {
+        // DELETE /rest/api/{v}/attachment/{id} — 204 on success.
+        let url = format!("{}/attachment/{}", self.base_url, asset_id);
+        let response = self
+            .request(reqwest::Method::DELETE, &url)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+        Ok(())
+    }
+
+    fn asset_capabilities(&self) -> AssetCapabilities {
+        // Jira exposes a full CRUD REST API for attachments on issues.
+        AssetCapabilities {
+            issue: ContextCapabilities {
+                upload: true,
+                download: true,
+                delete: true,
+                list: true,
+                max_file_size: None,
+                allowed_types: Vec::new(),
+            },
+            ..Default::default()
+        }
+    }
+
     fn provider_name(&self) -> &'static str {
         "jira"
     }
@@ -1726,6 +1870,7 @@ mod tests {
                 parent: None,
                 subtasks: vec![],
                 issuelinks: vec![],
+                attachment: vec![],
             },
         };
 
@@ -1784,6 +1929,7 @@ mod tests {
                 parent: None,
                 subtasks: vec![],
                 issuelinks: vec![],
+                attachment: vec![],
             },
         };
 
@@ -1809,6 +1955,7 @@ mod tests {
                 parent: None,
                 subtasks: vec![],
                 issuelinks: vec![],
+                attachment: vec![],
             },
         };
 
@@ -3169,6 +3316,119 @@ mod tests {
             assert_eq!(relations.blocks.len(), 1);
             assert_eq!(relations.blocks[0].issue.key, "jira#PROJ-3");
         }
+
+        // =================================================================
+        // Attachment tests (Phase 2)
+        // =================================================================
+
+        #[tokio::test]
+        async fn test_get_issue_attachments_maps_fields() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/issue/PROJ-1")
+                    .query_param("fields", "attachment");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "10001",
+                    "key": "PROJ-1",
+                    "fields": {
+                        "attachment": [
+                            {
+                                "id": "42",
+                                "filename": "crash.log",
+                                "content": "https://example/rest/api/2/attachment/content/42",
+                                "size": 2048,
+                                "mimeType": "text/plain",
+                                "created": "2024-01-01T00:00:00.000+0000",
+                                "author": {
+                                    "name": "uploader",
+                                    "displayName": "Upload User"
+                                }
+                            }
+                        ]
+                    }
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let assets = client.get_issue_attachments("jira#PROJ-1").await.unwrap();
+            assert_eq!(assets.len(), 1);
+            let a = &assets[0];
+            assert_eq!(a.id, "42");
+            assert_eq!(a.filename, "crash.log");
+            assert_eq!(a.mime_type.as_deref(), Some("text/plain"));
+            assert_eq!(a.size, Some(2048));
+            assert_eq!(a.author.as_deref(), Some("Upload User"));
+        }
+
+        #[tokio::test]
+        async fn test_download_attachment_returns_bytes() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/attachment/content/42");
+                then.status(200).body("stack trace here");
+            });
+
+            let client = create_self_hosted_client(&server);
+            let bytes = client
+                .download_attachment("jira#PROJ-1", "42")
+                .await
+                .unwrap();
+            assert_eq!(bytes, b"stack trace here");
+        }
+
+        #[tokio::test]
+        async fn test_delete_attachment_ok() {
+            let server = MockServer::start();
+
+            let mock = server.mock(|when, then| {
+                when.method(DELETE).path("/attachment/42");
+                then.status(204);
+            });
+
+            let client = create_self_hosted_client(&server);
+            client.delete_attachment("jira#PROJ-1", "42").await.unwrap();
+            mock.assert();
+        }
+
+        #[tokio::test]
+        async fn test_upload_attachment_returns_content_url() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(POST)
+                    .path("/issue/PROJ-1/attachments")
+                    .header("X-Atlassian-Token", "no-check");
+                then.status(200).json_body(serde_json::json!([
+                    {
+                        "id": "99",
+                        "filename": "report.txt",
+                        "content": "https://example/rest/api/2/attachment/content/99",
+                        "size": 10
+                    }
+                ]));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let url = client
+                .upload_attachment("jira#PROJ-1", "report.txt", b"0123456789")
+                .await
+                .unwrap();
+            assert_eq!(url, "https://example/rest/api/2/attachment/content/99");
+        }
+
+        #[tokio::test]
+        async fn test_jira_asset_capabilities() {
+            let server = MockServer::start();
+            let client = create_self_hosted_client(&server);
+            let caps = client.asset_capabilities();
+            assert!(caps.issue.upload);
+            assert!(caps.issue.download);
+            assert!(caps.issue.delete);
+            assert!(caps.issue.list);
+        }
     }
 
     // =========================================================================
@@ -3193,6 +3453,7 @@ mod tests {
                 parent: None,
                 subtasks: vec![],
                 issuelinks: vec![],
+                attachment: vec![],
             },
         };
 
@@ -3227,6 +3488,7 @@ mod tests {
                 parent: None,
                 subtasks: vec![],
                 issuelinks: vec![],
+                attachment: vec![],
             },
         });
 
@@ -3246,6 +3508,7 @@ mod tests {
                 parent: Some(parent),
                 subtasks: vec![],
                 issuelinks: vec![],
+                attachment: vec![],
             },
         };
 
@@ -3293,6 +3556,7 @@ mod tests {
                             parent: None,
                             subtasks: vec![],
                             issuelinks: vec![],
+                            attachment: vec![],
                         },
                     },
                     JiraIssue {
@@ -3311,10 +3575,12 @@ mod tests {
                             parent: None,
                             subtasks: vec![],
                             issuelinks: vec![],
+                            attachment: vec![],
                         },
                     },
                 ],
                 issuelinks: vec![],
+                attachment: vec![],
             },
         };
 
@@ -3369,6 +3635,7 @@ mod tests {
                                 parent: None,
                                 subtasks: vec![],
                                 issuelinks: vec![],
+                                attachment: vec![],
                             },
                         })),
                         inward_issue: None,
@@ -3398,10 +3665,12 @@ mod tests {
                                 parent: None,
                                 subtasks: vec![],
                                 issuelinks: vec![],
+                                attachment: vec![],
                             },
                         })),
                     },
                 ],
+                attachment: vec![],
             },
         };
 
@@ -3456,6 +3725,7 @@ mod tests {
                                 parent: None,
                                 subtasks: vec![],
                                 issuelinks: vec![],
+                                attachment: vec![],
                             },
                         })),
                         inward_issue: None,
@@ -3485,10 +3755,12 @@ mod tests {
                                 parent: None,
                                 subtasks: vec![],
                                 issuelinks: vec![],
+                                attachment: vec![],
                             },
                         })),
                     },
                 ],
+                attachment: vec![],
             },
         };
 
@@ -3540,10 +3812,12 @@ mod tests {
                             parent: None,
                             subtasks: vec![],
                             issuelinks: vec![],
+                            attachment: vec![],
                         },
                     })),
                     inward_issue: None,
                 }],
+                attachment: vec![],
             },
         };
 
@@ -3585,6 +3859,7 @@ mod tests {
                         parent: None,
                         subtasks: vec![],
                         issuelinks: vec![],
+                        attachment: vec![],
                     },
                 })),
                 subtasks: vec![JiraIssue {
@@ -3603,6 +3878,7 @@ mod tests {
                         parent: None,
                         subtasks: vec![],
                         issuelinks: vec![],
+                        attachment: vec![],
                     },
                 }],
                 issuelinks: vec![JiraIssueLink {
@@ -3628,10 +3904,12 @@ mod tests {
                             parent: None,
                             subtasks: vec![],
                             issuelinks: vec![],
+                            attachment: vec![],
                         },
                     })),
                     inward_issue: None,
                 }],
+                attachment: vec![],
             },
         };
 

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -828,14 +828,13 @@ fn map_comment(jira_comment: &JiraComment, flavor: JiraFlavor) -> Comment {
 
 /// Map a Jira attachment payload to the provider-agnostic [`AssetMeta`].
 fn map_jira_attachment(raw: &JiraAttachment) -> AssetMeta {
+    // Prefer the explicit `filename` from Jira. Don't fall back to
+    // `filename_from_url(content)` because Jira content URLs typically
+    // end with `/attachment/content/{id}`, producing useless filenames
+    // like "42". Fall back to `attachment-{id}` instead.
     let filename = raw
         .filename
         .clone()
-        .or_else(|| {
-            raw.content
-                .as_deref()
-                .map(devboy_core::asset::filename_from_url)
-        })
         .unwrap_or_else(|| format!("attachment-{}", raw.id));
     let author = raw
         .author
@@ -1383,7 +1382,12 @@ impl IssueProvider for JiraClient {
             .into_iter()
             .next()
             .and_then(|a| a.content)
-            .unwrap_or_default();
+            .filter(|u| !u.is_empty())
+            .ok_or_else(|| {
+                Error::InvalidData(
+                    "Jira upload returned no attachment with a content URL".to_string(),
+                )
+            })?;
         Ok(url)
     }
 

--- a/crates/plugins/api/jira/src/types.rs
+++ b/crates/plugins/api/jira/src/types.rs
@@ -80,6 +80,35 @@ pub struct JiraIssueFields {
     /// Issue links
     #[serde(default)]
     pub issuelinks: Vec<JiraIssueLink>,
+    /// Attachments on the issue (present when the caller requests
+    /// `fields=attachment` or uses `fields=*all`).
+    #[serde(default)]
+    pub attachment: Vec<JiraAttachment>,
+}
+
+/// Jira attachment as returned inside `fields.attachment`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct JiraAttachment {
+    /// Attachment id (numeric string).
+    pub id: String,
+    /// Original filename.
+    #[serde(default)]
+    pub filename: Option<String>,
+    /// Direct download URL (`content` in the Jira API).
+    #[serde(default)]
+    pub content: Option<String>,
+    /// Size in bytes.
+    #[serde(default)]
+    pub size: Option<u64>,
+    /// MIME type.
+    #[serde(default, rename = "mimeType")]
+    pub mime_type: Option<String>,
+    /// Creation timestamp (ISO 8601).
+    #[serde(default)]
+    pub created: Option<String>,
+    /// Author — Jira uses `author` inside the attachment object.
+    #[serde(default)]
+    pub author: Option<JiraUser>,
 }
 
 /// Jira issue status.


### PR DESCRIPTION
## Summary

Phase 2 of Asset Management (epic #120). Stacked on top of #126 (Phase 1) — targets the Phase 1 branch so the diff stays focused on provider wiring.

Closes #122.

## What's included

### \`devboy-core\`

- Extend \`IssueProvider\` with \`get_issue_attachments\`, \`download_attachment\`, \`delete_attachment\`, and \`asset_capabilities\`.
- Extend \`MergeRequestProvider\` with \`get_mr_attachments\`, \`download_mr_attachment\`, \`delete_mr_attachment\`.
- All new methods are optional with sensible defaults (\`ProviderUnsupported\` / empty caps) so downstream consumers don't break.
- New shared helper \`parse_markdown_attachments\` + \`MarkdownAttachment\` — used by GitLab and GitHub to reconstruct attachment lists from issue/MR bodies.

### Provider CRUD matrix

| Provider | Upload | Download | List | Delete | Notes |
|----------|--------|----------|------|--------|-------|
| **ClickUp** | ✅ existed | ✅ new | ✅ new | ❌ | No public delete endpoint |
| **Jira** | ✅ new | ✅ new | ✅ new | ✅ new | Full REST CRUD |
| **GitLab** | ✅ new | ✅ new | ✅ new | ❌ | Project-level uploads are immutable; lists reconstructed from markdown |
| **GitHub** | ❌ | ✅ new | ✅ new | ❌ | No public upload API for comments; lists reconstructed from markdown |

### Design notes

- **ClickUp**: attachments come embedded on the task payload. Download re-fetches the task to resolve the attachment's URL, then pulls it through the authenticated client so both public and proxied ClickUp deployments work.
- **Jira**: uses the \`X-Atlassian-Token: no-check\` header required for the multipart upload endpoint. Delete is a simple \`DELETE /attachment/{id}\`.
- **GitLab**: there is no per-issue attachment endpoint, so \`upload_attachment\` delegates to a new private \`upload_project_file\` that posts to \`/projects/{id}/uploads\` and returns an absolute URL. List and download work against the markdown references already embedded in issues / MRs.
- **GitHub**: we can't upload (no public API) but we can still surface what's already there by parsing issue / PR / comment bodies. Downloads go straight to the CDN URL.
- **Capabilities**: each provider returns its own \`AssetCapabilities\` so Phase 3 can surface them through enrichment before an agent calls anything it can't do.

## Tests

- **13** new inline unit tests for \`parse_markdown_attachments\` and \`filename_from_url\` in \`devboy-core\` (covering image/link syntax, URL dedup, titles, dot-in-path fallback, empty input).
- **7** new ClickUp tests — mappers + httpmock integration for list / download / capabilities.
- **5** new Jira integration tests — upload, list, download, delete, capabilities.
- **4** new GitLab integration tests — upload, list (deduped across body and notes), download of relative \`/uploads/...\`, capabilities.
- **3** new GitHub integration tests — list from body+comments, download from CDN-like URL, capabilities.

\`cargo test --workspace\` — **813 tests, all green**.

## Local checks

- \`cargo fmt --all -- --check\` — clean
- \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- \`cargo llvm-cov\` on the touched crates — **93.67%** line coverage overall; every new module stays above 90%.

## Not in this PR

- MCP tool registration (\`upload_asset\` / \`get_assets\` / \`download_asset\` / \`delete_asset\` / \`replace_asset\`) — see #123
- Built-in Level 1-2 processors — see #124
- Level 3 semantic analysis — see #125

## Review notes

- This PR targets \`feat/121-asset-management-phase1\` and should be rebased / re-targeted onto \`main\` once Phase 1 (#126) lands.
- Provider implementations intentionally stick to existing patterns (inline tests, httpmock integration, \`handle_response\`) — no structural refactors.

## Related

- Epic: #120
- Subtask: #122
- Stacked on: #126 (Phase 1)
- Design: ADR-010 / ADR-011 in meteora/devboy-cloud-monorepo