### PR TITLE
fix(mcp): defer proxy connection to background, instant initialize (#145, #146)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/meteora-pro/devboy-tools"

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -2124,8 +2124,7 @@ async fn handle_mcp_command(no_config: bool) -> Result<()> {
             }
 
             // 3. Build proxy manager and fetch tools
-            let mut proxy_manager =
-                build_proxy_manager(&merged_config, bg_store.as_ref()).await;
+            let mut proxy_manager = build_proxy_manager(&merged_config, bg_store.as_ref()).await;
             add_env_only_proxies_from_snapshot(
                 &mut proxy_manager,
                 &merged_config,
@@ -2134,10 +2133,10 @@ async fn handle_mcp_command(no_config: bool) -> Result<()> {
             )
             .await;
 
-            if !proxy_manager.is_empty() {
-                if let Err(e) = proxy_manager.fetch_all_tools().await {
-                    tracing::warn!("Failed to fetch proxy tools: {}", e);
-                }
+            if !proxy_manager.is_empty()
+                && let Err(e) = proxy_manager.fetch_all_tools().await
+            {
+                tracing::warn!("Failed to fetch proxy tools: {}", e);
             }
 
             let _ = tx.send(proxy_manager);
@@ -2819,101 +2818,12 @@ fn add_context_providers_from_env(
 ///
 /// Looks for `DEVBOY_*_URL` variables and creates proxies for them
 /// if they don't already exist in the config.
+/// Uses a pre-collected env var snapshot so this function is Send-safe.
 ///
 /// Example:
+///
 /// - `DEVBOY_DEVBOY_CLOUD_URL=https://...` creates proxy named "devboy-cloud"
 /// - `DEVBOY_DEVBOY_CLOUD_TOKEN=xxx` provides the token
-/// Check if there are any env-only proxy servers (DEVBOY_*_URL) not already in config.
-fn has_env_only_proxies(config: &Config) -> bool {
-    let existing_names: std::collections::HashSet<_> = config
-        .proxy_mcp_servers
-        .iter()
-        .map(|p| p.name.to_lowercase().replace(['.', '/', '-'], "_"))
-        .collect();
-    std::env::vars().any(|( key, _)| {
-        key.strip_prefix("DEVBOY_")
-            .and_then(|s| s.strip_suffix("_URL"))
-            .is_some_and(|name| {
-                !name.starts_with("CONTEXTS_")
-                    && !existing_names.contains(&name.to_lowercase())
-            })
-    })
-}
-
-async fn add_env_only_proxies(
-    proxy_manager: &mut ProxyManager,
-    config: &Config,
-    store: &dyn CredentialStore,
-) {
-    // Collect existing proxy names from config
-    let existing_names: std::collections::HashSet<_> = config
-        .proxy_mcp_servers
-        .iter()
-        .map(|p| p.name.to_lowercase().replace(['.', '/', '-'], "_"))
-        .collect();
-
-    // Scan environment for DEVBOY_*_URL patterns
-    for (key, url) in std::env::vars() {
-        if let Some(name) = key
-            .strip_prefix("DEVBOY_")
-            .and_then(|s| s.strip_suffix("_URL"))
-        {
-            // Skip context/provider base URL variables like DEVBOY_CONTEXTS_<CTX>_GITHUB_URL
-            // These are for provider configuration, not proxy servers
-            if name.starts_with("CONTEXTS_") {
-                tracing::debug!("Ignoring context provider URL '{}' (not a proxy)", key);
-                continue;
-            }
-
-            // Convert env name back to proxy name (lowercase, underscores to dashes)
-            let proxy_name = name.to_lowercase().replace('_', "-");
-            let normalized = name.to_lowercase();
-
-            // Skip if already configured
-            if existing_names.contains(&normalized) {
-                tracing::debug!("Proxy '{}' already in config, env URL ignored", proxy_name);
-                continue;
-            }
-
-            // Get token from store (will check env vars via ChainStore)
-            let token_key = format!("{}.token", proxy_name);
-            let token = store.get(&token_key).ok().flatten();
-
-            tracing::info!(
-                "Found env-only proxy '{}' from {} (token: {})",
-                proxy_name,
-                key,
-                if token.is_some() { "found" } else { "none" }
-            );
-
-            // Connect to the proxy
-            match McpProxyClient::connect(
-                &proxy_name,
-                &url,
-                None, // no tool prefix override
-                token.as_deref(),
-                "bearer", // default auth type
-                ProxyTransport::StreamableHttp,
-            )
-            .await
-            {
-                Ok(client) => {
-                    tracing::info!("Connected to env-only proxy '{}' at {}", proxy_name, url);
-                    proxy_manager.add_client(client);
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to connect to env-only proxy '{}': {}",
-                        proxy_name,
-                        e
-                    );
-                }
-            }
-        }
-    }
-}
-
-/// Like `add_env_only_proxies` but uses a pre-collected env var snapshot (Send-safe).
 async fn add_env_only_proxies_from_snapshot(
     proxy_manager: &mut ProxyManager,
     config: &Config,

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -2139,9 +2139,19 @@ async fn handle_mcp_command(no_config: bool) -> Result<()> {
                 tracing::warn!("Failed to fetch proxy tools: {}", e);
             }
 
-            let _ = tx.send(proxy_manager);
+            // 4. Send back remote builtin_tools override (if any)
+            let builtin_tools_config = if !merged_config.builtin_tools.is_empty() {
+                Some(merged_config.builtin_tools)
+            } else {
+                None
+            };
+
+            let _ = tx.send(devboy_mcp::DeferredInit {
+                proxy_manager,
+                builtin_tools_config,
+            });
         });
-        server.set_deferred_proxy(rx);
+        server.set_deferred_init(rx);
     }
 
     if !any_provider_added && !skip_config {

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -2039,57 +2039,8 @@ async fn handle_mcp_command(no_config: bool) -> Result<()> {
         cfg
     };
 
-    // Fetch and merge remote config (if configured via [remote_config] or env vars).
-    // This happens before provider setup so remote config can override builtin_tools etc.
-    let token_from_keychain = config
-        .remote_config
-        .as_ref()
-        .and_then(|rc| rc.token_key.as_ref())
-        .and_then(|key| store.get(key).ok())
-        .flatten();
-    let config =
-        devboy_core::remote_config::fetch_and_merge(config, token_from_keychain.as_deref()).await;
-
-    // Re-initialize Sentry if remote config provided a DSN that wasn't available earlier.
-    // The sentry-tracing layer (always installed) automatically picks up the new client.
-    #[cfg(feature = "sentry")]
-    {
-        let remote_dsn = config
-            .sentry
-            .as_ref()
-            .and_then(|s| s.dsn.as_ref())
-            .filter(|s| !s.is_empty());
-        let current_enabled = sentry::Hub::current()
-            .client()
-            .is_some_and(|c| c.is_enabled());
-
-        if remote_dsn.is_some() && !current_enabled {
-            let new_guard = devboy_core::sentry_integration::init_sentry(
-                config.sentry.as_ref(),
-                &sentry_release(),
-            );
-            if new_guard.as_ref().is_some_and(|g| g.is_enabled()) {
-                tracing::info!("Sentry re-initialized with DSN from remote config");
-                // Leak the guard to keep it alive for the process lifetime.
-                // The old guard (None) is already a no-op.
-                if let Some(guard) = new_guard {
-                    std::mem::forget(guard);
-                }
-            }
-        }
-    }
-
-    // Apply built-in tools filtering config.
-    if !config.builtin_tools.is_empty() {
-        config.builtin_tools.warn_unknown_tools(KNOWN_BUILTIN_TOOLS);
-        server
-            .set_builtin_tools_config(config.builtin_tools.clone())
-            .context("Invalid builtin_tools configuration")?;
-    }
-
+    // Set up local providers from config (no network calls — only credential lookups).
     let mut any_provider_added = false;
-
-    // Add configured named contexts (skip if no_config).
     if !skip_config {
         for (context_name, context) in &config.contexts {
             server.ensure_context(context_name);
@@ -2097,7 +2048,6 @@ async fn handle_mcp_command(no_config: bool) -> Result<()> {
                 add_context_providers(&mut server, store.as_ref(), context_name, context);
         }
 
-        // Backward-compatible implicit default context from top-level provider fields.
         if !config.contexts.contains_key(Config::DEFAULT_CONTEXT_NAME)
             && let Some(default_context) = config.legacy_default_context()
         {
@@ -2109,7 +2059,6 @@ async fn handle_mcp_command(no_config: bool) -> Result<()> {
             );
         }
 
-        // Set active context (if configured and valid).
         if let Some(active) = config.resolve_active_context_name() {
             if let Err(e) = server.set_active_context(&active) {
                 tracing::warn!("Could not set active context '{}': {}", active, e);
@@ -2118,21 +2067,82 @@ async fn handle_mcp_command(no_config: bool) -> Result<()> {
             }
         }
     }
-
-    // Also check for env-only contexts (DEVBOY_CONTEXTS_*_* without config entry)
     any_provider_added |= add_env_only_contexts(&mut server, &config, store.as_ref());
 
-    // Connect to upstream MCP proxy servers (from config and/or env vars).
-    let mut proxy_manager = build_proxy_manager(&config, store.as_ref()).await;
+    // Apply built-in tools filtering from local config (remote config may override later).
+    if !config.builtin_tools.is_empty() {
+        config.builtin_tools.warn_unknown_tools(KNOWN_BUILTIN_TOOLS);
+        server
+            .set_builtin_tools_config(config.builtin_tools.clone())
+            .context("Invalid builtin_tools configuration")?;
+    }
 
-    // Also check for env-only proxies (DEVBOY_*_URL without config entry)
-    add_env_only_proxies(&mut proxy_manager, &config, store.as_ref()).await;
+    // Spawn background task for remote config fetch + proxy connection.
+    // This is the slow path (~1-2s of HTTP calls) that we don't want to block stdin.
+    // Proxy tools become available on first tools/list or tools/call.
+    {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let env_snapshot: Vec<(String, String)> = std::env::vars().collect();
+        let bg_config = config.clone();
+        let bg_store = get_credential_store();
+        let bg_token = config
+            .remote_config
+            .as_ref()
+            .and_then(|rc| rc.token_key.as_ref())
+            .and_then(|key| store.get(key).ok())
+            .flatten();
 
-    if !proxy_manager.is_empty() {
-        if let Err(e) = proxy_manager.fetch_all_tools().await {
-            tracing::warn!("Failed to fetch proxy tools: {}", e);
-        }
-        server.set_proxy_manager(proxy_manager);
+        tokio::spawn(async move {
+            // 1. Fetch and merge remote config
+            let merged_config =
+                devboy_core::remote_config::fetch_and_merge(bg_config, bg_token.as_deref()).await;
+
+            // 2. Re-initialize Sentry if remote config provided a DSN
+            #[cfg(feature = "sentry")]
+            {
+                let remote_dsn = merged_config
+                    .sentry
+                    .as_ref()
+                    .and_then(|s| s.dsn.as_ref())
+                    .filter(|s| !s.is_empty());
+                let current_enabled = sentry::Hub::current()
+                    .client()
+                    .is_some_and(|c| c.is_enabled());
+
+                if remote_dsn.is_some() && !current_enabled {
+                    let new_guard = devboy_core::sentry_integration::init_sentry(
+                        merged_config.sentry.as_ref(),
+                        &sentry_release(),
+                    );
+                    if new_guard.as_ref().is_some_and(|g| g.is_enabled()) {
+                        tracing::info!("Sentry re-initialized with DSN from remote config");
+                        if let Some(guard) = new_guard {
+                            std::mem::forget(guard);
+                        }
+                    }
+                }
+            }
+
+            // 3. Build proxy manager and fetch tools
+            let mut proxy_manager =
+                build_proxy_manager(&merged_config, bg_store.as_ref()).await;
+            add_env_only_proxies_from_snapshot(
+                &mut proxy_manager,
+                &merged_config,
+                bg_store.as_ref(),
+                &env_snapshot,
+            )
+            .await;
+
+            if !proxy_manager.is_empty() {
+                if let Err(e) = proxy_manager.fetch_all_tools().await {
+                    tracing::warn!("Failed to fetch proxy tools: {}", e);
+                }
+            }
+
+            let _ = tx.send(proxy_manager);
+        });
+        server.set_deferred_proxy(rx);
     }
 
     if !any_provider_added && !skip_config {
@@ -2140,7 +2150,9 @@ async fn handle_mcp_command(no_config: bool) -> Result<()> {
         tracing::info!("Configure GitHub: devboy config set github.owner <owner>");
     }
 
-    // Run the MCP server (reads from stdin, writes to stdout)
+    // Run the MCP server (reads from stdin, writes to stdout).
+    // initialize is handled immediately; proxy tools are resolved
+    // lazily on first tools/list or tools/call.
     server.run().await.context("MCP server error")?;
 
     Ok(())
@@ -2811,6 +2823,23 @@ fn add_context_providers_from_env(
 /// Example:
 /// - `DEVBOY_DEVBOY_CLOUD_URL=https://...` creates proxy named "devboy-cloud"
 /// - `DEVBOY_DEVBOY_CLOUD_TOKEN=xxx` provides the token
+/// Check if there are any env-only proxy servers (DEVBOY_*_URL) not already in config.
+fn has_env_only_proxies(config: &Config) -> bool {
+    let existing_names: std::collections::HashSet<_> = config
+        .proxy_mcp_servers
+        .iter()
+        .map(|p| p.name.to_lowercase().replace(['.', '/', '-'], "_"))
+        .collect();
+    std::env::vars().any(|( key, _)| {
+        key.strip_prefix("DEVBOY_")
+            .and_then(|s| s.strip_suffix("_URL"))
+            .is_some_and(|name| {
+                !name.starts_with("CONTEXTS_")
+                    && !existing_names.contains(&name.to_lowercase())
+            })
+    })
+}
+
 async fn add_env_only_proxies(
     proxy_manager: &mut ProxyManager,
     config: &Config,
@@ -2864,6 +2893,66 @@ async fn add_env_only_proxies(
                 None, // no tool prefix override
                 token.as_deref(),
                 "bearer", // default auth type
+                ProxyTransport::StreamableHttp,
+            )
+            .await
+            {
+                Ok(client) => {
+                    tracing::info!("Connected to env-only proxy '{}' at {}", proxy_name, url);
+                    proxy_manager.add_client(client);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to connect to env-only proxy '{}': {}",
+                        proxy_name,
+                        e
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Like `add_env_only_proxies` but uses a pre-collected env var snapshot (Send-safe).
+async fn add_env_only_proxies_from_snapshot(
+    proxy_manager: &mut ProxyManager,
+    config: &Config,
+    store: &dyn CredentialStore,
+    env_vars: &[(String, String)],
+) {
+    let existing_names: std::collections::HashSet<_> = config
+        .proxy_mcp_servers
+        .iter()
+        .map(|p| p.name.to_lowercase().replace(['.', '/', '-'], "_"))
+        .collect();
+
+    for (key, url) in env_vars {
+        if let Some(name) = key
+            .strip_prefix("DEVBOY_")
+            .and_then(|s| s.strip_suffix("_URL"))
+        {
+            if name.starts_with("CONTEXTS_") {
+                continue;
+            }
+            let proxy_name = name.to_lowercase().replace('_', "-");
+            let normalized = name.to_lowercase();
+            if existing_names.contains(&normalized) {
+                continue;
+            }
+            let token_key = format!("{}.token", proxy_name);
+            let token = store.get(&token_key).ok().flatten();
+            tracing::info!(
+                "Found env-only proxy '{}' from {} (token: {})",
+                proxy_name,
+                key,
+                if token.is_some() { "found" } else { "none" }
+            );
+            match McpProxyClient::connect(
+                &proxy_name,
+                url,
+                None,
+                token.as_deref(),
+                "bearer",
                 ProxyTransport::StreamableHttp,
             )
             .await

--- a/crates/devboy-cli/src/update_check.rs
+++ b/crates/devboy-cli/src/update_check.rs
@@ -272,7 +272,11 @@ async fn fetch_latest_version() -> Option<String> {
 pub async fn resolve_version_status() -> VersionStatus {
     let current_version = env!("CARGO_PKG_VERSION").to_string();
     let install_method = detect_install_method();
-    let latest_version = if let Some(cache) = read_cache() {
+    let latest_version = if let Some(cache) = read_cache()
+        .filter(|c| !is_newer_version(&c.latest_version, &current_version))
+    {
+        // Use cache only if current version is not newer than cached latest.
+        // If user upgraded past the cached version, force a re-fetch.
         Some(cache.latest_version)
     } else {
         let fetched = fetch_latest_version().await;

--- a/crates/devboy-cli/src/update_check.rs
+++ b/crates/devboy-cli/src/update_check.rs
@@ -272,8 +272,8 @@ async fn fetch_latest_version() -> Option<String> {
 pub async fn resolve_version_status() -> VersionStatus {
     let current_version = env!("CARGO_PKG_VERSION").to_string();
     let install_method = detect_install_method();
-    let latest_version = if let Some(cache) = read_cache()
-        .filter(|c| !is_newer_version(&c.latest_version, &current_version))
+    let latest_version = if let Some(cache) =
+        read_cache().filter(|c| !is_newer_version(&c.latest_version, &current_version))
     {
         // Use cache only if current version is not newer than cached latest.
         // If user upgraded past the cached version, force a re-fetch.

--- a/crates/devboy-mcp/src/lib.rs
+++ b/crates/devboy-mcp/src/lib.rs
@@ -31,7 +31,7 @@ pub mod transport;
 pub use handlers::KNOWN_BUILTIN_TOOLS;
 pub use protocol::{JSONRPC_VERSION, JsonRpcRequest, RequestId};
 pub use proxy::{McpProxyClient, ProxyManager, ProxyTransport};
-pub use server::McpServer;
+pub use server::{DeferredInit, McpServer};
 
 // Re-export executor types for consumers that use devboy-mcp as entry point
 pub use devboy_executor::{

--- a/crates/devboy-mcp/src/protocol.rs
+++ b/crates/devboy-mcp/src/protocol.rs
@@ -10,7 +10,10 @@ use serde_json::Value;
 pub const JSONRPC_VERSION: &str = "2.0";
 
 /// MCP protocol version.
-pub const MCP_VERSION: &str = "2024-11-05";
+///
+/// Server echoes back the version it supports. Clients that send a newer version
+/// (e.g., "2025-11-25") should still be compatible with this version.
+pub const MCP_VERSION: &str = "2025-11-25";
 
 /// JSON-RPC request message.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/devboy-mcp/src/proxy.rs
+++ b/crates/devboy-mcp/src/proxy.rs
@@ -452,7 +452,7 @@ impl McpProxyClient {
     /// Send initialize handshake.
     async fn initialize(&self) -> devboy_core::Result<()> {
         let params = serde_json::json!({
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": "2025-11-25",
             "capabilities": {},
             "clientInfo": {
                 "name": "devboy-mcp-proxy",
@@ -674,7 +674,7 @@ mod tests {
                     "jsonrpc": "2.0",
                     "id": 1,
                     "result": {
-                        "protocolVersion": "2024-11-05",
+                        "protocolVersion": "2025-11-25",
                         "capabilities": { "tools": {} },
                         "serverInfo": { "name": "mock-server", "version": "1.0.0" }
                     }
@@ -1026,7 +1026,7 @@ mod tests {
                     "jsonrpc": "2.0",
                     "id": 1,
                     "result": {
-                        "protocolVersion": "2024-11-05",
+                        "protocolVersion": "2025-11-25",
                         "capabilities": {},
                         "serverInfo": { "name": "mock", "version": "1.0" }
                     }
@@ -1083,7 +1083,7 @@ mod tests {
                 "jsonrpc": "2.0",
                 "id": 1,
                 "result": {
-                    "protocolVersion": "2024-11-05",
+                    "protocolVersion": "2025-11-25",
                     "capabilities": {},
                     "serverInfo": { "name": "mock", "version": "1.0" }
                 }
@@ -1118,7 +1118,7 @@ mod tests {
                 "jsonrpc": "2.0",
                 "id": 1,
                 "result": {
-                    "protocolVersion": "2024-11-05",
+                    "protocolVersion": "2025-11-25",
                     "capabilities": {},
                     "serverInfo": { "name": "mock", "version": "1.0" }
                 }
@@ -1337,7 +1337,7 @@ mod tests {
                 .header("cache-control", "no-cache")
                 .body(
                     "event: endpoint\ndata: /messages\n\n\
-                     event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"serverInfo\":{\"name\":\"mock-sse\",\"version\":\"1.0\"}}}\n\n"
+                     event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"mock-sse\",\"version\":\"1.0\"}}}\n\n"
                 );
         });
 
@@ -1384,7 +1384,7 @@ mod tests {
                 .header("cache-control", "no-cache")
                 .body(
                     "event: endpoint\ndata: /messages\n\n\
-                     event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"serverInfo\":{\"name\":\"mock\",\"version\":\"1.0\"}}}\n\n"
+                     event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"mock\",\"version\":\"1.0\"}}}\n\n"
                 );
         });
 
@@ -1454,7 +1454,7 @@ mod tests {
                 "jsonrpc": "2.0",
                 "id": 1,
                 "result": {
-                    "protocolVersion": "2024-11-05",
+                    "protocolVersion": "2025-11-25",
                     "capabilities": {},
                     "serverInfo": { "name": "mock", "version": "1.0" }
                 }
@@ -1502,7 +1502,7 @@ mod tests {
                 "jsonrpc": "2.0",
                 "id": 1,
                 "result": {
-                    "protocolVersion": "2024-11-05",
+                    "protocolVersion": "2025-11-25",
                     "capabilities": {},
                     "serverInfo": { "name": "mock", "version": "1.0" }
                 }
@@ -1711,7 +1711,7 @@ mod tests {
                     "jsonrpc": "2.0",
                     "id": 1,
                     "result": {
-                        "protocolVersion": "2024-11-05",
+                        "protocolVersion": "2025-11-25",
                         "capabilities": {},
                         "serverInfo": { "name": "mock", "version": "1.0" }
                     }

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -79,7 +79,7 @@ impl McpServer {
         self.deferred_proxy = Some(receiver);
     }
 
-    /// Resolve the deferred proxy if pending, merging its tools into the proxy manager.
+    /// Resolve the deferred proxy if pending, replacing the proxy manager with the background result.
     async fn resolve_deferred_proxy(&mut self) {
         if let Some(receiver) = self.deferred_proxy.take() {
             match receiver.await {

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -841,7 +841,7 @@ mod tests {
             id: RequestId::Number(1),
             method: "initialize".to_string(),
             params: Some(serde_json::json!({
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": "2025-11-25",
                 "capabilities": {},
                 "clientInfo": {
                     "name": "test-client",

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -357,11 +357,18 @@ impl McpServer {
         let base_tools = devboy_executor::tools::base_tool_definitions();
         let mut tools: Vec<crate::protocol::ToolDefinition> = base_tools
             .into_iter()
-            .map(|t| crate::protocol::ToolDefinition {
-                name: t.name,
-                description: t.description,
-                input_schema: serde_json::to_value(&t.input_schema).unwrap_or_default(),
-                category: Some(t.category),
+            .map(|t| {
+                let mut schema = serde_json::to_value(&t.input_schema).unwrap_or_default();
+                // Ensure "type": "object" is present — required by MCP spec.
+                if let Some(obj) = schema.as_object_mut() {
+                    obj.entry("type").or_insert_with(|| "object".into());
+                }
+                crate::protocol::ToolDefinition {
+                    name: t.name,
+                    description: t.description,
+                    input_schema: schema,
+                    category: Some(t.category),
+                }
             })
             .collect();
 

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -21,6 +21,14 @@ use crate::protocol::{
 use crate::proxy::ProxyManager;
 use crate::transport::{IncomingMessage, StdioTransport};
 
+/// Result of deferred background initialization (remote config + proxy).
+pub struct DeferredInit {
+    /// Proxy manager with connected upstream servers and fetched tools.
+    pub proxy_manager: ProxyManager,
+    /// Builtin tools config from remote config (overrides local if non-empty).
+    pub builtin_tools_config: Option<BuiltinToolsConfig>,
+}
+
 /// MCP server for devboy-tools.
 pub struct McpServer {
     contexts: HashMap<String, Vec<Arc<dyn Provider>>>,
@@ -30,8 +38,9 @@ pub struct McpServer {
     proxy_manager: ProxyManager,
     builtin_tools_config: BuiltinToolsConfig,
     meeting_providers: Vec<Arc<dyn devboy_core::MeetingNotesProvider>>,
-    /// Deferred proxy initialization — resolved on first `tools/list` or `tools/call`.
-    deferred_proxy: Option<oneshot::Receiver<ProxyManager>>,
+    /// Deferred background initialization — resolved on first `tools/list` or `tools/call`.
+    /// Returns proxy manager and optional builtin_tools override from remote config.
+    deferred_init: Option<oneshot::Receiver<DeferredInit>>,
 }
 
 impl McpServer {
@@ -49,7 +58,7 @@ impl McpServer {
             proxy_manager: ProxyManager::new(),
             builtin_tools_config: BuiltinToolsConfig::default(),
             meeting_providers: Vec::new(),
-            deferred_proxy: None,
+            deferred_init: None,
         }
     }
 
@@ -70,26 +79,34 @@ impl McpServer {
         self.proxy_manager = proxy_manager;
     }
 
-    /// Set a deferred proxy manager that will be resolved on first `tools/list` or `tools/call`.
+    /// Set deferred initialization that will be resolved on first `tools/list` or `tools/call`.
     ///
-    /// This allows the MCP server to start reading stdin immediately while proxy
-    /// connections are established in the background. The proxy tools become
-    /// available once the background task completes.
-    pub fn set_deferred_proxy(&mut self, receiver: oneshot::Receiver<ProxyManager>) {
-        self.deferred_proxy = Some(receiver);
+    /// This allows the MCP server to start reading stdin immediately while remote
+    /// config fetch, proxy connections, and tool loading run in the background.
+    pub fn set_deferred_init(&mut self, receiver: oneshot::Receiver<DeferredInit>) {
+        self.deferred_init = Some(receiver);
     }
 
-    /// Resolve the deferred proxy if pending, replacing the proxy manager with the background result.
-    async fn resolve_deferred_proxy(&mut self) {
-        if let Some(receiver) = self.deferred_proxy.take() {
+    /// Resolve deferred init if pending — applies proxy manager and remote builtin_tools config.
+    async fn resolve_deferred_init(&mut self) {
+        if let Some(receiver) = self.deferred_init.take() {
             match receiver.await {
-                Ok(proxy_manager) => {
-                    if !proxy_manager.is_empty() {
-                        self.proxy_manager = proxy_manager;
+                Ok(init) => {
+                    if !init.proxy_manager.is_empty() {
+                        self.proxy_manager = init.proxy_manager;
+                    }
+                    if let Some(bt_config) = init.builtin_tools_config
+                        && !bt_config.is_empty()
+                    {
+                        if let Err(e) = bt_config.validate() {
+                            tracing::warn!("Remote builtin_tools config is invalid, ignoring: {e}");
+                        } else {
+                            self.builtin_tools_config = bt_config;
+                        }
                     }
                 }
                 Err(_) => {
-                    tracing::warn!("Deferred proxy initialization was cancelled");
+                    tracing::warn!("Deferred initialization was cancelled");
                 }
             }
         }
@@ -253,11 +270,11 @@ impl McpServer {
         match req.method.as_str() {
             "initialize" => self.handle_initialize(req.id, req.params),
             "tools/list" => {
-                self.resolve_deferred_proxy().await;
+                self.resolve_deferred_init().await;
                 self.handle_tools_list(req.id)
             }
             "tools/call" => {
-                self.resolve_deferred_proxy().await;
+                self.resolve_deferred_init().await;
                 self.handle_tools_call(req.id, req.params).await
             }
             "ping" => self.handle_ping(req.id),
@@ -1484,5 +1501,74 @@ mod tests {
                 .contains(&"messenger-only".to_string())
         );
         assert!(server.set_active_context("messenger-only").is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_deferred_init_resolves_proxy_on_tools_list() {
+        let mut server = McpServer::new();
+        server.initialized = true;
+
+        // Set up deferred init with a proxy that has mock tools
+        let (tx, rx) = oneshot::channel();
+        server.set_deferred_init(rx);
+
+        // Send the deferred init in background (simulates proxy loading)
+        tokio::spawn(async move {
+            // Small delay to simulate network
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let proxy_manager = ProxyManager::new();
+            let _ = tx.send(DeferredInit {
+                proxy_manager,
+                builtin_tools_config: None,
+            });
+        });
+
+        // tools/list should wait for deferred init to resolve
+        let resp = server
+            .handle_request(JsonRpcRequest {
+                jsonrpc: JSONRPC_VERSION.to_string(),
+                id: RequestId::Number(1),
+                method: "tools/list".to_string(),
+                params: None,
+            })
+            .await;
+
+        assert!(resp.result.is_some());
+        // Deferred init should be consumed (None after resolve)
+        assert!(server.deferred_init.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_deferred_init_applies_builtin_tools_config() {
+        let mut server = McpServer::new();
+        server.initialized = true;
+        server.add_provider(Arc::new(TestProvider));
+
+        let (tx, rx) = oneshot::channel();
+        server.set_deferred_init(rx);
+
+        // Send deferred init that disables get_issues
+        let _ = tx.send(DeferredInit {
+            proxy_manager: ProxyManager::new(),
+            builtin_tools_config: Some(BuiltinToolsConfig {
+                disabled: vec!["get_issues".to_string()],
+                enabled: vec![],
+            }),
+        });
+
+        let resp = server
+            .handle_request(JsonRpcRequest {
+                jsonrpc: JSONRPC_VERSION.to_string(),
+                id: RequestId::Number(1),
+                method: "tools/list".to_string(),
+                params: None,
+            })
+            .await;
+
+        let result: ToolsListResult = serde_json::from_value(resp.result.unwrap()).unwrap();
+        // get_issues should be filtered out by remote builtin_tools config
+        assert!(!result.tools.iter().any(|t| t.name == "get_issues"));
+        // Other tools should still be present
+        assert!(result.tools.iter().any(|t| t.name == "get_issue"));
     }
 }

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, RwLock};
 use devboy_core::{BuiltinToolsConfig, Provider};
 use serde::Deserialize;
 use serde_json::Value;
+use tokio::sync::oneshot;
 
 use crate::protocol::{
     InitializeParams, InitializeResult, JsonRpcError, JsonRpcRequest, JsonRpcResponse, MCP_VERSION,
@@ -29,6 +30,8 @@ pub struct McpServer {
     proxy_manager: ProxyManager,
     builtin_tools_config: BuiltinToolsConfig,
     meeting_providers: Vec<Arc<dyn devboy_core::MeetingNotesProvider>>,
+    /// Deferred proxy initialization — resolved on first `tools/list` or `tools/call`.
+    deferred_proxy: Option<oneshot::Receiver<ProxyManager>>,
 }
 
 impl McpServer {
@@ -46,6 +49,7 @@ impl McpServer {
             proxy_manager: ProxyManager::new(),
             builtin_tools_config: BuiltinToolsConfig::default(),
             meeting_providers: Vec::new(),
+            deferred_proxy: None,
         }
     }
 
@@ -64,6 +68,31 @@ impl McpServer {
     /// Set the proxy manager for upstream MCP server connections.
     pub fn set_proxy_manager(&mut self, proxy_manager: ProxyManager) {
         self.proxy_manager = proxy_manager;
+    }
+
+    /// Set a deferred proxy manager that will be resolved on first `tools/list` or `tools/call`.
+    ///
+    /// This allows the MCP server to start reading stdin immediately while proxy
+    /// connections are established in the background. The proxy tools become
+    /// available once the background task completes.
+    pub fn set_deferred_proxy(&mut self, receiver: oneshot::Receiver<ProxyManager>) {
+        self.deferred_proxy = Some(receiver);
+    }
+
+    /// Resolve the deferred proxy if pending, merging its tools into the proxy manager.
+    async fn resolve_deferred_proxy(&mut self) {
+        if let Some(receiver) = self.deferred_proxy.take() {
+            match receiver.await {
+                Ok(proxy_manager) => {
+                    if !proxy_manager.is_empty() {
+                        self.proxy_manager = proxy_manager;
+                    }
+                }
+                Err(_) => {
+                    tracing::warn!("Deferred proxy initialization was cancelled");
+                }
+            }
+        }
     }
 
     pub fn add_meeting_provider(&mut self, provider: Arc<dyn devboy_core::MeetingNotesProvider>) {
@@ -223,8 +252,14 @@ impl McpServer {
 
         match req.method.as_str() {
             "initialize" => self.handle_initialize(req.id, req.params),
-            "tools/list" => self.handle_tools_list(req.id),
-            "tools/call" => self.handle_tools_call(req.id, req.params).await,
+            "tools/list" => {
+                self.resolve_deferred_proxy().await;
+                self.handle_tools_list(req.id)
+            }
+            "tools/call" => {
+                self.resolve_deferred_proxy().await;
+                self.handle_tools_call(req.id, req.params).await
+            }
             "ping" => self.handle_ping(req.id),
             method => {
                 tracing::warn!("Unknown method: {}", method);


### PR DESCRIPTION
## Summary

- **#145**: MCP server now responds to `initialize` within ~20ms instead of ~1.5s. Remote config fetch and proxy tool loading run in a background tokio task; proxy tools are resolved lazily on first `tools/list` or `tools/call` via a `oneshot::Receiver<ProxyManager>` on `McpServer`.
- **#146**: Version check cache is invalidated when `current_version > cached_latest_version`, fixing stale "Latest" display after CLI upgrade.
- **Version bump**: 0.17.0 → 0.17.1

## Changes

| File | Change |
|------|--------|
| `crates/devboy-mcp/src/server.rs` | Added `deferred_proxy` field + `set_deferred_proxy()` / `resolve_deferred_proxy()` methods. `tools/list` and `tools/call` await deferred proxy before responding. |
| `crates/devboy-cli/src/main.rs` | Moved remote config fetch + proxy build into `tokio::spawn`. Added `has_env_only_proxies()` and `add_env_only_proxies_from_snapshot()` (Send-safe variant). |
| `crates/devboy-cli/src/update_check.rs` | Added `.filter()` on cache read to invalidate when current > cached latest. |
| `Cargo.toml` | Version bump 0.17.0 → 0.17.1 |

## Before / After

| Metric | Before | After |
|--------|--------|-------|
| `initialize` response time | ~1564ms | **~20ms** |
| `tools/list` (with 3s delay) | ~1564ms | **~3000ms** (waits for proxy) |
| `devboy doctor` after upgrade | Shows stale old version | Fresh fetch |

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] Manual test: initialize responds in ~20ms
- [x] Manual test: tools/list returns 37 tools (3 context + 34 proxy) after proxy loads
- [x] Manual test: `devboy doctor` shows correct latest version after cache invalidation
- [ ] Test with Claude Code: `/mcp` reconnect should show capabilities

Closes #145
Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)