### PR TITLE
fix: add Jira wiki markup hint to tool descriptions (#128)

### DIFF
--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -211,7 +211,7 @@ define_tools! {
                 },
                 "description": {
                     "type": "string",
-                    "description": "Issue description/body"
+                    "description": "Issue description/body. For Jira Server (self-hosted, API v2) use Jira wiki markup (h2. Heading, *bold*, {code:java}...{code}, * list item). For Jira Cloud and other providers use markdown."
                 },
                 "labels": {
                     "type": "array",
@@ -257,7 +257,7 @@ define_tools! {
                 },
                 "description": {
                     "type": "string",
-                    "description": "New description"
+                    "description": "New description. For Jira Server (self-hosted, API v2) use Jira wiki markup (h2. Heading, *bold*, {code:java}...{code}, * list item). For Jira Cloud and other providers use markdown."
                 },
                 "state": {
                     "type": "string",
@@ -299,7 +299,7 @@ define_tools! {
                 },
                 "body": {
                     "type": "string",
-                    "description": "Comment text"
+                    "description": "Comment text. For Jira Server (self-hosted, API v2) use Jira wiki markup. For Jira Cloud and other providers use markdown."
                 }
             }
         }

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -211,7 +211,7 @@ define_tools! {
                 },
                 "description": {
                     "type": "string",
-                    "description": "Issue description/body. For Jira Server (self-hosted, API v2) use Jira wiki markup (h2. Heading, *bold*, {code:java}...{code}, * list item). For Jira Cloud and other providers use markdown."
+                    "description": "Issue description/body. For Jira Server (self-hosted, API v2) use Jira wiki markup (h2. Heading, *bold*, {code:java}...{code}, * list item). For Jira Cloud, provide plain text (converted to ADF automatically). Other providers support markdown."
                 },
                 "labels": {
                     "type": "array",
@@ -257,7 +257,7 @@ define_tools! {
                 },
                 "description": {
                     "type": "string",
-                    "description": "New description. For Jira Server (self-hosted, API v2) use Jira wiki markup (h2. Heading, *bold*, {code:java}...{code}, * list item). For Jira Cloud and other providers use markdown."
+                    "description": "New description. For Jira Server (self-hosted, API v2) use Jira wiki markup (h2. Heading, *bold*, {code:java}...{code}, * list item). For Jira Cloud, provide plain text (converted to ADF automatically). Other providers support markdown."
                 },
                 "state": {
                     "type": "string",
@@ -299,7 +299,7 @@ define_tools! {
                 },
                 "body": {
                     "type": "string",
-                    "description": "Comment text. For Jira Server (self-hosted, API v2) use Jira wiki markup. For Jira Cloud and other providers use markdown."
+                    "description": "Comment text. For Jira Server (self-hosted, API v2) use Jira wiki markup. For Jira Cloud, provide plain text (converted to ADF automatically). Other providers support markdown."
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Added Jira wiki markup format hints to `description` and `body` field descriptions in `create_issue`, `update_issue`, and `add_issue_comment` MCP tool schemas
- Jira Server (self-hosted, API v2) expects wiki markup, not markdown — AI agents need to know this to format text correctly

Closes #128

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes