### PR TITLE
feat(skills): category 0 — self-bootstrap skills (#159)

### DIFF
--- a/skills/00-self-bootstrap/devboy-repair/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-repair/SKILL.md
@@ -37,51 +37,41 @@ devboy doctor --format json > /tmp/devboy-doctor.json
 jq '.' /tmp/devboy-doctor.json
 ```
 
-Read the JSON: every check has `{ id, status, message, remediation }`. `status = "fail"` entries are the ones to fix.
+The JSON shape is:
+
+```json
+{
+  "version": { "current_version": "...", "latest_version": "...", "update_available": false, "install_method": "...", "update_command": "devboy upgrade" },
+  "results": [
+    { "id": "environment.os_support", "category": "Environment", "name": "...", "status": "pass|warning|error", "message": "...", "details": null, "fix_command": "devboy init", "fix_url": null }
+  ]
+}
+```
+
+Every result has `{ id, category, name, status, message, details, fix_command, fix_url }`. Status values are `pass` (good), `warning` (recoverable but worth attention), and `error` (must be fixed). Any non-null `fix_command` is a suggested starting point.
 
 If the command itself fails to run, `devboy` is not on `PATH` — install or re-link the binary before continuing.
 
 ### 2. Classify by check id
 
-Work through the failing checks in order. Common buckets:
+The real check id taxonomy (from `devboy doctor --list-checks`):
 
-**`config.*`** — the `.devboy.toml` is missing, malformed, or points at something that no longer exists.
-
-- `config.exists` fails → run `devboy init` (see `devboy-setup`).
-- `config.valid_toml` fails → `jq .` or `cat .devboy.toml` to find the syntax error; back up and re-run `devboy init --force` if unsalvageable.
-- `config.contexts.<name>.missing` → edit `.devboy.toml` to either remove the stale context reference or re-run `devboy init` to regenerate.
-
-**`providers.*`** — credentials are missing or invalid.
-
-- `providers.<name>.no_token` → `devboy config set-secret <name>.token` (or set the env var on CI).
-- `providers.<name>.unauthorised` (401) → the token is wrong or expired. Rotate and re-store.
-- `providers.<name>.forbidden` (403) → the token lacks the required scopes. Re-issue the token with the scopes listed in the remediation hint.
-- `providers.<name>.unreachable` → network or DNS issue. Verify with `curl -v <base-url>`.
-
-**`keychain.*`** — the OS keychain is not reachable.
-
-- macOS / Windows keychain locked → unlock the user session; re-run.
-- Linux headless (no D-Bus) → move to env vars: `export DEVBOY_<PROVIDER>_TOKEN=...` and re-run `devboy doctor`.
-
-**`proxy.servers.*`** — an upstream MCP proxy is not responding.
-
-- Network failure → verify with `curl -v <proxy URL>`.
-- Bad token → re-issue via `devboy proxy add <name> --url <url> --force` with a new `--token`.
-
-**`remote_config.*`** — the remote config endpoint is down or the token is wrong.
-
-- 401 / 403 → re-issue the `--remote-config-token`.
-- 5xx / timeout → retry; if persistent, the remote endpoint is the problem and local config takes over (remote config is best-effort).
+- **Environment** — `environment.os_support`, `environment.config_dir`, `environment.credential_store`. The first two warn when the config directory is missing (run `devboy init`); the third warns when the OS keychain daemon isn't reachable (move tokens to env vars — see step 3).
+- **Configuration** — `config.exists`, `config.valid_toml`, `config.active_context`. Missing file → `devboy init`; invalid TOML → open `.devboy.toml` in an editor or run `devboy init --force`; stale active context → edit the `active_context` field or re-run `devboy init`.
+- **Credentials** — `credentials.github`, `credentials.gitlab`, `credentials.clickup`, `credentials.jira`, `credentials.slack`. A `warning`/`error` means the token is missing. Store it with `devboy config set-secret <provider>.token` or set the matching `DEVBOY_<PROVIDER>_TOKEN` / `<PROVIDER>_TOKEN` env var.
+- **Provider Connectivity** — `providers.github`, `providers.gitlab`, `providers.clickup`, `providers.jira`, `providers.slack`. `error` means the token is rejected (401/403) or the endpoint is unreachable. 401/403 → rotate the token. Unreachable → check network / base URL.
+- **MCP Server** — `mcp.tools` reports on the built-in tool filter; only warns if the config disables every tool.
+- **Proxy** — `proxy.servers` checks upstream MCP proxy connectivity. Failure usually means a bad `--proxy-token` or a dead URL; re-issue with `devboy proxy add <name> --url <url> --force --token <new>`.
 
 ### 3. Re-verify
 
 After each fix:
 
 ```bash
-devboy doctor --format json | jq '[.checks[] | select(.status=="fail")] | length'
+devboy doctor --format json | jq '[.results[] | select(.status=="error")] | length'
 ```
 
-Zero failing checks is the target. Repeat step 2 until the number reaches zero.
+Zero `error` results is the target (some `warning`s are expected — e.g. "no config file" until `devboy init` runs). Repeat step 2 until every `error` is resolved.
 
 ### 4. Smoke-test the tool bundle
 

--- a/skills/00-self-bootstrap/devboy-repair/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-repair/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: devboy-repair
+description: Diagnose and fix a broken devboy-tools setup — corrupt config, missing tokens, keychain trouble, wrong paths.
+category: self-bootstrap
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "repair devboy"
+  - "fix devboy"
+  - "devboy is broken"
+  - "devboy doctor failing"
+tools:
+  - doctor
+  - config
+  - test
+---
+
+# devboy-repair
+
+Walk a misbehaving `devboy-tools` setup back to health. This skill is driven by `devboy doctor --format json` — the structured output is the source of truth for what's wrong, and every repair step maps to a diagnostic code.
+
+## When to use
+
+- `devboy doctor` exits non-zero.
+- Tool calls return `ProviderUnsupported` unexpectedly.
+- The user reports "it worked yesterday, now it does not".
+- `devboy test <provider>` prints a 401 / 403 / network error.
+
+If the issue is "nothing is configured yet" — use `devboy-setup` instead. This skill assumes a prior configuration existed.
+
+## Procedure
+
+### 1. Pin the fault
+
+```bash
+devboy doctor --format json > /tmp/devboy-doctor.json
+jq '.' /tmp/devboy-doctor.json
+```
+
+Read the JSON: every check has `{ id, status, message, remediation }`. `status = "fail"` entries are the ones to fix.
+
+If the command itself fails to run, `devboy` is not on `PATH` — install or re-link the binary before continuing.
+
+### 2. Classify by check id
+
+Work through the failing checks in order. Common buckets:
+
+**`config.*`** — the `.devboy.toml` is missing, malformed, or points at something that no longer exists.
+
+- `config.exists` fails → run `devboy init` (see `devboy-setup`).
+- `config.valid_toml` fails → `jq .` or `cat .devboy.toml` to find the syntax error; back up and re-run `devboy init --force` if unsalvageable.
+- `config.contexts.<name>.missing` → edit `.devboy.toml` to either remove the stale context reference or re-run `devboy init` to regenerate.
+
+**`providers.*`** — credentials are missing or invalid.
+
+- `providers.<name>.no_token` → `devboy config set-secret <name>.token` (or set the env var on CI).
+- `providers.<name>.unauthorised` (401) → the token is wrong or expired. Rotate and re-store.
+- `providers.<name>.forbidden` (403) → the token lacks the required scopes. Re-issue the token with the scopes listed in the remediation hint.
+- `providers.<name>.unreachable` → network or DNS issue. Verify with `curl -v <base-url>`.
+
+**`keychain.*`** — the OS keychain is not reachable.
+
+- macOS / Windows keychain locked → unlock the user session; re-run.
+- Linux headless (no D-Bus) → move to env vars: `export DEVBOY_<PROVIDER>_TOKEN=...` and re-run `devboy doctor`.
+
+**`proxy.servers.*`** — an upstream MCP proxy is not responding.
+
+- Network failure → verify with `curl -v <proxy URL>`.
+- Bad token → re-issue via `devboy proxy add <name> --url <url> --force` with a new `--token`.
+
+**`remote_config.*`** — the remote config endpoint is down or the token is wrong.
+
+- 401 / 403 → re-issue the `--remote-config-token`.
+- 5xx / timeout → retry; if persistent, the remote endpoint is the problem and local config takes over (remote config is best-effort).
+
+### 3. Re-verify
+
+After each fix:
+
+```bash
+devboy doctor --format json | jq '[.checks[] | select(.status=="fail")] | length'
+```
+
+Zero failing checks is the target. Repeat step 2 until the number reaches zero.
+
+### 4. Smoke-test the tool bundle
+
+```bash
+devboy tools list
+devboy tools call get_issues '{"limit": 3}'
+```
+
+Either must produce real data. `ProviderUnsupported` at this point means the provider is mis-configured (wrong project id, wrong list id, wrong repo owner) — go back to step 2.
+
+## Guardrails
+
+- **Never print token values** into the chat. When the user asks "what is my token?" the answer is "it lives in your keychain — re-issue it from the provider if you need a copy". Treat every `*_token` / `set-secret` argument as opaque.
+- **Do not commit changes to `.devboy.toml`** automatically — config changes are a user decision.
+- **If two checks disagree**, trust `devboy doctor` — it is the only deterministic source of ground truth here.
+
+## Success criteria
+
+- `devboy doctor` exits zero with no failing checks.
+- At least one real tool call against each previously-broken provider succeeds.
+- If the session started with a specific complaint from the user (e.g. "get_issues returns nothing"), the exact reported behaviour is now correct.

--- a/skills/00-self-bootstrap/devboy-setup/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devboy-setup
-description: Walk the user through initial devboy configuration from scratch.
+description: Walk a user through configuring devboy-tools from scratch — providers, credentials, Claude Code registration, verification.
 category: self-bootstrap
 version: 1
 compatibility: devboy-tools >= 0.18
@@ -8,28 +8,126 @@ activation:
   - "setup devboy"
   - "configure devboy"
   - "initialise devboy"
+  - "install devboy"
 tools:
-  - doctor
+  - init
   - config
+  - doctor
+  - test
 ---
 
 # devboy-setup
 
-> Placeholder content. Fleshed out in PR-B (#159). The frontmatter above is
-> the real schema; the body below is a skeleton so the embedded source has
-> a valid file to enumerate during PR-A.
+Configure `devboy-tools` end-to-end for the current project or the current user. The skill handles the happy path and the common "something is not quite right" branches; for a broken state that needs triage, use `devboy-repair`.
 
-## What this skill does
+## When to use
 
-Walks a user through configuring `devboy-tools` from scratch: detecting
-the environment, running `devboy init`, storing tokens in the OS keychain
-(or the environment-variable fallback chain), and verifying with
-`devboy test <provider>` and `devboy doctor`.
+- A new clone of a project and `.devboy.toml` is missing.
+- A new machine and `devboy doctor` reports no configured providers.
+- A user asks "how do I set devboy up for this repo?" or equivalent.
 
-## Commands the skill relies on
+## Preconditions
 
-- `devboy init --yes` — non-interactive bootstrap
-- `devboy config set <key> <value>` — set a configuration key
-- `devboy config set-secret <key>` — store a secret in the keychain
-- `devboy doctor --format json` — diagnose the current state
-- `devboy test <provider>` — verify provider connectivity
+1. `devboy` is on `PATH`. If it is not:
+
+   ```bash
+   devboy tools call doctor '{}' >/dev/null 2>&1 || \
+     echo "devboy is not on PATH — install it via 'npm install -g @devboy-tools/cli' first"
+   ```
+
+2. The user knows which provider(s) they want to configure (GitHub, GitLab, ClickUp, Jira, Slack, Fireflies).
+
+## Procedure
+
+### 1. Pick the install target
+
+- If a `.devboy.toml` already exists in the repo root, the skill is operating on an already-initialised project — jump to **step 4**.
+- If not, run `devboy init` interactively or use `--yes` for auto-detection:
+
+  ```bash
+  devboy init --yes
+  ```
+
+  This auto-detects GitHub / GitLab from the `origin` remote and creates `.devboy.toml`.
+
+### 2. Non-interactive bootstrap with remote config
+
+When the user mentions a remote configuration endpoint, prefer that path — it keeps the machine's local config minimal and avoids drift:
+
+```bash
+devboy init --yes \
+  --remote-config-url "<URL from the user>" \
+  --remote-config-token "<token>" \
+  --claude
+```
+
+By design (ADR-DEV-798), `--remote-config-url` suppresses the local git auto-detection — the remote endpoint is treated as the source of truth for integrations.
+
+### 3. Register with Claude Code
+
+If the `--claude` flag was not passed during init, register separately:
+
+```bash
+devboy init --claude
+# or, equivalently:
+claude mcp add devboy -- devboy mcp
+```
+
+### 4. Add per-provider tokens
+
+For each provider the user wants to exercise:
+
+```bash
+# GitHub
+devboy config set github.owner <owner>
+devboy config set github.repo <repo>
+devboy config set-secret github.token          # prompts for the value
+
+# GitLab
+devboy config set gitlab.url https://gitlab.com
+devboy config set gitlab.project_id <owner/repo or numeric id>
+devboy config set-secret gitlab.token
+
+# ClickUp
+devboy config set clickup.list_id <list id>
+devboy config set clickup.team_id <team id>
+devboy config set-secret clickup.token
+
+# Jira (Cloud)
+devboy config set jira.url https://<company>.atlassian.net
+devboy config set jira.project_key <KEY>
+devboy config set jira.email <email>
+devboy config set-secret jira.token
+```
+
+On CI / headless hosts where the OS keychain is unavailable, set the corresponding env vars instead (`DEVBOY_GITHUB_TOKEN`, `DEVBOY_GITLAB_TOKEN`, …). See the `README` for the full fallback chain.
+
+### 5. Verify
+
+```bash
+devboy test github            # once per configured provider
+devboy doctor                 # overall health check
+```
+
+Both must print green. If either flags a failure, stop and fall through to `devboy-repair`.
+
+### 6. Confirm the tool bundle is wired
+
+```bash
+devboy tools list
+devboy tools call get_issues '{"limit": 3}'
+```
+
+If `tools list` is empty or the tool call returns `ProviderUnsupported`, something was misconfigured — go to `devboy-repair`.
+
+## Success criteria
+
+- `devboy doctor` reports every configured provider as healthy.
+- `devboy test <provider>` succeeds for each provider the user cares about.
+- At least one real tool call (`get_issues`, `get_merge_requests`, or the equivalent for the provider) returns data rather than `ProviderUnsupported`.
+- If the user asked for Claude Code integration, `claude mcp list` shows `devboy`.
+
+## Non-goals
+
+- This skill does not configure a proxy MCP server. Use `devboy proxy add` with its documented flags.
+- This skill does not migrate an existing setup between machines — it assumes a fresh install.

--- a/skills/00-self-bootstrap/devboy-setup/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-setup/SKILL.md
@@ -31,7 +31,7 @@ Configure `devboy-tools` end-to-end for the current project or the current user.
 1. `devboy` is on `PATH`. If it is not:
 
    ```bash
-   devboy tools call doctor '{}' >/dev/null 2>&1 || \
+   command -v devboy >/dev/null 2>&1 || \
      echo "devboy is not on PATH — install it via 'npm install -g @devboy-tools/cli' first"
    ```
 

--- a/skills/00-self-bootstrap/devboy-tools-catalog/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-tools-catalog/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: devboy-tools-catalog
+description: Enumerate and introspect the active tool bundle — names, categories, schemas, how to invoke each tool from the CLI.
+category: self-bootstrap
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "list devboy tools"
+  - "what tools does devboy have"
+  - "show devboy tools"
+  - "inspect devboy tools"
+tools:
+  - tools
+  - config
+---
+
+# devboy-tools-catalog
+
+Answer the question "what tools does the current `devboy-tools` installation expose, and how do I invoke them?". Useful as the first step of any exploration — other skills invoke tools through `devboy tools call`, and that assumes the agent knows the tool names and argument shapes.
+
+## When to use
+
+- First contact with a devboy setup — the agent wants to know what's available before writing a multi-tool recipe.
+- Before writing a new skill — confirm the tool names and argument shapes you plan to use actually exist in the active configuration.
+- To confirm that a configured provider's tools really show up (e.g. after `devboy-setup` or `devboy-repair`).
+
+## Procedure
+
+### 1. Enumerate
+
+```bash
+devboy tools list
+```
+
+Output includes each tool's name, enabled/disabled status, and the category it belongs to (`git_repository`, `issue_tracker`, `epics`, `releases`, `meeting_notes`, `messenger`, plus pipeline helpers). Tools from a provider that is not configured are hidden — if you expected a tool and do not see it, that provider is not active in this setup.
+
+### 2. Inspect one tool's schema
+
+```bash
+devboy tools call get_issues --help 2>/dev/null || \
+  devboy mcp <<< '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
+    jq '.result.tools[] | select(.name=="get_issues")'
+```
+
+The second form prints the full JSON Schema (required fields, enums, provider-specific `cf_*` custom-field extensions, etc.). Use it when you need to know exactly what an argument accepts.
+
+### 3. Invoke a tool
+
+Synchronous call via the CLI:
+
+```bash
+# POSIX shells
+devboy tools call get_issues '{"state": "open", "limit": 20}'
+
+# Windows cmd.exe / PowerShell
+devboy tools call get_issues "{\"state\": \"open\", \"limit\": 20}"
+```
+
+The default JSON payload is `{}`. For tools that take no arguments, omit it entirely:
+
+```bash
+devboy tools call list_contexts
+```
+
+### 4. Filter to a category
+
+If you only care about issue-tracker tools, filter the list:
+
+```bash
+devboy tools list | grep -E "issue|comment"
+```
+
+(There is no built-in `--category` filter on `tools list` today — that is a follow-up.)
+
+### 5. Disable unused tools
+
+Skills that only need a handful of tools can disable the rest to shrink the prompt that an MCP client sees. This is optional — most skills leave the defaults alone.
+
+```bash
+devboy tools disable some_unused_tool another_one
+devboy tools list          # confirm
+devboy tools reset         # undo
+```
+
+## Key concepts worth narrating to the agent
+
+- **Tools are provider-scoped.** A given install only exposes the tools for the providers that are configured. `devboy-tools-catalog` therefore gives a snapshot, not a universal list.
+- **Categories are coarse.** `ToolCategory` has six members (`GitRepository`, `IssueTracker`, `Epics`, `Releases`, `MeetingNotes`, `Messenger`). A tool from an uncovered category is hidden by the executor.
+- **Enrichment happens at `tools/list` time.** Each provider gets a chance to add provider-specific parameters to the schema (custom fields, enum values drawn from real project metadata). The schema you see in `tools/list` is already enriched — the agent does not need to flatten or merge anything.
+- **Prefer `devboy tools call` over MCP** when a skill only needs one tool. It avoids paying the full `tools/list` context tax the MCP transport imposes.
+
+## Success criteria
+
+- The agent can name the tools that apply to the current configuration without guessing.
+- For any tool the agent plans to call next, the argument shape matches the real schema.
+- The agent knows whether a tool is shipped but disabled versus not available at all (different problems, different fixes).

--- a/skills/00-self-bootstrap/devboy-tools-catalog/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-tools-catalog/SKILL.md
@@ -32,17 +32,18 @@ Answer the question "what tools does the current `devboy-tools` installation exp
 devboy tools list
 ```
 
-Output includes each tool's name, enabled/disabled status, and the category it belongs to (`git_repository`, `issue_tracker`, `epics`, `releases`, `meeting_notes`, `messenger`, plus pipeline helpers). Tools from a provider that is not configured are hidden — if you expected a tool and do not see it, that provider is not active in this setup.
+Output is a flat list of tool names with enabled/disabled status — `devboy tools list` does not print descriptions or categories itself. Tools from providers that are not configured for the active context are filtered out, so an empty or short list almost always means "no provider is wired up yet" rather than "devboy is broken".
 
 ### 2. Inspect one tool's schema
 
+`devboy tools call` does not take `--help`; the schema is not served as a flag. The only way to see a tool's full JSON Schema (required fields, enums, provider-specific `cf_*` custom-field extensions) is to ask the MCP server directly:
+
 ```bash
-devboy tools call get_issues --help 2>/dev/null || \
-  devboy mcp <<< '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
-    jq '.result.tools[] | select(.name=="get_issues")'
+devboy mcp <<< '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
+  jq '.result.tools[] | select(.name=="get_issues")'
 ```
 
-The second form prints the full JSON Schema (required fields, enums, provider-specific `cf_*` custom-field extensions, etc.). Use it when you need to know exactly what an argument accepts.
+The MCP server exits after serving one request on stdin, so no background process remains.
 
 ### 3. Invoke a tool
 


### PR DESCRIPTION
Part of #156. Depends on and is stacked on top of **#167**.

Closes #159.

Fills the `skills/00-self-bootstrap/` directory with three real SKILL.md files, replacing the placeholder `devboy-setup` landed in #167.

## Skills

| Name | Scope |
|------|-------|
| `devboy-setup` | Walk a user through configuring devboy-tools from scratch — init, provider tokens (keychain + env-var fallback), Claude Code registration, verification via `devboy test` / `devboy doctor`. Explicitly covers the `--remote-config-url` path from DEV-798. |
| `devboy-repair` | `devboy doctor --format json`-driven triage: maps failing check ids (`config.*` / `providers.*` / `keychain.*` / `proxy.servers.*` / `remote_config.*`) to concrete remediation steps. Includes guardrails (never log token values, never auto-commit `.devboy.toml`). |
| `devboy-tools-catalog` | Introspects the active tool bundle — listing, schema inspection (with the full `tools/list` JSON-RPC form), CLI invocation (POSIX vs Windows quoting), category filtering, selective disable. The "first contact" skill for exploring a new setup. |

## Conventions

- English-only per ADR-016.
- CLI-first tool invocation (`devboy tools call <name>`) — no hard-coded MCP server names.
- Minimal YAML frontmatter: 4 required + 3 recommended fields, unknown keys preserved.
- Bodies stay ≤ 1 page each.

## Test plan

- [x] `cargo run -q -p devboy-cli -- skills list` prints all three under `[self-bootstrap]` with the right description and version.
- [x] `cargo run -q -p devboy-cli -- skills show devboy-setup` (and the other two) returns valid parsed frontmatter + body.
- [x] Pre-existing integration tests (`cargo test -p devboy-cli --test skills_test`) — 10/10 pass against the now-real skill content.

## Stacked on #167

This PR branches off `feat/skills-infra-157-158` and targets that branch. Once #167 merges into `main`, GitHub will automatically retarget this PR to `main` (or I'll rebase manually if needed).

## Out of scope

- Category 1–5 skills are separate PRs (#160, #161, #164, #165).
- Populating `skills/history.json` with the real SHA256 of these files — handled by the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)