### PR TITLE
fix(init): skip git auto-detect when --remote-config-url is set

### DIFF
--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -1318,8 +1318,9 @@ fn detect_provider_defaults() -> Vec<bool> {
     vec![is_github, is_gitlab, false, false]
 }
 
-/// Build Config from collected options.
-/// Decide whether `devboy init --yes` should skip local git remote auto-detection.
+/// Decide whether `devboy init` should skip local git remote auto-detection and
+/// fall through to a minimal-config branch instead of calling `collect_options_auto`
+/// (for `--yes`) or `collect_options_interactive` (for the interactive path).
 ///
 /// Git detection is skipped when any of the following holds:
 /// - `--proxy-only` was passed (explicit opt-out, pre-existing behaviour);
@@ -1337,6 +1338,7 @@ fn should_skip_git_detect(
     remote_config_url.is_some() && !detect_git
 }
 
+/// Build Config from collected options.
 fn build_config(options: &InitOptions) -> Config {
     let mut config = Config::default();
 

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -167,6 +167,15 @@ enum Commands {
         /// Bearer token for remote config endpoint
         #[arg(long, requires = "remote_config_url")]
         remote_config_token: Option<String>,
+
+        /// Force git remote auto-detection even when `--remote-config-url` is set.
+        ///
+        /// By default, passing `--remote-config-url` suppresses local git auto-detection
+        /// (remote config is treated as the source of truth for integrations). Use
+        /// `--detect-git` to restore the pre-existing behaviour and auto-add a local
+        /// GitHub/GitLab context alongside the remote config.
+        #[arg(long)]
+        detect_git: bool,
     },
 
     /// Start the MCP server (stdio mode for AI assistants)
@@ -580,6 +589,7 @@ async fn main() -> Result<()> {
                 proxy_auth_type,
                 remote_config_url,
                 remote_config_token,
+                detect_git,
             }) => {
                 handle_init_command(
                     yes,
@@ -596,6 +606,7 @@ async fn main() -> Result<()> {
                     proxy_auth_type,
                     remote_config_url,
                     remote_config_token,
+                    detect_git,
                 )
                 .await?;
             }
@@ -746,6 +757,7 @@ async fn handle_init_command(
     proxy_auth_type: Option<AuthType>,
     remote_config_url: Option<String>,
     remote_config_token: Option<String>,
+    detect_git: bool,
 ) -> Result<()> {
     let config_path = PathBuf::from(INIT_CONFIG_FILE);
     let is_tty = io::stdin().is_terminal();
@@ -773,9 +785,15 @@ async fn handle_init_command(
         );
     }
 
+    let skip_git_detect =
+        should_skip_git_detect(proxy_only, remote_config_url.as_deref(), detect_git);
+
     // Collect options
-    let mut options = if proxy_only {
-        // Skip git remote detection, create minimal config with just proxy
+    let mut options = if skip_git_detect {
+        // Skip git remote detection, create minimal config.
+        // Reason: either --proxy-only was passed, or --remote-config-url was provided
+        // without --detect-git (remote config is the source of truth for integrations,
+        // so an auto-detected local provider would almost always be stale/wrong).
         let ctx_name = context_name.unwrap_or_else(|| {
             std::env::current_dir()
                 .ok()
@@ -1301,6 +1319,24 @@ fn detect_provider_defaults() -> Vec<bool> {
 }
 
 /// Build Config from collected options.
+/// Decide whether `devboy init --yes` should skip local git remote auto-detection.
+///
+/// Git detection is skipped when any of the following holds:
+/// - `--proxy-only` was passed (explicit opt-out, pre-existing behaviour);
+/// - `--remote-config-url` is present and `--detect-git` is not (remote config is
+///   the source of truth for integrations, so a local auto-detected provider would
+///   almost always be stale or conflict).
+fn should_skip_git_detect(
+    proxy_only: bool,
+    remote_config_url: Option<&str>,
+    detect_git: bool,
+) -> bool {
+    if proxy_only {
+        return true;
+    }
+    remote_config_url.is_some() && !detect_git
+}
+
 fn build_config(options: &InitOptions) -> Config {
     let mut config = Config::default();
 
@@ -3936,6 +3972,60 @@ mod tests {
         let options = InitOptions::default();
         let config = build_config(&options);
         assert!(config.contexts.is_empty());
+    }
+
+    // ==========================================================================
+    // should_skip_git_detect tests
+    // ==========================================================================
+
+    #[test]
+    fn test_skip_git_detect_default_behaviour() {
+        // Plain `devboy init --yes` — no proxy, no remote config, no override.
+        // Must preserve pre-existing auto-detect behaviour.
+        assert!(!should_skip_git_detect(false, None, false));
+    }
+
+    #[test]
+    fn test_skip_git_detect_proxy_only() {
+        // --proxy --proxy-only keeps its original skip behaviour.
+        assert!(should_skip_git_detect(true, None, false));
+    }
+
+    #[test]
+    fn test_skip_git_detect_remote_config_implies_skip() {
+        // --remote-config-url alone now suppresses git auto-detection.
+        assert!(should_skip_git_detect(
+            false,
+            Some("https://example.com/config"),
+            false
+        ));
+    }
+
+    #[test]
+    fn test_skip_git_detect_remote_config_with_detect_git_override() {
+        // Users who want both (remote config + local git-detected provider) opt in
+        // explicitly via --detect-git.
+        assert!(!should_skip_git_detect(
+            false,
+            Some("https://example.com/config"),
+            true
+        ));
+    }
+
+    #[test]
+    fn test_skip_git_detect_proxy_only_beats_detect_git() {
+        // --proxy-only is an explicit skip and wins even if --detect-git is also set.
+        assert!(should_skip_git_detect(
+            true,
+            Some("https://example.com/config"),
+            true
+        ));
+    }
+
+    #[test]
+    fn test_skip_git_detect_detect_git_without_remote_config_is_noop() {
+        // --detect-git with no remote config URL doesn't spuriously flip behaviour.
+        assert!(!should_skip_git_detect(false, None, true));
     }
 
     #[test]

--- a/crates/devboy-cli/tests/init_test.rs
+++ b/crates/devboy-cli/tests/init_test.rs
@@ -590,8 +590,8 @@ fn test_init_remote_config_url_skips_git_detection_by_default() {
         "Should contain remote config URL"
     );
     assert!(
-        !content.contains("[contexts.") || !content.contains(".gitlab]"),
-        "Should NOT contain gitlab config section when remote config is the source of truth"
+        !content.contains(".gitlab]"),
+        "Should NOT contain a [contexts.*.gitlab] section when remote config is the source of truth"
     );
     assert!(
         !content.contains("company/project"),

--- a/crates/devboy-cli/tests/init_test.rs
+++ b/crates/devboy-cli/tests/init_test.rs
@@ -552,6 +552,96 @@ fn test_init_with_proxy_only_skips_git_detection() {
 }
 
 #[test]
+fn test_init_remote_config_url_skips_git_detection_by_default() {
+    // Running `devboy init --yes --remote-config-url ...` inside a git repo used to
+    // auto-add a [contexts.*.github]/[contexts.*.gitlab] section from the origin
+    // remote alongside [remote_config]. Remote config is meant to be the source of
+    // truth for integrations, so the local auto-detected provider is almost always
+    // stale/wrong. Issue #151 changed the default to skip git detection in this case.
+    let temp_dir = create_temp_git_repo("git@gitlab.com:company/project.git");
+    let config_path = temp_dir.path().join(".devboy.toml");
+
+    let output = Command::new(devboy_bin())
+        .args([
+            "init",
+            "--yes",
+            "--remote-config-url",
+            "https://example.com/config",
+        ])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "Command should succeed");
+    assert!(
+        !stdout.contains("Detected GitLab"),
+        "Should NOT auto-detect GitLab when --remote-config-url is set"
+    );
+
+    let content = fs::read_to_string(&config_path).unwrap();
+    assert!(
+        content.contains("[remote_config]"),
+        "Should contain [remote_config] section"
+    );
+    assert!(
+        content.contains("https://example.com/config"),
+        "Should contain remote config URL"
+    );
+    assert!(
+        !content.contains("[contexts.") || !content.contains(".gitlab]"),
+        "Should NOT contain gitlab config section when remote config is the source of truth"
+    );
+    assert!(
+        !content.contains("company/project"),
+        "Should NOT contain git-detected project path"
+    );
+}
+
+#[test]
+fn test_init_remote_config_url_with_detect_git_keeps_auto_detection() {
+    // Escape hatch: `--detect-git` restores pre-#151 behaviour for users who
+    // genuinely want both a remote config and an auto-detected local provider.
+    let temp_dir = create_temp_git_repo("git@github.com:test-owner/test-repo.git");
+    let config_path = temp_dir.path().join(".devboy.toml");
+
+    let output = Command::new(devboy_bin())
+        .args([
+            "init",
+            "--yes",
+            "--remote-config-url",
+            "https://example.com/config",
+            "--detect-git",
+        ])
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "Command should succeed");
+    assert!(
+        stdout.contains("Detected GitHub repository"),
+        "Should auto-detect GitHub when --detect-git override is passed"
+    );
+
+    let content = fs::read_to_string(&config_path).unwrap();
+    assert!(
+        content.contains("[remote_config]"),
+        "Should still contain [remote_config] section"
+    );
+    assert!(
+        content.contains("test-owner"),
+        "Should contain auto-detected owner"
+    );
+    assert!(
+        content.contains("test-repo"),
+        "Should contain auto-detected repo"
+    );
+}
+
+#[test]
 fn test_proxy_add_creates_config() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join(".devboy.toml");

--- a/docs/guide/configuration/environment-variables.md
+++ b/docs/guide/configuration/environment-variables.md
@@ -376,6 +376,8 @@ token_key = "remote_config.token"
 devboy init --yes --remote-config-url "https://example.com/config" --remote-config-token "token" --claude
 ```
 
+This generates a minimal `.devboy.toml` with only the `[remote_config]` section — git remote auto-detection is suppressed when `--remote-config-url` is set, since the remote endpoint is expected to supply integration settings. Pass `--detect-git` to override that and also pin a locally auto-detected GitHub/GitLab provider. See [Project initialization](../getting-started/init) for details.
+
 ### Behavior
 
 - Remote config is fetched on each `devboy mcp` startup

--- a/docs/guide/getting-started/init.md
+++ b/docs/guide/getting-started/init.md
@@ -44,6 +44,9 @@ This automatically detects your Git provider from the `origin` remote and create
 | `--proxy-token` | | Proxy token value (stored in keychain automatically, requires `--proxy`) |
 | `--proxy-token-key` | | Custom keychain key for token (default: "proxy.{name}.token", requires `--proxy`) |
 | `--proxy-auth-type` | | Auth type: "bearer", "api_key", or "none" (default: "bearer" if token, else "none") |
+| `--remote-config-url` | | Remote config endpoint; sets `[remote_config]` and, by default, **suppresses git auto-detection** (remote config is treated as the source of truth for integrations) |
+| `--remote-config-token` | | Bearer token for the remote config endpoint (stored in keychain as `remote_config.token`, requires `--remote-config-url`) |
+| `--detect-git` | | Force git remote auto-detection even when `--remote-config-url` is set (restores the pre-#151 behaviour for users who want both a remote config and an auto-detected local provider) |
 
 ## Examples
 
@@ -125,6 +128,34 @@ This skips Git remote detection and creates a minimal config with only the proxy
 
 See [MCP proxy](../configuration/proxy) for more details on proxy configuration.
 
+### Initialize with a remote config endpoint
+
+```bash
+devboy init --yes \
+  --remote-config-url "https://app.devboy.pro/api/config/mcp" \
+  --remote-config-token "your-token-here" \
+  --claude
+```
+
+Generates a minimal `.devboy.toml` that points at the remote config endpoint:
+
+```toml
+[remote_config]
+url = "https://app.devboy.pro/api/config/mcp"
+token_key = "remote_config.token"
+```
+
+**By default, `--remote-config-url` suppresses git remote auto-detection.** The remote config endpoint is treated as the source of truth for integrations, so devboy does not add a local `[contexts.*.github]` / `[contexts.*.gitlab]` section from the current `origin` — a local section would almost always be stale and drift from whatever the remote is actually serving.
+
+If you genuinely want both — a remote config *and* an auto-detected local provider pinned at bootstrap time — add `--detect-git`:
+
+```bash
+devboy init --yes \
+  --remote-config-url "https://app.devboy.pro/api/config/mcp" \
+  --remote-config-token "your-token-here" \
+  --detect-git
+```
+
 ## Auto-detection
 
 When using `--yes` or in interactive mode, devboy automatically detects:
@@ -133,6 +164,13 @@ When using `--yes` or in interactive mode, devboy automatically detects:
 - **GitLab** repositories from SSH (`git@gitlab.com:owner/repo.git`) or HTTPS (`https://gitlab.com/owner/repo`) remotes
 
 The detected provider is pre-selected in interactive mode or automatically configured in `--yes` mode.
+
+**Auto-detection is suppressed when:**
+
+- `--proxy-only` is passed (requires `--proxy`)
+- `--remote-config-url` is passed without `--detect-git`
+
+In both cases the rationale is the same — an external source (a proxy server or a remote config endpoint) is expected to supply the integration settings, so a locally auto-detected provider would just create drift.
 
 ## Token storage
 


### PR DESCRIPTION
Closes #151.

## Problem

`devboy init --yes --remote-config-url <url>` inside a git repo used to produce a `.devboy.toml` with two sections — the requested `[remote_config]` plus an auto-detected `[contexts.*.github]` / `[contexts.*.gitlab]` pulled from the current `origin`. Remote config is meant to be the source of truth for integrations; the extra local section was almost always stale or in conflict with whatever the remote serves.

## Fix

- **New default:** when `--remote-config-url` is present, skip local git auto-detection.
- **Escape hatch:** `--detect-git` restores the pre-#151 behaviour for users who genuinely want both.

The decision is extracted into a pure helper `should_skip_git_detect(proxy_only, remote_config_url, detect_git) -> bool`, which makes it trivially unit-testable.

## What's in this PR

- `crates/devboy-cli/src/main.rs` — new `--detect-git` clap flag, new helper `should_skip_git_detect`, and `handle_init_command` now routes through it instead of the old `if proxy_only { ... } else if yes { ... }` branch. `--proxy-only` behaviour is unchanged (it's folded into the same helper).
- `crates/devboy-cli/src/main.rs` — 6 new unit tests covering every combination of the three inputs.
- `crates/devboy-cli/tests/init_test.rs` — 2 new integration tests that run the actual binary in a temp git repo:
  - `test_init_remote_config_url_skips_git_detection_by_default` (with `gitlab.com` origin, asserts no `[contexts.*.gitlab]` in output, `[remote_config]` is present)
  - `test_init_remote_config_url_with_detect_git_keeps_auto_detection` (with `github.com` origin + `--detect-git`, asserts both sections present)
- `docs/guide/getting-started/init.md` — flag table updated (new entries for `--remote-config-url`, `--remote-config-token`, `--detect-git`), new "Initialize with a remote config endpoint" example section, "Auto-detection" section explains suppression rules for both `--proxy-only` and `--remote-config-url` with the same rationale.
- `docs/guide/configuration/environment-variables.md` — CLI setup note added, cross-links to `init.md`.

## Behavioural matrix

| Flags | Git detection? |
|-------|----------------|
| `devboy init --yes` | ✅ on (unchanged) |
| `devboy init --yes --proxy-only --proxy ...` | ❌ skipped (unchanged) |
| `devboy init --yes --remote-config-url ...` | ❌ **skipped (new default)** |
| `devboy init --yes --remote-config-url ... --detect-git` | ✅ on (opt-in) |
| `devboy init --yes --proxy-only --proxy ... --detect-git` | ❌ skipped — `--proxy-only` wins |

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p devboy-cli --bin devboy` — 6/6 new unit tests pass
- [x] `cargo test -p devboy-cli --test init_test` — 29/29 (including 2 new integration tests) pass
- [x] Pre-existing `test_init_with_proxy_only_skips_git_detection` still passes — `--proxy-only` behaviour is unchanged
- [x] Pre-existing `test_init_yes_creates_config_with_{github,gitlab}` still pass — plain `--yes` behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)