### PR TITLE
fix(executor): accept `parentId` alias in `create_issue` params (#153)

### DIFF
--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -670,6 +670,7 @@ struct CreateIssueParams {
     assignees: Vec<String>,
     #[serde(default, deserialize_with = "deserialize_string_or_number")]
     priority: Option<String>,
+    #[serde(alias = "parentId")]
     parent: Option<String>,
     markdown: Option<bool>,
     #[serde(rename = "projectId")]
@@ -2022,6 +2023,20 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(result, ToolOutput::SingleIssue(_)));
+    }
+
+    #[test]
+    fn create_issue_params_accepts_parent_id_alias() {
+        let args = serde_json::json!({ "title": "t", "parentId": "DEV-799" });
+        let params: CreateIssueParams = serde_json::from_value(args).unwrap();
+        assert_eq!(params.parent.as_deref(), Some("DEV-799"));
+    }
+
+    #[test]
+    fn create_issue_params_still_accepts_parent() {
+        let args = serde_json::json!({ "title": "t", "parent": "DEV-799" });
+        let params: CreateIssueParams = serde_json::from_value(args).unwrap();
+        assert_eq!(params.parent.as_deref(), Some("DEV-799"));
     }
 
     #[tokio::test]

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -82,7 +82,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("description", PropertySchema::string("Issue description/body"));
                 s.add_property("labels", PropertySchema::array(PropertySchema::string("label"), "Labels to add"));
                 s.add_property("assignees", PropertySchema::array(PropertySchema::string("assignee"), "Assignee usernames"));
-                s.add_property("parentId", PropertySchema::string("Parent issue key to create a subtask (e.g., 'CU-abc123' or 'DEV-42'). Only supported by ClickUp. Alias: 'parent'."));
+                s.add_property("parentId", PropertySchema::string("Parent issue key to create a subtask (e.g., 'CU-abc123' or 'DEV-42'). Only supported by ClickUp."));
                 s.add_property("markdown", PropertySchema::boolean("Whether the description is markdown (default: true). When true, ClickUp renders formatted text."));
                 s.add_property("projectId", PropertySchema::string("Jira project key (not numeric ID) for issue creation (e.g., \"PROJ\"). Optional — overrides the default project."));
                 s.add_property("issueType", PropertySchema::string("Issue type (e.g., \"Task\", \"Bug\", \"Story\"). Default: \"Task\". Removed by providers that don't support it."));

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -82,7 +82,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("description", PropertySchema::string("Issue description/body"));
                 s.add_property("labels", PropertySchema::array(PropertySchema::string("label"), "Labels to add"));
                 s.add_property("assignees", PropertySchema::array(PropertySchema::string("assignee"), "Assignee usernames"));
-                s.add_property("parent", PropertySchema::string("Parent issue key to create a subtask (e.g., 'CU-abc123' or 'DEV-42'). Only supported by ClickUp."));
+                s.add_property("parentId", PropertySchema::string("Parent issue key to create a subtask (e.g., 'CU-abc123' or 'DEV-42'). Only supported by ClickUp. Alias: 'parent'."));
                 s.add_property("markdown", PropertySchema::boolean("Whether the description is markdown (default: true). When true, ClickUp renders formatted text."));
                 s.add_property("projectId", PropertySchema::string("Jira project key (not numeric ID) for issue creation (e.g., \"PROJ\"). Optional — overrides the default project."));
                 s.add_property("issueType", PropertySchema::string("Issue type (e.g., \"Task\", \"Bug\", \"Story\"). Default: \"Task\". Removed by providers that don't support it."));


### PR DESCRIPTION
## Summary

Fixes #153 — the `create_issue` MCP tool silently dropped the `parentId` argument, so tasks were created without a parent link and no error was surfaced to the caller.

Root cause: `CreateIssueParams` in the executor only declared a `parent` field, while the NestJS tool schema and `update_issue` both use `parentId`. Serde's default unknown-field handling caused the value to be ignored.

## Changes

- `crates/devboy-executor/src/executor.rs`: add `#[serde(alias = "parentId")]` on `CreateIssueParams.parent` — both spellings now deserialize correctly, with full back-compat for clients still sending the legacy `parent` key.
- `crates/devboy-executor/src/tools.rs`: update the public `create_issue` tool schema to advertise `parentId` (alias: `parent`), matching `update_issue`.
- Two regression tests covering both aliases.

## Test plan

- [x] `cargo test -p devboy-executor` — 152 passed, 0 failed (2 new tests included)
- [x] `cargo clippy -p devboy-executor --all-targets -- -D warnings` — clean
- [ ] Verify end-to-end in a consuming MCP client that `create_issue` with `parentId: "DEV-42"` produces a subtask