### PR TITLE
fix(jira): support projectKey override and nativeQuery in get_issues (#130)

### DIFF
--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -121,6 +121,13 @@ pub struct IssueFilter {
     pub sort_by: Option<String>,
     /// Sort order ("asc" or "desc")
     pub sort_order: Option<String>,
+    /// Project key override (e.g., "PROJ"). When set, overrides the default project
+    /// configured for the provider. Ignored by providers that don't support it.
+    pub project_key: Option<String>,
+    /// Native query passed directly to the provider (e.g., Jira JQL).
+    /// Takes precedence over other filters. If the query doesn't contain a project
+    /// clause, the provider may inject one automatically.
+    pub native_query: Option<String>,
 }
 
 /// Input for creating a new issue.

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -298,6 +298,10 @@ struct GetIssuesParams {
     offset: Option<u32>,
     sort_by: Option<String>,
     sort_order: Option<String>,
+    #[serde(rename = "projectKey")]
+    project_key: Option<String>,
+    #[serde(rename = "nativeQuery")]
+    native_query: Option<String>,
     /// Token budget for response size control (consumed by format layer via execute_and_format).
     #[allow(dead_code)]
     budget: Option<usize>,
@@ -319,6 +323,8 @@ async fn execute_get_issues(
         offset: params.offset,
         sort_by: params.sort_by,
         sort_order: params.sort_order,
+        project_key: params.project_key,
+        native_query: params.native_query,
     };
     let result = provider.get_issues(filter).await?;
     let meta = ResultMeta {
@@ -978,6 +984,8 @@ async fn execute_get_epics(
         offset: params.offset,
         sort_by: None,
         sort_order: None,
+        project_key: None,
+        native_query: None,
     };
     let result = provider.get_issues(filter).await?;
     let mut epics = result.items;

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -32,6 +32,8 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("offset", PropertySchema::integer("Number of results to skip (default: 0)", Some(0.0), None));
                 s.add_property("sort_by", PropertySchema::string_enum(&["created_at", "updated_at"], "Sort by field (default: updated_at)"));
                 s.add_property("sort_order", PropertySchema::string_enum(&["asc", "desc"], "Sort order (default: desc)"));
+                s.add_property("projectKey", PropertySchema::string("Project key to filter issues (e.g., \"PROJ\"). Overrides default project. Removed by providers that don't support it."));
+                s.add_property("nativeQuery", PropertySchema::string("Native query passed directly to provider (e.g., Jira JQL). Takes precedence over other filters except projectKey injection."));
                 s
             },
         },
@@ -514,12 +516,14 @@ mod tests {
         let get_issues = tools.iter().find(|t| t.name == "get_issues").unwrap();
         let json = serde_json::to_string_pretty(get_issues).unwrap();
 
-        // get_issues should have state, search, labels, assignee, limit, offset, sort_by, sort_order
+        // get_issues should have state, search, labels, assignee, limit, offset, sort_by, sort_order, projectKey, nativeQuery
         assert!(json.contains("state"));
         assert!(json.contains("search"));
         assert!(json.contains("labels"));
         assert!(json.contains("assignee"));
         assert!(json.contains("limit"));
+        assert!(json.contains("projectKey"));
+        assert!(json.contains("nativeQuery"));
     }
 
     #[test]

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -33,7 +33,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("sort_by", PropertySchema::string_enum(&["created_at", "updated_at"], "Sort by field (default: updated_at)"));
                 s.add_property("sort_order", PropertySchema::string_enum(&["asc", "desc"], "Sort order (default: desc)"));
                 s.add_property("projectKey", PropertySchema::string("Project key to filter issues (e.g., \"PROJ\"). Overrides default project. Removed by providers that don't support it."));
-                s.add_property("nativeQuery", PropertySchema::string("Native query passed directly to provider (e.g., Jira JQL). Takes precedence over other filters except projectKey injection."));
+                s.add_property("nativeQuery", PropertySchema::string("Native query passed directly to provider (e.g., Jira JQL). Replaces auto-generated filters. If the query omits a project clause, the default project is auto-injected."));
                 s
             },
         },

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -772,6 +772,7 @@ impl ToolHandler {
             offset: Some(params.offset.unwrap_or(0) as u32),
             sort_by: params.sort_by,
             sort_order: params.sort_order,
+            ..Default::default()
         };
 
         let mut all_issues = Vec::new();

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -772,7 +772,8 @@ impl ToolHandler {
             offset: Some(params.offset.unwrap_or(0) as u32),
             sort_by: params.sort_by,
             sort_order: params.sort_order,
-            ..Default::default()
+            project_key: params.project_key,
+            native_query: params.native_query,
         };
 
         let mut all_issues = Vec::new();
@@ -1888,6 +1889,10 @@ struct GetIssuesParams {
     provider: Option<String>,
     sort_by: Option<String>,
     sort_order: Option<String>,
+    #[serde(rename = "projectKey")]
+    project_key: Option<String>,
+    #[serde(rename = "nativeQuery")]
+    native_query: Option<String>,
     budget: Option<usize>,
     chunk: Option<usize>,
 }

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -910,6 +910,32 @@ fn generic_status_to_category(status: &str) -> Option<&'static str> {
     }
 }
 
+/// Check if a keyword appears outside quoted strings in JQL.
+fn has_unquoted_keyword(jql: &str, keyword: &str) -> bool {
+    let lower = jql.to_lowercase();
+    let kw = keyword.to_lowercase();
+    let bytes = lower.as_bytes();
+    let mut in_quote = false;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && in_quote && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
+        if bytes[i] == b'"' {
+            in_quote = !in_quote;
+            i += 1;
+            continue;
+        }
+        if !in_quote && i + kw.len() <= bytes.len() && lower[i..i + kw.len()] == kw {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
 /// Get the Jira instance URL from the API base URL.
 fn instance_url_from_base(base_url: &str) -> String {
     base_url
@@ -932,7 +958,12 @@ impl IssueProvider for JiraClient {
         let offset = filter.offset.unwrap_or(0);
 
         // Resolve effective project key: filter override → self.project_key
-        let effective_project = filter.project_key.as_deref().unwrap_or(&self.project_key);
+        // Treat blank project_key as unset
+        let effective_project = filter
+            .project_key
+            .as_deref()
+            .filter(|k| !k.trim().is_empty())
+            .unwrap_or(&self.project_key);
 
         // Build JQL query — native_query takes precedence over filter-based construction
         let escaped_project = escape_jql(effective_project);
@@ -995,7 +1026,7 @@ impl IssueProvider for JiraClient {
             Some("asc") => "ASC",
             _ => "DESC",
         };
-        let has_order_by = jql.to_lowercase().contains("order by");
+        let has_order_by = has_unquoted_keyword(&jql, "order by");
         let jql_with_order = if has_order_by {
             jql
         } else {

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -849,30 +849,52 @@ fn escape_jql(value: &str) -> String {
 
 /// Check whether a JQL string already contains a project filter clause.
 /// Matches `project` as a JQL field name (word boundary) followed by an operator.
-/// Avoids false positives like `summary ~ "project information"`.
+/// Skips occurrences inside quoted strings to avoid false positives.
 fn has_project_clause(jql: &str) -> bool {
     let lower = jql.to_lowercase();
     let bytes = lower.as_bytes();
     let keyword = b"project";
+    let mut in_quote = false;
+    let mut i = 0;
 
-    for (i, window) in bytes.windows(keyword.len()).enumerate() {
-        if window != keyword {
+    while i < bytes.len() {
+        // Track quoted strings — skip content inside quotes
+        if bytes[i] == b'\\' && in_quote && i + 1 < bytes.len() {
+            i += 2; // skip escaped character
             continue;
         }
-        // Check word boundary before "project"
-        if i > 0 && bytes[i - 1].is_ascii_alphanumeric() {
+        if bytes[i] == b'"' {
+            in_quote = !in_quote;
+            i += 1;
             continue;
         }
-        // Check what follows "project" — skip whitespace, then expect operator
-        let after = &lower[i + keyword.len()..];
-        let trimmed = after.trim_start();
-        if trimmed.starts_with('=')
-            || trimmed.starts_with('~')
-            || trimmed.starts_with("in ")
-            || trimmed.starts_with("in(")
-        {
-            return true;
+        if in_quote {
+            i += 1;
+            continue;
         }
+
+        // Check for "project" keyword at position i
+        if i + keyword.len() <= bytes.len() && &bytes[i..i + keyword.len()] == keyword {
+            // Word boundary before: not preceded by alphanumeric or underscore
+            if i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_') {
+                i += 1;
+                continue;
+            }
+            // Check what follows — skip whitespace, then expect a JQL operator
+            let after = &lower[i + keyword.len()..];
+            let trimmed = after.trim_start();
+            if trimmed.starts_with("!=")
+                || trimmed.starts_with("not in ")
+                || trimmed.starts_with("not in(")
+                || trimmed.starts_with('=')
+                || trimmed.starts_with('~')
+                || trimmed.starts_with("in ")
+                || trimmed.starts_with("in(")
+            {
+                return true;
+            }
+        }
+        i += 1;
     }
     false
 }
@@ -939,7 +961,7 @@ impl IssueProvider for JiraClient {
                     "all" => {} // No filter
                     other => {
                         // Exact status name
-                        jql_parts.push(format!("status = \"{}\"", other));
+                        jql_parts.push(format!("status = \"{}\"", escape_jql(other)));
                     }
                 }
             }
@@ -961,7 +983,7 @@ impl IssueProvider for JiraClient {
             jql_parts.join(" AND ")
         };
 
-        // Add ORDER BY
+        // Add ORDER BY — skip if native_query already contains one
         let order_by = match filter.sort_by.as_deref() {
             Some("created_at" | "created") => "created",
             Some("priority") => "priority",
@@ -971,7 +993,12 @@ impl IssueProvider for JiraClient {
             Some("asc") => "ASC",
             _ => "DESC",
         };
-        let jql_with_order = format!("{} ORDER BY {} {}", jql, order_by, order);
+        let has_order_by = jql.to_lowercase().contains("order by");
+        let jql_with_order = if has_order_by {
+            jql
+        } else {
+            format!("{} ORDER BY {} {}", jql, order_by, order)
+        };
 
         let instance_url = &self.instance_url;
 
@@ -3329,7 +3356,7 @@ mod tests {
 
         #[test]
         fn test_has_project_clause() {
-            // Positive cases
+            // Positive cases — standard operators
             assert!(has_project_clause("project = \"PROJ\""));
             assert!(has_project_clause("project = PROJ AND status = Open"));
             assert!(has_project_clause("project IN (\"A\", \"B\")"));
@@ -3337,11 +3364,19 @@ mod tests {
             assert!(has_project_clause("PROJECT = KEY")); // case-insensitive
             assert!(has_project_clause("status = Open AND project = X"));
             assert!(has_project_clause("project ~ KEY")); // contains operator
-            // Negative cases
+            // Positive cases — negation operators
+            assert!(has_project_clause("project != \"PROJ\""));
+            assert!(has_project_clause("project NOT IN (\"A\", \"B\")"));
+            assert!(has_project_clause("project not in(A)"));
+            // Negative cases — no project clause
             assert!(!has_project_clause("fixVersion = \"1.0\""));
+            assert!(!has_project_clause("status = Done"));
+            // Negative cases — "project" inside quoted strings
             assert!(!has_project_clause("summary ~ \"project plan\""));
             assert!(!has_project_clause("summary ~ \"project information\""));
-            assert!(!has_project_clause("status = Done"));
+            assert!(!has_project_clause("summary ~ \"project = foo\""));
+            // Negative cases — underscore word boundary
+            assert!(!has_project_clause("my_project = X"));
         }
 
         // =================================================================

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -914,6 +914,7 @@ fn generic_status_to_category(status: &str) -> Option<&'static str> {
 fn has_unquoted_keyword(jql: &str, keyword: &str) -> bool {
     let lower = jql.to_lowercase();
     let kw = keyword.to_lowercase();
+    let kw_bytes = kw.as_bytes();
     let bytes = lower.as_bytes();
     let mut in_quote = false;
     let mut i = 0;
@@ -928,7 +929,10 @@ fn has_unquoted_keyword(jql: &str, keyword: &str) -> bool {
             i += 1;
             continue;
         }
-        if !in_quote && i + kw.len() <= bytes.len() && lower[i..i + kw.len()] == kw {
+        if !in_quote
+            && i + kw_bytes.len() <= bytes.len()
+            && bytes[i..i + kw_bytes.len()] == *kw_bytes
+        {
             return true;
         }
         i += 1;

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -3336,6 +3336,7 @@ mod tests {
             assert!(has_project_clause("project in(A, B)"));
             assert!(has_project_clause("PROJECT = KEY")); // case-insensitive
             assert!(has_project_clause("status = Open AND project = X"));
+            assert!(has_project_clause("project ~ KEY")); // contains operator
             // Negative cases
             assert!(!has_project_clause("fixVersion = \"1.0\""));
             assert!(!has_project_clause("summary ~ \"project plan\""));

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -847,6 +847,17 @@ fn escape_jql(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
+/// Check whether a JQL string already contains a project filter clause.
+/// Matches patterns like `project = KEY`, `project IN (...)`, `project ~ ...`.
+fn has_project_clause(jql: &str) -> bool {
+    let lower = jql.to_lowercase();
+    // Look for "project" followed by optional whitespace and an operator
+    lower.contains("project =")
+        || lower.contains("project in")
+        || lower.contains("project in(")
+        || lower.contains("project ~")
+}
+
 /// This maps user-friendly aliases to the correct category key, used as fallback
 /// when the exact status name is not found in available transitions.
 fn generic_status_to_category(status: &str) -> Option<&'static str> {
@@ -879,41 +890,61 @@ impl IssueProvider for JiraClient {
         }
         let offset = filter.offset.unwrap_or(0);
 
-        // Build JQL query
-        let mut jql_parts: Vec<String> = vec![format!("project = \"{}\"", self.project_key)];
+        // Resolve effective project key: filter override → self.project_key
+        let effective_project = filter
+            .project_key
+            .as_deref()
+            .unwrap_or(&self.project_key);
 
-        // State filter
-        if let Some(state) = &filter.state {
-            match state.as_str() {
-                "open" | "opened" => {
-                    jql_parts.push("statusCategory != Done".to_string());
-                }
-                "closed" | "done" => {
-                    jql_parts.push("statusCategory = Done".to_string());
-                }
-                "all" => {} // No filter
-                other => {
-                    // Exact status name
-                    jql_parts.push(format!("status = \"{}\"", other));
+        // Build JQL query — native_query takes precedence over filter-based construction
+        let jql = if let Some(native) = &filter.native_query {
+            // If native query doesn't mention a project clause, prepend one
+            // (Jira Cloud requires a project filter)
+            if has_project_clause(native) {
+                native.clone()
+            } else {
+                format!(
+                    "project = \"{}\" AND {}",
+                    effective_project, native
+                )
+            }
+        } else {
+            let mut jql_parts: Vec<String> =
+                vec![format!("project = \"{}\"", effective_project)];
+
+            // State filter
+            if let Some(state) = &filter.state {
+                match state.as_str() {
+                    "open" | "opened" => {
+                        jql_parts.push("statusCategory != Done".to_string());
+                    }
+                    "closed" | "done" => {
+                        jql_parts.push("statusCategory = Done".to_string());
+                    }
+                    "all" => {} // No filter
+                    other => {
+                        // Exact status name
+                        jql_parts.push(format!("status = \"{}\"", other));
+                    }
                 }
             }
-        }
 
-        if let Some(search) = &filter.search {
-            jql_parts.push(format!("summary ~ \"{}\"", escape_jql(search)));
-        }
-
-        if let Some(labels) = &filter.labels {
-            for label in labels {
-                jql_parts.push(format!("labels = \"{}\"", escape_jql(label)));
+            if let Some(search) = &filter.search {
+                jql_parts.push(format!("summary ~ \"{}\"", escape_jql(search)));
             }
-        }
 
-        if let Some(assignee) = &filter.assignee {
-            jql_parts.push(format!("assignee = \"{}\"", escape_jql(assignee)));
-        }
+            if let Some(labels) = &filter.labels {
+                for label in labels {
+                    jql_parts.push(format!("labels = \"{}\"", escape_jql(label)));
+                }
+            }
 
-        let jql = jql_parts.join(" AND ");
+            if let Some(assignee) = &filter.assignee {
+                jql_parts.push(format!("assignee = \"{}\"", escape_jql(assignee)));
+            }
+
+            jql_parts.join(" AND ")
+        };
 
         // Add ORDER BY
         let order_by = match filter.sort_by.as_deref() {
@@ -2133,6 +2164,130 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_get_issues_project_key_override() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/search")
+                    .query_param_includes("jql", "project = \"OTHER\"");
+                then.status(200).json_body(serde_json::json!({
+                    "issues": [sample_issue_json()],
+                    "startAt": 0,
+                    "maxResults": 20,
+                    "total": 1
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let issues = client
+                .get_issues(IssueFilter {
+                    project_key: Some("OTHER".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+
+            assert_eq!(issues.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_get_issues_native_query_passthrough() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/search")
+                    .query_param_includes("jql", "project = \"CUSTOM\" AND fixVersion = \"1.0\"");
+                then.status(200).json_body(serde_json::json!({
+                    "issues": [sample_issue_json()],
+                    "startAt": 0,
+                    "maxResults": 20,
+                    "total": 1
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let issues = client
+                .get_issues(IssueFilter {
+                    native_query: Some(
+                        "project = \"CUSTOM\" AND fixVersion = \"1.0\"".to_string(),
+                    ),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+
+            assert_eq!(issues.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_get_issues_native_query_auto_injects_project() {
+            let server = MockServer::start();
+
+            // Client is configured with project_key = "PROJ", native_query has no project clause
+            // → should auto-prepend project = "PROJ"
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/search")
+                    .query_param_includes("jql", "project = \"PROJ\" AND fixVersion = \"2.0\"");
+                then.status(200).json_body(serde_json::json!({
+                    "issues": [sample_issue_json()],
+                    "startAt": 0,
+                    "maxResults": 20,
+                    "total": 1
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let issues = client
+                .get_issues(IssueFilter {
+                    native_query: Some("fixVersion = \"2.0\"".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+
+            assert_eq!(issues.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_get_issues_native_query_with_project_in() {
+            let server = MockServer::start();
+
+            // Native query already has "project IN (...)" — should NOT prepend another project clause
+            server.mock(|when, then| {
+                when.method(GET).path("/search").query_param_includes(
+                    "jql",
+                    "project IN (\"A\", \"B\") AND status = \"Open\"",
+                );
+                then.status(200).json_body(serde_json::json!({
+                    "issues": [sample_issue_json()],
+                    "startAt": 0,
+                    "maxResults": 20,
+                    "total": 1
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let issues = client
+                .get_issues(IssueFilter {
+                    native_query: Some(
+                        "project IN (\"A\", \"B\") AND status = \"Open\"".to_string(),
+                    ),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+
+            assert_eq!(issues.len(), 1);
+        }
+
+        #[tokio::test]
         async fn test_get_issue() {
             let server = MockServer::start();
 
@@ -3096,6 +3251,21 @@ mod tests {
                 escape_jql(r#"both "and" \ here"#),
                 r#"both \"and\" \\ here"#
             );
+        }
+
+        #[test]
+        fn test_has_project_clause() {
+            // Positive cases
+            assert!(has_project_clause("project = \"PROJ\""));
+            assert!(has_project_clause("project = PROJ AND status = Open"));
+            assert!(has_project_clause("project IN (\"A\", \"B\")"));
+            assert!(has_project_clause("project in(A, B)"));
+            assert!(has_project_clause("PROJECT = KEY")); // case-insensitive
+            assert!(has_project_clause("status = Open AND project = X"));
+            // Negative cases
+            assert!(!has_project_clause("fixVersion = \"1.0\""));
+            assert!(!has_project_clause("summary ~ \"project plan\""));
+            assert!(!has_project_clause("status = Done"));
         }
 
         // =================================================================

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -943,6 +943,8 @@ impl IssueProvider for JiraClient {
             // (Jira Cloud requires a project filter)
             if has_project_clause(native) {
                 native.clone()
+            } else if native.trim_start().to_lowercase().starts_with("order by") {
+                format!("project = \"{}\" {}", escaped_project, native)
             } else {
                 format!("project = \"{}\" AND {}", escaped_project, native)
             }
@@ -2379,6 +2381,37 @@ mod tests {
             let issues = client
                 .get_issues(IssueFilter {
                     native_query: Some("".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+
+            assert_eq!(issues.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_get_issues_native_query_order_by_only() {
+            let server = MockServer::start();
+
+            // native_query = "ORDER BY created ASC" without filters
+            // → should produce "project = "PROJ" ORDER BY created ASC" (no AND)
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/search")
+                    .query_param_includes("jql", "project = \"PROJ\" ORDER BY created ASC");
+                then.status(200).json_body(serde_json::json!({
+                    "issues": [sample_issue_json()],
+                    "startAt": 0,
+                    "maxResults": 20,
+                    "total": 1
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let issues = client
+                .get_issues(IssueFilter {
+                    native_query: Some("ORDER BY created ASC".to_string()),
                     ..Default::default()
                 })
                 .await

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -891,10 +891,7 @@ impl IssueProvider for JiraClient {
         let offset = filter.offset.unwrap_or(0);
 
         // Resolve effective project key: filter override → self.project_key
-        let effective_project = filter
-            .project_key
-            .as_deref()
-            .unwrap_or(&self.project_key);
+        let effective_project = filter.project_key.as_deref().unwrap_or(&self.project_key);
 
         // Build JQL query — native_query takes precedence over filter-based construction
         let jql = if let Some(native) = &filter.native_query {
@@ -903,14 +900,10 @@ impl IssueProvider for JiraClient {
             if has_project_clause(native) {
                 native.clone()
             } else {
-                format!(
-                    "project = \"{}\" AND {}",
-                    effective_project, native
-                )
+                format!("project = \"{}\" AND {}", effective_project, native)
             }
         } else {
-            let mut jql_parts: Vec<String> =
-                vec![format!("project = \"{}\"", effective_project)];
+            let mut jql_parts: Vec<String> = vec![format!("project = \"{}\"", effective_project)];
 
             // State filter
             if let Some(state) = &filter.state {
@@ -2211,9 +2204,7 @@ mod tests {
             let client = create_self_hosted_client(&server);
             let issues = client
                 .get_issues(IssueFilter {
-                    native_query: Some(
-                        "project = \"CUSTOM\" AND fixVersion = \"1.0\"".to_string(),
-                    ),
+                    native_query: Some("project = \"CUSTOM\" AND fixVersion = \"1.0\"".to_string()),
                     ..Default::default()
                 })
                 .await
@@ -2260,10 +2251,9 @@ mod tests {
 
             // Native query already has "project IN (...)" — should NOT prepend another project clause
             server.mock(|when, then| {
-                when.method(GET).path("/search").query_param_includes(
-                    "jql",
-                    "project IN (\"A\", \"B\") AND status = \"Open\"",
-                );
+                when.method(GET)
+                    .path("/search")
+                    .query_param_includes("jql", "project IN (\"A\", \"B\") AND status = \"Open\"");
                 then.status(200).json_body(serde_json::json!({
                     "issues": [sample_issue_json()],
                     "startAt": 0,

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -848,14 +848,33 @@ fn escape_jql(value: &str) -> String {
 }
 
 /// Check whether a JQL string already contains a project filter clause.
-/// Matches patterns like `project = KEY`, `project IN (...)`, `project ~ ...`.
+/// Matches `project` as a JQL field name (word boundary) followed by an operator.
+/// Avoids false positives like `summary ~ "project information"`.
 fn has_project_clause(jql: &str) -> bool {
     let lower = jql.to_lowercase();
-    // Look for "project" followed by optional whitespace and an operator
-    lower.contains("project =")
-        || lower.contains("project in")
-        || lower.contains("project in(")
-        || lower.contains("project ~")
+    let bytes = lower.as_bytes();
+    let keyword = b"project";
+
+    for (i, window) in bytes.windows(keyword.len()).enumerate() {
+        if window != keyword {
+            continue;
+        }
+        // Check word boundary before "project"
+        if i > 0 && bytes[i - 1].is_ascii_alphanumeric() {
+            continue;
+        }
+        // Check what follows "project" — skip whitespace, then expect operator
+        let after = &lower[i + keyword.len()..];
+        let trimmed = after.trim_start();
+        if trimmed.starts_with('=')
+            || trimmed.starts_with('~')
+            || trimmed.starts_with("in ")
+            || trimmed.starts_with("in(")
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// This maps user-friendly aliases to the correct category key, used as fallback
@@ -894,16 +913,19 @@ impl IssueProvider for JiraClient {
         let effective_project = filter.project_key.as_deref().unwrap_or(&self.project_key);
 
         // Build JQL query — native_query takes precedence over filter-based construction
-        let jql = if let Some(native) = &filter.native_query {
+        let escaped_project = escape_jql(effective_project);
+        let jql = if let Some(native) = &filter.native_query
+            && !native.trim().is_empty()
+        {
             // If native query doesn't mention a project clause, prepend one
             // (Jira Cloud requires a project filter)
             if has_project_clause(native) {
                 native.clone()
             } else {
-                format!("project = \"{}\" AND {}", effective_project, native)
+                format!("project = \"{}\" AND {}", escaped_project, native)
             }
         } else {
-            let mut jql_parts: Vec<String> = vec![format!("project = \"{}\"", effective_project)];
+            let mut jql_parts: Vec<String> = vec![format!("project = \"{}\"", escaped_project)];
 
             // State filter
             if let Some(state) = &filter.state {
@@ -2278,6 +2300,68 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_get_issues_project_key_with_native_query() {
+            let server = MockServer::start();
+
+            // project_key override + native_query without project clause
+            // → should inject the overridden project key, not the default one
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/search")
+                    .query_param_includes("jql", "project = \"OVERRIDE\" AND sprint = 42");
+                then.status(200).json_body(serde_json::json!({
+                    "issues": [sample_issue_json()],
+                    "startAt": 0,
+                    "maxResults": 20,
+                    "total": 1
+                }));
+            });
+
+            let client = create_self_hosted_client(&server); // default project = "PROJ"
+            let issues = client
+                .get_issues(IssueFilter {
+                    project_key: Some("OVERRIDE".to_string()),
+                    native_query: Some("sprint = 42".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+
+            assert_eq!(issues.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_get_issues_empty_native_query_falls_back() {
+            let server = MockServer::start();
+
+            // Empty native_query should fall back to normal filter-based JQL
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/search")
+                    .query_param_includes("jql", "project = \"PROJ\"");
+                then.status(200).json_body(serde_json::json!({
+                    "issues": [sample_issue_json()],
+                    "startAt": 0,
+                    "maxResults": 20,
+                    "total": 1
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let issues = client
+                .get_issues(IssueFilter {
+                    native_query: Some("".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .items;
+
+            assert_eq!(issues.len(), 1);
+        }
+
+        #[tokio::test]
         async fn test_get_issue() {
             let server = MockServer::start();
 
@@ -3255,6 +3339,7 @@ mod tests {
             // Negative cases
             assert!(!has_project_clause("fixVersion = \"1.0\""));
             assert!(!has_project_clause("summary ~ \"project plan\""));
+            assert!(!has_project_clause("summary ~ \"project information\""));
             assert!(!has_project_clause("status = Done"));
         }
 


### PR DESCRIPTION
## Summary

- Add `projectKey` and `nativeQuery` parameters to `get_issues` tool, wired through `IssueFilter` → `GetIssuesParams` → `JiraClient`
- `projectKey` overrides the hardcoded `self.project_key` in JQL construction
- `nativeQuery` passes raw JQL directly, with smart project clause auto-injection when missing (required by Jira Cloud)
- Word-boundary detection in `has_project_clause()` avoids false positives like `"project information"`
- Other providers (GitHub, GitLab, ClickUp) unaffected — their enrichers already remove these params

Closes #130

## Changes

- `crates/devboy-core/src/types.rs` — add `project_key`, `native_query` to `IssueFilter`
- `crates/devboy-executor/src/executor.rs` — add fields to `GetIssuesParams`, pass through
- `crates/devboy-executor/src/tools.rs` — add `projectKey`, `nativeQuery` to base schema
- `crates/devboy-mcp/src/handlers.rs` — use `..Default::default()` for forward compat
- `crates/plugins/api/jira/src/client.rs` — implement project override, native query, escape, tests

## Testing

- [x] 8 new tests: project_key override, native_query passthrough, auto-inject, project IN, combined, empty query, has_project_clause unit test
- [x] All 91 Jira tests pass
- [x] Full test suite passes (0 failures)
- [x] `cargo clippy` clean (RUSTFLAGS=-Dwarnings)
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)