### PR TITLE
feat(skills): category 5 — messenger via Slack (3 skills, #165)

### DIFF
--- a/skills/05-messenger/devboy-chat-search/SKILL.md
+++ b/skills/05-messenger/devboy-chat-search/SKILL.md
@@ -36,7 +36,7 @@ If the user said something like "in #eng" or "in the deploys channel", resolve t
 devboy tools call get_messenger_chats '{"search": "eng", "limit": 10}'
 ```
 
-Useful filters: `chat_type` (`direct` / `group` / `channel`), `include_inactive` (archived chats are hidden by default), `cursor` for pagination.
+Useful filters: `chat_type` (`direct` / `group` / `channel`), `include_inactive` (archived chats are hidden by default). Note: `cursor`-based pagination is accepted by the tool's argument schema today but the response is formatted as text and does not surface a `next_cursor` back to the caller — narrow the hit list with `search` / `limit` instead, or refine the query.
 
 ### 2. Run the search
 
@@ -63,15 +63,16 @@ devboy tools call search_chat_messages '{
 
 `since` / `until` are provider-native timestamps (Slack passes them straight through — floating-point epoch seconds, as strings). If the user phrases a window in natural language ("yesterday", "last week"), convert to epoch seconds before calling.
 
-### 3. Page through large result sets
+### 3. Narrow a too-large result set
 
-`search_chat_messages` returns at most `limit` hits per call (capped at 1000). If the response carries a `cursor`, walk the pages:
+`search_chat_messages` returns at most `limit` hits per call (capped at 1000). The response is rendered as formatted text and **does not surface a `next_cursor` back to the caller** today, so cursor-based pagination is not actionable from the tool output. Instead of trying to page, narrow the query:
 
-```bash
-devboy tools call search_chat_messages '{"query": "rollback", "limit": 100, "cursor": "<cursor-from-previous-call>"}'
-```
+- Tighten `since` / `until` to a smaller window.
+- Add distinguishing words to `query`.
+- Scope with `chat_id` to the channel the user actually meant.
+- Raise `limit` as a last resort, but the hit list gets harder to skim fast.
 
-Stop when a page returns no cursor, or when you have enough recent material to answer.
+If cursor pagination becomes genuinely necessary for a user's workflow, that requires a tool-side change to expose the pagination metadata, not a skill-side workaround.
 
 ### 4. Rank and present
 
@@ -80,12 +81,12 @@ Before handing the hits back to the user:
 - **Sort by recency.** Messengers default to relevance; users almost always want "the most recent mention" first. Override the order client-side.
 - **One line per hit.** Channel (or DM partner) + author + date + a one-line excerpt (≤ 120 chars, collapse newlines).
 - **Deduplicate threads.** If multiple hits belong to the same thread, show the root hit once with a count of matching replies.
-- **Link when the provider supports it.** Slack responses include permalinks — surface them so the user can jump straight to the message.
+- **Cite coordinates, not permalinks.** The unified `MessengerMessage` type does not include a `permalink` field, so do not promise jump-to-message URLs. Surface the `chat_id` + message `id` / `timestamp` instead — that's enough for the user to open the message directly in Slack (`slack://channel?team=…&id=<chat_id>&message=<ts>`) or paste into a helper script.
 
 Example render:
 
 ```
-#eng        alice   2026-04-15 14:02   "…rolling back v2.4.1, see incident-204…"  (permalink)
+#eng        alice   2026-04-15 14:02   "…rolling back v2.4.1, see incident-204…"  (C0123/ts=1712584920.010)
 DM bob      bob     2026-04-14 09:31   "feature flag cutover is done on staging"
 ```
 

--- a/skills/05-messenger/devboy-chat-search/SKILL.md
+++ b/skills/05-messenger/devboy-chat-search/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: devboy-chat-search
+description: Search messenger history for messages mentioning a keyword, optionally scoped to one chat or a date window.
+category: messenger
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "find slack message about"
+  - "search messenger for"
+  - "who mentioned X in slack"
+  - "find the message where"
+  - "search chat for"
+tools:
+  - get_messenger_chats
+  - search_chat_messages
+---
+
+# devboy-chat-search
+
+Locate one or more messages across the configured messenger (Slack today, additional providers as they come online) by keyword, optional chat scope, and optional time window. The skill returns a ranked list of hits — it does **not** condense a long conversation into a narrative; for that, use `devboy-chat-summary`.
+
+## When to use
+
+- The user asks "find the slack message where Alice mentioned the rollback", "search messenger for 'feature flag cutover'", or similar.
+- Another skill (e.g. `devboy-solve-issue`) needs to cite the originating chat discussion before acting on a ticket.
+- The user remembers a phrase but not the channel or the author.
+
+## Procedure
+
+### 1. Resolve a chat scope (only if the user named one)
+
+If the user said something like "in #eng" or "in the deploys channel", resolve the humanised name to a `chat_id` first. Searching without a scope is also fine — it's just slower and noisier.
+
+```bash
+# Narrow by name — pick the best match from the returned list
+devboy tools call get_messenger_chats '{"search": "eng", "limit": 10}'
+```
+
+Useful filters: `chat_type` (`direct` / `group` / `channel`), `include_inactive` (archived chats are hidden by default), `cursor` for pagination.
+
+### 2. Run the search
+
+`search_chat_messages` takes a free-text `query` and optional `chat_id`, plus a provider-timestamp `since` / `until` window when the user cares about recency:
+
+```bash
+# Global search
+devboy tools call search_chat_messages '{"query": "rollback", "limit": 30}'
+
+# Scoped to one chat
+devboy tools call search_chat_messages '{
+  "query": "feature flag cutover",
+  "chat_id": "C0123456789",
+  "limit": 50
+}'
+
+# Last week, any chat
+devboy tools call search_chat_messages '{
+  "query": "incident",
+  "since": "1712448000.000000",
+  "until": "1713052800.000000"
+}'
+```
+
+`since` / `until` are provider-native timestamps (Slack passes them straight through — floating-point epoch seconds, as strings). If the user phrases a window in natural language ("yesterday", "last week"), convert to epoch seconds before calling.
+
+### 3. Page through large result sets
+
+`search_chat_messages` returns at most `limit` hits per call (capped at 1000). If the response carries a `cursor`, walk the pages:
+
+```bash
+devboy tools call search_chat_messages '{"query": "rollback", "limit": 100, "cursor": "<cursor-from-previous-call>"}'
+```
+
+Stop when a page returns no cursor, or when you have enough recent material to answer.
+
+### 4. Rank and present
+
+Before handing the hits back to the user:
+
+- **Sort by recency.** Messengers default to relevance; users almost always want "the most recent mention" first. Override the order client-side.
+- **One line per hit.** Channel (or DM partner) + author + date + a one-line excerpt (≤ 120 chars, collapse newlines).
+- **Deduplicate threads.** If multiple hits belong to the same thread, show the root hit once with a count of matching replies.
+- **Link when the provider supports it.** Slack responses include permalinks — surface them so the user can jump straight to the message.
+
+Example render:
+
+```
+#eng        alice   2026-04-15 14:02   "…rolling back v2.4.1, see incident-204…"  (permalink)
+DM bob      bob     2026-04-14 09:31   "feature flag cutover is done on staging"
+```
+
+## Success criteria
+
+- The hits all contain the query term (the provider did real matching, not a partial / fuzzy miss the skill silently tolerated).
+- The list is ordered newest-first and limited to what the user asked for — no dumping 500 rows when the user said "find the message".
+- Channel, author, and date are present for every hit; excerpts are truncated, not walls of text.
+
+## Guardrails
+
+- Messenger content is often confidential. Do not forward raw message bodies to external systems (trackers, PR descriptions, documentation) without the user explicitly asking for that forwarding.
+- If the configured Slack token lacks the read scopes (`channels:history`, `groups:history`, `im:history`, `mpim:history`), search results will be incomplete or empty. When hits look suspiciously thin, run `devboy test slack` and check the "Missing scopes" line.
+
+## Non-goals
+
+- This skill does not summarise a long channel or catch the user up on a day — use `devboy-chat-summary` for that.
+- It does not send or forward anything — use `devboy-notify` when the user wants to post.

--- a/skills/05-messenger/devboy-chat-summary/SKILL.md
+++ b/skills/05-messenger/devboy-chat-summary/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: devboy-chat-summary
+description: Catch the user up on a channel or DM by summarising messages over a time window, chunk by chunk, into grouped bullet points.
+category: messenger
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "summarise today's messages"
+  - "what happened in #eng this week"
+  - "catch me up on the deploy channel"
+  - "summarise slack"
+  - "summary of chat"
+tools:
+  - get_messenger_chats
+  - get_chat_messages
+---
+
+# devboy-chat-summary
+
+Produce a concise, grouped summary of what happened in a chat (channel, group, or DM) over a user-specified window. The skill pulls message history in pages, summarises each page, then merges the page-level summaries into a single grouped bullet list — it does **not** keyword-search across chats (that's `devboy-chat-search`) and it does **not** send anything (that's `devboy-notify`).
+
+## When to use
+
+- The user asks "catch me up on the deploy channel", "what did #eng discuss this morning?", or "summary of my DMs with Alice this week".
+- Another skill needs a short narrative of what a channel has been talking about before making a decision.
+- The user was offline and wants a quick briefing before opening the messenger UI.
+
+## Procedure
+
+### 1. Resolve the chat
+
+If the user named the chat by a humanised handle (`#eng`, "the deploy channel", "DMs with Alice"), look up the `chat_id`:
+
+```bash
+devboy tools call get_messenger_chats '{"search": "eng", "limit": 10}'
+# Pick the match whose name / topic clearly corresponds to what the user said.
+```
+
+If the user already handed over a `chat_id`, skip this step.
+
+### 2. Convert the window to provider timestamps
+
+`get_chat_messages` takes `since` / `until` as provider-native timestamps (for Slack: floating-point epoch seconds, as strings — e.g. `"1712448000.000000"`). Convert the user's natural-language window ("today", "this week", "since Monday") into those before calling. Default to **the last 24 hours** when the user does not name a window.
+
+### 3. Pull messages in pages — do not load the whole history
+
+Paginate via the response `cursor`. Cap each page at 200 messages to keep chunks small enough to summarise cleanly:
+
+```bash
+# First page
+devboy tools call get_chat_messages '{
+  "chat_id": "C0123456789",
+  "since": "1713052800.000000",
+  "until": "1713139200.000000",
+  "limit": 200
+}'
+
+# Follow-up pages: pass the cursor from the previous response
+devboy tools call get_chat_messages '{
+  "chat_id": "C0123456789",
+  "since": "1713052800.000000",
+  "until": "1713139200.000000",
+  "limit": 200,
+  "cursor": "<cursor-from-previous-call>"
+}'
+```
+
+If a response carries no cursor, you have the full window. If a thread is referenced by `thread_id` and the user asked about a specific thread, pull its replies separately:
+
+```bash
+devboy tools call get_chat_messages '{"chat_id": "C0123456789", "thread_id": "1712450000.001500", "limit": 200}'
+```
+
+### 4. Summarise chunk by chunk, then merge
+
+Rather than feeding the entire history into one summary prompt:
+
+1. **Per page**, draft 3–6 bullet points: decisions, open questions, action items, notable quotes (with author handle).
+2. **Merge** the page-level bullets into a single list, collapsing duplicates and merging threads that span pages.
+3. **Group the final list by topic**, not by time. Suggested top-level groups: `Decisions`, `Action items`, `Open questions`, `Context / FYI`. Omit groups that have no bullets.
+4. Keep each bullet to **one line**, prefixed with the author when it matters (`alice: shipped v2.4.2`). Link threads by their `thread_id` permalink where the provider supplies one.
+
+### 5. Render the summary
+
+Target shape (adjust headings based on what actually came up):
+
+```
+Summary of #eng — 2026-04-14 00:00 UTC → 2026-04-15 00:00 UTC (312 messages, 4 threads)
+
+Decisions
+- Rolled back v2.4.1 after staging regression (alice, bob)
+- Ship v2.4.2 with the patched migration tomorrow at 09:00 UTC
+
+Action items
+- @alice: draft incident-204 post-mortem by Thursday
+- @carol: add regression test covering the migration case
+
+Open questions
+- Is the feature flag cutover still on for Friday?
+
+Context
+- Customer X asked about the GitLab SAML change — redirected to #support
+```
+
+If the window had fewer than ~20 messages, skip the grouping and render a single flat list.
+
+## Success criteria
+
+- The summary covers the requested window — the earliest and latest messages are reflected.
+- Bullets are grouped, not a flat timestamp dump. Duplicates across threads are collapsed.
+- Author handles are present where they add signal (decisions, action items).
+- Pagination was actually used — the skill did not truncate silently at the first page.
+
+## Guardrails
+
+- Messages frequently reference confidential business decisions, customer names, or unreleased work. **Never forward the raw message content** to external systems — the issue tracker, a PR description, an email, a public channel — without the user's explicit ask. A summary surfaced in the conversation with the requesting user is fine; cross-posting it is not.
+- If the Slack token lacks `channels:history`, `groups:history`, `im:history`, or `mpim:history`, the corresponding chat types will return empty. When a summary feels suspiciously short, run `devboy test slack` and check the "Missing scopes" line before blaming the users.
+
+## Non-goals
+
+- This skill does not search across many chats for a keyword — that is `devboy-chat-search`.
+- It does not post the summary anywhere — if the user wants that, hand the summary to `devboy-notify` after confirming the target.

--- a/skills/05-messenger/devboy-chat-summary/SKILL.md
+++ b/skills/05-messenger/devboy-chat-summary/SKILL.md
@@ -42,30 +42,29 @@ If the user already handed over a `chat_id`, skip this step.
 
 `get_chat_messages` takes `since` / `until` as provider-native timestamps (for Slack: floating-point epoch seconds, as strings — e.g. `"1712448000.000000"`). Convert the user's natural-language window ("today", "this week", "since Monday") into those before calling. Default to **the last 24 hours** when the user does not name a window.
 
-### 3. Pull messages in pages — do not load the whole history
+### 3. Pull messages in narrow slices — do not load the whole history
 
-Paginate via the response `cursor`. Cap each page at 200 messages to keep chunks small enough to summarise cleanly:
+The tool returns formatted text and **does not surface a `next_cursor`** in the output today, so you cannot page by cursor from the tool result. Instead, split a large window into several narrow `since` / `until` calls and summarise each slice independently:
 
 ```bash
-# First page
+# Morning slice
 devboy tools call get_chat_messages '{
   "chat_id": "C0123456789",
   "since": "1713052800.000000",
-  "until": "1713139200.000000",
+  "until": "1713091200.000000",
   "limit": 200
 }'
 
-# Follow-up pages: pass the cursor from the previous response
+# Afternoon slice
 devboy tools call get_chat_messages '{
   "chat_id": "C0123456789",
-  "since": "1713052800.000000",
+  "since": "1713091200.000000",
   "until": "1713139200.000000",
-  "limit": 200,
-  "cursor": "<cursor-from-previous-call>"
+  "limit": 200
 }'
 ```
 
-If a response carries no cursor, you have the full window. If a thread is referenced by `thread_id` and the user asked about a specific thread, pull its replies separately:
+Cap `limit` at 200 per call to keep each response small enough to summarise cleanly. If a slice comes back close to the cap, halve the window and re-run. If a thread is referenced by `thread_id` and the user asked about a specific thread, pull its replies separately:
 
 ```bash
 devboy tools call get_chat_messages '{"chat_id": "C0123456789", "thread_id": "1712450000.001500", "limit": 200}'
@@ -78,7 +77,7 @@ Rather than feeding the entire history into one summary prompt:
 1. **Per page**, draft 3–6 bullet points: decisions, open questions, action items, notable quotes (with author handle).
 2. **Merge** the page-level bullets into a single list, collapsing duplicates and merging threads that span pages.
 3. **Group the final list by topic**, not by time. Suggested top-level groups: `Decisions`, `Action items`, `Open questions`, `Context / FYI`. Omit groups that have no bullets.
-4. Keep each bullet to **one line**, prefixed with the author when it matters (`alice: shipped v2.4.2`). Link threads by their `thread_id` permalink where the provider supplies one.
+4. Keep each bullet to **one line**, prefixed with the author when it matters (`alice: shipped v2.4.2`). Cite threads by their `chat_id` + `thread_id` pair — the unified messenger output does not supply a permalink field.
 
 ### 5. Render the summary
 

--- a/skills/05-messenger/devboy-notify/SKILL.md
+++ b/skills/05-messenger/devboy-notify/SKILL.md
@@ -27,7 +27,7 @@ Send a one-shot, structured notification — a short subject line, 2–3 body bu
 ## Preconditions
 
 1. **The user must have asked.** If the user said something like "maybe we should tell #eng" or "should we notify?", treat that as a **draft** — confirm the target and the text with the user before calling `send_message`. Never post on an ambiguous signal.
-2. **Slack write scope present.** `send_message` on Slack requires the `chat:write` scope. The full list of scopes the devboy Slack integration expects is defined by `default_slack_required_scopes` in `crates/devboy-core/src/config.rs` (`channels:read`, `channels:history`, `groups:read`, `groups:history`, `im:read`, `im:history`, `mpim:read`, `mpim:history`, `chat:write`, `users:read`). Verify the token has them before posting — see step 2 below.
+2. **Slack write scope present.** `send_message` on Slack requires the `chat:write` scope. The full list of scopes the devboy Slack integration expects is defined by the `default_slack_required_scopes()` function in `crates/devboy-core/src/config.rs` (`channels:read`, `channels:history`, `groups:read`, `groups:history`, `im:read`, `im:history`, `mpim:read`, `mpim:history`, `chat:write`, `users:read`). Verify the token has them before posting — see step 2 below.
 
 ## Procedure
 
@@ -104,7 +104,7 @@ devboy tools call send_message '{
 
 ### 6. Report back
 
-After `send_message` returns, tell the user where you posted (chat name + permalink if the response supplies one) and echo the final text. If the call failed, surface the provider error verbatim — don't swallow it.
+After `send_message` returns, tell the user where you posted (chat name + the returned message `chat_id` / `id` / `timestamp` — the unified `MessengerMessage` does not include a `permalink` field, so don't promise a jump-to link) and echo the final text. If the call failed, surface the provider error verbatim — don't swallow it.
 
 ## Success criteria
 

--- a/skills/05-messenger/devboy-notify/SKILL.md
+++ b/skills/05-messenger/devboy-notify/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: devboy-notify
+description: Post a short, structured notification — subject, bullets, optional link — to a chat or channel the user explicitly names.
+category: messenger
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "post to"
+  - "notify the team"
+  - "send a message to slack"
+  - "announce in"
+  - "ping the channel"
+tools:
+  - get_messenger_chats
+  - send_message
+---
+
+# devboy-notify
+
+Send a one-shot, structured notification — a short subject line, 2–3 body bullets, and an optional link — to a chat or channel the user has explicitly asked you to post in. The skill confirms the target and verifies the required write scope **before** calling `send_message`; it never posts speculatively.
+
+## When to use
+
+- The user says "post to #eng that the rollback is done", "notify the team about the release", or "send a quick message to #support".
+- Another skill finished a long operation (deploy, migration, review sweep) and the user explicitly asked for a chat notification at the end of it.
+
+## Preconditions
+
+1. **The user must have asked.** If the user said something like "maybe we should tell #eng" or "should we notify?", treat that as a **draft** — confirm the target and the text with the user before calling `send_message`. Never post on an ambiguous signal.
+2. **Slack write scope present.** `send_message` on Slack requires the `chat:write` scope. The full list of scopes the devboy Slack integration expects is defined by `default_slack_required_scopes` in `crates/devboy-core/src/config.rs` (`channels:read`, `channels:history`, `groups:read`, `groups:history`, `im:read`, `im:history`, `mpim:read`, `mpim:history`, `chat:write`, `users:read`). Verify the token has them before posting — see step 2 below.
+
+## Procedure
+
+### 1. Resolve the target chat
+
+If the user named the chat by a handle (`#eng`, "the release channel", "DM to alice"), look up the `chat_id`:
+
+```bash
+devboy tools call get_messenger_chats '{"search": "eng", "limit": 10}'
+```
+
+Pick the match whose name clearly corresponds to what the user asked for. If more than one chat matches and the correct one is not obvious, **stop and ask** rather than guessing. Posting to the wrong channel is hard to undo.
+
+### 2. Verify the write scope — fail fast if it's missing
+
+Before the first `send_message` of a session, confirm the Slack token carries the required scopes. Run the built-in health check:
+
+```bash
+devboy test slack
+```
+
+The command prints the granted scopes and a `Missing scopes` line if anything on the required list is absent. Relevant for notifications:
+
+- `chat:write` — required to post.
+- `channels:read` / `groups:read` / `im:read` / `mpim:read` — required for the `get_messenger_chats` lookup in step 1.
+
+If `Missing scopes` is non-empty, **do not call `send_message`.** Surface the missing-scope list back to the user with a clear remediation message, e.g.:
+
+> The Slack token is missing `chat:write`. Re-issue the bot token with the scope added (`channels:read`, `groups:read`, `im:read`, `mpim:read`, `chat:write`, …) and re-run `devboy test slack` to confirm.
+
+The exact default list lives in `default_slack_required_scopes()` — follow that source rather than hardcoding the scope list in a conversation.
+
+### 3. Compose the message — short and structured
+
+Keep notifications skimmable. Target format:
+
+```
+*Release v2.4.2 deployed*
+- Rollback of v2.4.1 complete, staging + prod green
+- Follow-up: regression test in MR !842
+- Incident post-mortem: <https://wiki/.../incident-204|incident-204>
+```
+
+Conventions:
+
+- **One-line subject** in `*bold*`.
+- **2–3 body bullets** — each a single line.
+- **Optional link** on the last bullet (Slack link syntax: `<url|label>`).
+- Slack markup: `*bold*`, `_italic_`, inline `` `code` ``, and triple-backtick fences for short snippets. Do not paste long logs — link to them instead.
+- Mentions only when the user asked for them. On Slack: `<@U0123ABCD>` for a user, `<!subteam^SXXXXXXX>` for a group, `<!here>` / `<!channel>` sparingly.
+
+### 4. Confirm the draft with the user (if there's any ambiguity)
+
+If the user's wording left the text or the target open, show the drafted subject + bullets + target chat name and wait for a "go". If the user was explicit ("post exactly this to #eng"), skip the confirmation.
+
+### 5. Send
+
+```bash
+devboy tools call send_message '{
+  "chat_id": "C0123456789",
+  "text": "*Release v2.4.2 deployed*\n- Rollback of v2.4.1 complete, staging + prod green\n- Follow-up: regression test in MR !842\n- Incident post-mortem: <https://wiki/.../incident-204|incident-204>"
+}'
+```
+
+For a threaded reply, add `thread_id` (or `reply_to_id` where the provider supports it):
+
+```bash
+devboy tools call send_message '{
+  "chat_id": "C0123456789",
+  "thread_id": "1713052800.001500",
+  "text": "Patch merged — closing the thread."
+}'
+```
+
+### 6. Report back
+
+After `send_message` returns, tell the user where you posted (chat name + permalink if the response supplies one) and echo the final text. If the call failed, surface the provider error verbatim — don't swallow it.
+
+## Success criteria
+
+- The message was posted to the chat the user named, not a near-miss.
+- The subject, bullets, and any link render cleanly in the target messenger (Slack markup, not raw Markdown).
+- If scopes were missing, the skill failed **early** with a clear remediation rather than silently dropping the notification.
+
+## Guardrails
+
+- **Never post without an explicit ask.** "We could maybe tell the team" is not an ask. Draft and confirm.
+- **Never post unreviewed generated content** (logs, AI-generated summaries, raw tool output) into a channel. Summarise first, show the user, then send.
+- **Honour channel audience.** Ask for the target when the user says "the team" without naming a chat — there is almost always more than one plausible channel.
+
+## Non-goals
+
+- **No scheduling or recurring sends.** The tool bundle does not expose scheduled messages today — if the user asks for one, say so and suggest the native messenger scheduler.
+- **No multi-channel fan-out.** This skill posts to one `chat_id` per invocation. For cross-posts, call it once per target and surface each result.
+- **No message edits / deletes.** `send_message` is the only write tool in the messenger bundle today.


### PR DESCRIPTION
Part of #156. Depends on #168 (category 0) → #167 (infra).

Closes #165.

## Skills

| Name | Scope |
|------|-------|
| devboy-chat-search | Search across channels / DMs via search_chat_messages. Optional humanised-name → chat_id lookup via get_messenger_chats. Surfaces channel + author + date + excerpt. |
| devboy-chat-summary | Summarise a channel or DM over a time window. Uses the format pipeline's pagination (budget / chunk) to chunk history, then merges per-chunk summaries. Guardrail: never forward raw message content to external systems without explicit ask. |
| devboy-notify | Post a structured short notification with a pre-flight scope check. The skill points at 'devboy test slack' for the authoritative scope list rather than hardcoding; canonical scopes at crates/devboy-core/src/config.rs::default_slack_required_scopes. Never sends without explicit user confirmation. |

## Conventions
ADR-012. Tools confirmed: get_messenger_chats, get_chat_messages, search_chat_messages, send_message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)