### PR TITLE
feat(skills): category 1 — issue tracking (5 skills, #160)

### DIFF
--- a/skills/01-issue-tracking/devboy-create-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-create-issue/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: devboy-create-issue
+description: Create a well-structured issue in the configured tracker using Feature, Defect, or Task templates.
+category: issue-tracking
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "create an issue"
+  - "file a bug"
+  - "open a ticket"
+  - "make a new ticket"
+  - "add a task"
+tools:
+  - create_issue
+  - add_issue_comment
+  - get_available_statuses
+  - get_users
+---
+
+# devboy-create-issue
+
+Turn a free-form user request into a structured ticket the team can actually work on. The skill picks one of three templates, fills it, creates the issue, and (optionally) attaches reproduction details or logs as a follow-up comment.
+
+## When to use
+
+- The user describes a bug, a feature idea, or a piece of work without a ticket yet.
+- Another skill discovered something worth filing (e.g. `devboy-review-mr` flagged a deeper issue).
+- The user asks to "open a ticket for this" in the middle of a longer conversation.
+
+## Procedure
+
+### 1. Pick the template
+
+Classify the request before writing anything. The three templates share the same shape — swap the word and tweak the slots.
+
+**Feature** — new capability, user-visible change, or design work.
+
+```markdown
+## Title
+<verb + concrete outcome>, e.g. "Add bulk archive to issue list"
+
+## Context
+Who asked for this and why. Link the user conversation or meeting note.
+
+## Acceptance criteria
+- [ ] Observable behaviour #1
+- [ ] Observable behaviour #2
+- [ ] Docs / changelog updated
+
+## Notes
+Design sketches, open questions, out-of-scope.
+```
+
+**Defect** — something is demonstrably broken.
+
+```markdown
+## Title
+<component>: <what breaks>, e.g. "Dashboard: pipeline badge shows stale status after retry"
+
+## Context
+Environment, version, user impact. Link the failing run / screenshot / log if there is one.
+
+## Acceptance criteria
+- [ ] Steps to reproduce no longer trigger the bug
+- [ ] Regression test covers the fix
+- [ ] Release note drafted
+
+## Notes
+Suspected root cause, related incidents.
+```
+
+**Task** — chore, refactor, docs, infra, anything that is not a user-facing feature and not a bug.
+
+```markdown
+## Title
+<scope>: <short outcome>, e.g. "Infra: rotate CI signing keys"
+
+## Context
+Why now, what it unblocks.
+
+## Acceptance criteria
+- [ ] The concrete thing is done
+- [ ] Follow-up tickets filed for anything we deliberately punted
+
+## Notes
+```
+
+### 2. Create the issue
+
+Pass the title and the rendered Markdown body to `create_issue`:
+
+```bash
+devboy tools call create_issue '{
+  "title": "Dashboard: pipeline badge shows stale status after retry",
+  "description": "## Context\nSeen by @alice on prod v2.4.1. The badge keeps the first status after a manual retry.\n\n## Acceptance criteria\n- [ ] Badge refreshes within 5s of retry\n- [ ] Regression test covers the fix\n\n## Notes\nSuspected cache miss in `PipelineStatusService`.",
+  "labels": ["bug", "dashboard"],
+  "assignees": ["alice"]
+}'
+```
+
+On Windows, JSON needs escaped quotes:
+
+```cmd
+devboy tools call create_issue "{\"title\": \"...\", \"description\": \"...\"}"
+```
+
+Useful optional fields: `parentId` (ClickUp subtasks), `issueType` (Jira: `Task` / `Bug` / `Story`), `projectId` (Jira project key override), `markdown: false` when the description is plain text.
+
+### 3. Attach reproduction details as a comment
+
+Keep the description tight — offload long logs, stack traces, or screenshots to a comment. `add_issue_comment` takes the key returned by step 2:
+
+```bash
+devboy tools call add_issue_comment '{
+  "key": "DEV-789",
+  "body": "Full stack trace from staging:\n\n```\nReferenceError: ...\n```"
+}'
+```
+
+On ClickUp, the same tool accepts `attachments` for small files (each ≤ 10 MB, base64-encoded).
+
+### 4. Confirm the result
+
+Read the new issue back so the user sees exactly what was filed:
+
+```bash
+devboy tools call get_issue '{"key": "DEV-789"}'
+```
+
+## Success criteria
+
+- The created issue has a clear title, a populated body following the chosen template, and the right labels / assignees.
+- Any reproduction material lives in a comment rather than bloating the description.
+- The agent reports the new issue key back to the user so they can link it elsewhere.
+
+## Non-goals
+
+- This skill does not triage or reassign existing issues — that is `devboy-update-issue`.
+- It does not link issues together — that is `devboy-link-issues`.

--- a/skills/01-issue-tracking/devboy-create-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-create-issue/SKILL.md
@@ -15,6 +15,7 @@ tools:
   - add_issue_comment
   - get_available_statuses
   - get_users
+  - get_issue
 ---
 
 # devboy-create-issue

--- a/skills/01-issue-tracking/devboy-get-issues/SKILL.md
+++ b/skills/01-issue-tracking/devboy-get-issues/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: devboy-get-issues
+description: Fetch and summarise issues from the configured tracker — filter, paginate, then drill into a single issue when needed.
+category: issue-tracking
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "list issues"
+  - "show open issues"
+  - "fetch tickets"
+  - "get issues"
+  - "what's on the backlog"
+tools:
+  - get_issues
+  - get_issue
+  - get_issue_comments
+  - get_issue_relations
+  - get_available_statuses
+---
+
+# devboy-get-issues
+
+Enumerate issues from whichever tracker is active (GitLab, GitHub, ClickUp, or Jira) and hand back either a compact summary of the result set or the full body of a single ticket the user cares about. The skill is always a read-only operation — it never mutates state.
+
+## When to use
+
+- The user asks "what issues are open?", "show me the backlog", or names a label / assignee they want to filter by.
+- Another skill (e.g. `devboy-solve-issue`) needs to look up a specific ticket before acting on it.
+- The agent is gathering context for a daily report or status update.
+
+## Procedure
+
+### 1. Scope the query
+
+Most useful filters live directly on `get_issues`:
+
+```bash
+# Default: 20 most recently updated open issues
+devboy tools call get_issues '{"state": "open", "limit": 20}'
+
+# Narrow by label / assignee / free-text search
+devboy tools call get_issues '{"state": "open", "labels": ["bug"], "assignee": "alice"}'
+devboy tools call get_issues '{"search": "websocket reconnect", "limit": 10}'
+```
+
+Supported keys: `state` (`open` / `closed` / `all`), `search`, `labels`, `assignee`, `limit` (1–100), `offset`, `sort_by` (`created_at` / `updated_at`), `sort_order` (`asc` / `desc`), `projectKey`, `nativeQuery`. On Jira, `nativeQuery` accepts raw JQL and takes precedence over the other filters.
+
+### 2. Paginate when the result set is large
+
+`get_issues` returns at most 100 items per call. Walk the pages with `offset`:
+
+```bash
+devboy tools call get_issues '{"state": "open", "limit": 50, "offset": 0}'
+devboy tools call get_issues '{"state": "open", "limit": 50, "offset": 50}'
+```
+
+Stop once a page returns fewer items than `limit`.
+
+### 3. Summarise the set
+
+Before dumping the raw list to the user, produce a compact roll-up:
+
+- Total count, grouped by state (`open` / `closed`).
+- Top labels and assignees by frequency.
+- Any `priority` or status values that cluster (e.g. "4 urgent, 12 normal").
+
+If the user asked a qualitative question ("is anything blocking the release?"), prioritise issues with `blocked`, `urgent`, or `in_progress` status over a flat listing.
+
+### 4. Drill into a single issue
+
+Once the user picks one, fetch the full record — including comments and relations in a single call:
+
+```bash
+devboy tools call get_issue '{"key": "DEV-123"}'
+# or, to skip related chatter
+devboy tools call get_issue '{"key": "DEV-123", "includeComments": false, "includeRelations": false}'
+```
+
+For heavier comment threads, page them separately:
+
+```bash
+devboy tools call get_issue_comments '{"key": "DEV-123"}'
+devboy tools call get_issue_relations '{"key": "DEV-123"}'
+```
+
+### 5. (Optional) Enumerate tracker statuses
+
+If the user asks "what states can an issue be in?", surface the tracker's workflow:
+
+```bash
+devboy tools call get_available_statuses
+```
+
+This is handy before calling `devboy-update-issue` on a provider whose state vocabulary is not "open / closed".
+
+## Success criteria
+
+- The filtered result set matches what the user asked for (state, label, assignee).
+- The summary names the total count and the top groupings, not just the first page.
+- For any issue the user inspects, the detail call returns real fields — not `ProviderUnsupported` or an empty payload.
+
+## Non-goals
+
+- This skill does not create, update, or close issues — use `devboy-create-issue` / `devboy-update-issue`.
+- It does not start a branch or MR — that is `devboy-solve-issue`.

--- a/skills/01-issue-tracking/devboy-link-issues/SKILL.md
+++ b/skills/01-issue-tracking/devboy-link-issues/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: devboy-link-issues
+description: Connect two issues with a typed relationship — blocks, blocked-by, related, duplicates, or parent/subtask.
+category: issue-tracking
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "link issues"
+  - "mark as blocked by"
+  - "set parent"
+  - "relate to"
+  - "mark as duplicate"
+tools:
+  - get_issue
+  - get_issue_relations
+  - link_issues
+  - unlink_issues
+  - update_issue
+---
+
+# devboy-link-issues
+
+Create a typed relationship between two issues so the tracker's dependency graph reflects the real one. The skill covers the four canonical link types plus the special case of parent/subtask, and it inspects existing links first to avoid duplicates.
+
+## When to use
+
+- The user says "DEV-200 is blocked by DEV-100", "mark DEV-55 as a duplicate of DEV-40", or "make this a subtask of the epic".
+- A fix unblocks another ticket and the blocker relationship should be recorded before the close.
+- Back-office cleanup: stitching together issues that were filed separately but describe the same work.
+
+## Key concepts
+
+`IssueRelations` (the shape returned by `get_issue_relations`) groups links into five buckets:
+
+| Bucket | `linkType` to pass | Meaning |
+|--------|---------------------|---------|
+| `blocked_by` | `blocked_by` | The source cannot progress until the target is done |
+| `blocks` | `blocks` | The source must be done before the target can progress |
+| `related_to` | `relates_to` | Soft relationship — "see also" |
+| `duplicates` | `duplicates` | The source is a duplicate of the target |
+| `parent` / `subtasks` | `subtask` | Source is a subtask of target (ClickUp / Jira) |
+
+Provider support varies:
+
+- **GitLab** exposes `relates_to`, `blocks`, `blocked_by`.
+- **GitHub** exposes a flat `relates_to` (dependency-free by default; Projects v2 adds more).
+- **ClickUp** exposes parent/subtask via `update_issue` `parentId` in addition to `link_issues`.
+- **Jira** exposes the full set and honours whatever link types are configured on the project.
+
+If a given relationship is not supported by the active provider, `link_issues` returns `ProviderUnsupported` — fall back to an explanatory comment instead.
+
+## Procedure
+
+### 1. Inspect the current graph
+
+Before adding a link, list the existing ones so you do not create a duplicate edge:
+
+```bash
+devboy tools call get_issue_relations '{"key": "DEV-200"}'
+# or in aggregate via get_issue
+devboy tools call get_issue '{"key": "DEV-200", "includeRelations": true}'
+```
+
+Look at `blocked_by`, `blocks`, `related_to`, `duplicates`, `parent`, `subtasks`. If the edge you are about to add already exists, stop — the tracker is already correct.
+
+### 2. Add the link
+
+One `link_issues` call per edge. All three fields are required:
+
+```bash
+# "DEV-200 is blocked by DEV-100"
+devboy tools call link_issues '{
+  "sourceIssueKey": "DEV-200",
+  "targetIssueKey": "DEV-100",
+  "linkType": "blocked_by"
+}'
+
+# "DEV-55 duplicates DEV-40"
+devboy tools call link_issues '{
+  "sourceIssueKey": "DEV-55",
+  "targetIssueKey": "DEV-40",
+  "linkType": "duplicates"
+}'
+
+# "DEV-42 is related to DEV-17"
+devboy tools call link_issues '{
+  "sourceIssueKey": "DEV-42",
+  "targetIssueKey": "DEV-17",
+  "linkType": "relates_to"
+}'
+```
+
+### 3. Parent / subtask is a special case
+
+Where the provider supports it, prefer `update_issue` with `parentId` — it moves the issue under the parent in one call and most trackers render the hierarchy natively:
+
+```bash
+devboy tools call update_issue '{"key": "CU-child", "parentId": "CU-epic"}'
+```
+
+Fall back to `link_issues` with `"linkType": "subtask"` if the provider expects that shape.
+
+### 4. Multi-link sequences
+
+A real request usually needs more than one edge. Walk them one at a time — the tool is not batched:
+
+> "This MR fixes DEV-123 and is blocked by DEV-100."
+
+```bash
+# DEV-<current> blocks? no — DEV-<current> is blocked by DEV-100
+devboy tools call link_issues '{
+  "sourceIssueKey": "DEV-<current>",
+  "targetIssueKey": "DEV-100",
+  "linkType": "blocked_by"
+}'
+# "fixes" on most trackers is just a related link + automation on merge
+devboy tools call link_issues '{
+  "sourceIssueKey": "DEV-<current>",
+  "targetIssueKey": "DEV-123",
+  "linkType": "relates_to"
+}'
+```
+
+### 5. Removing a stale link
+
+`unlink_issues` takes the same three fields:
+
+```bash
+devboy tools call unlink_issues '{
+  "sourceIssueKey": "DEV-55",
+  "targetIssueKey": "DEV-40",
+  "linkType": "duplicates"
+}'
+```
+
+## Success criteria
+
+- `get_issue_relations` after the operation shows the new edge in the correct bucket.
+- No duplicate edges were created — pre-check in step 1 caught them.
+- Where the provider rejected a link type, the agent surfaced that to the user instead of silently retrying.
+
+## Non-goals
+
+- This skill does not create issues — use `devboy-create-issue` and then link.
+- It does not automatically close duplicates — mark the relationship, let the user decide whether to close.

--- a/skills/01-issue-tracking/devboy-solve-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-solve-issue/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: devboy-solve-issue
+description: Full cycle for shipping an issue — read it, branch, implement, push, open an MR, and link back to the original ticket.
+category: issue-tracking
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "solve this issue"
+  - "implement DEV-XXX"
+  - "work on ticket"
+  - "start this task"
+  - "ship this issue"
+tools:
+  - get_issue
+  - get_issue_comments
+  - get_issue_relations
+  - create_merge_request
+  - add_issue_comment
+---
+
+# devboy-solve-issue
+
+Take a ticket from "assigned" to "review-ready MR with a comment on the issue pointing at it". The skill wraps the typical loop: read the issue, cut a branch, do the work, push, open an MR on the configured Git provider, and leave a breadcrumb on the issue so the next person can follow the trail.
+
+## When to use
+
+- The user says "implement DEV-123", "solve this issue", "take this ticket", or similar.
+- The agent has a clear, scoped issue to act on — not an open-ended discussion.
+- A Git provider (GitLab or GitHub) is configured alongside the issue tracker.
+
+If the request is vague, run `devboy-get-issues` first to surface the ticket, then come back here.
+
+## Procedure
+
+### 1. Read the issue
+
+Always start with the full ticket — description, comments, links:
+
+```bash
+devboy tools call get_issue '{"key": "DEV-123"}'
+```
+
+Pay attention to:
+
+- **Acceptance criteria** — they define "done".
+- **Blocking links** — if `blocked_by` is non-empty, surface that and stop. The skill does not fight upstream blockers.
+- **Recent comments** — later context often overrides the original description.
+
+### 2. Name the branch
+
+Pick a short, human-readable branch name that embeds the issue key:
+
+```
+feat/DEV-123-add-bulk-archive
+fix/DEV-456-pipeline-badge-stale
+chore/DEV-789-rotate-signing-keys
+```
+
+Rules:
+
+- Prefix with `feat/`, `fix/`, `chore/`, `docs/`, or `refactor/` depending on the work.
+- Include the issue key verbatim (no lowercasing — `DEV-123`, not `dev-123`).
+- Keep the trailing slug under ~5 words.
+
+### 3. Cut the branch and implement
+
+Standard local Git flow — the skill does not wrap these in `devboy` tools:
+
+```bash
+git fetch origin
+git switch -c feat/DEV-123-add-bulk-archive origin/main
+# ... write the code, run tests, verify locally ...
+git add -p
+git commit -m "feat(issues): add bulk archive (DEV-123)"
+git push -u origin HEAD
+```
+
+Commit messages should follow the repo's convention and end with the issue key in parentheses so the tracker auto-links them. Avoid `Fixes DEV-123` / `Closes #123` phrasing on the commit — see the guardrail below.
+
+### 4. Open the merge request
+
+`create_merge_request` is the unified tool — it opens a GitLab MR or a GitHub PR depending on the configured provider. Title and `source_branch` / `target_branch` are required:
+
+```bash
+devboy tools call create_merge_request '{
+  "title": "feat(issues): add bulk archive (DEV-123)",
+  "description": "Implements DEV-123.\n\n## What changed\n- Added `bulkArchive` action to the issue list\n- New keyboard shortcut `shift+a`\n\n## How to test\n1. Select multiple issues\n2. Press `shift+a`\n3. Confirm they move to the archived state\n\nRelates to DEV-123.",
+  "source_branch": "feat/DEV-123-add-bulk-archive",
+  "target_branch": "main",
+  "draft": false,
+  "labels": ["feature"],
+  "reviewers": ["alice"]
+}'
+```
+
+Record the MR key (`mr#<n>` for GitLab, `pr#<n>` for GitHub) — the next step needs it.
+
+### 5. Comment the MR link on the issue
+
+Close the loop so anyone looking at the ticket finds the work:
+
+```bash
+devboy tools call add_issue_comment '{
+  "key": "DEV-123",
+  "body": "Opened for review: mr#42 — `feat/DEV-123-add-bulk-archive`."
+}'
+```
+
+Include:
+
+- The MR / PR key (clickable on most trackers when the integration is configured).
+- The branch name.
+- Any context the reviewer needs that is not already in the MR description.
+
+### 6. Hand off
+
+Report back to the user with:
+
+- The issue key.
+- The branch name.
+- The MR / PR key and URL.
+- A one-line summary of the change.
+
+Then stop. Review happens in `devboy-review-mr`, fixing review comments happens in `devboy-fix-review-comments`.
+
+## Guardrails
+
+- **Do not auto-close the issue.** Leave the close to the merge commit. Most trackers have a `Fixes` keyword pipeline wired up on the MR description — use it there if the repo convention supports it, but do not call `update_issue` with `state: closed` from this skill.
+- **Do not force-push shared branches.** If the branch already exists remotely and someone else has work on it, stop and ask.
+- **Respect the scope.** The issue description is the contract — do not refactor adjacent code or add features the ticket did not ask for. If you find genuine tech debt, file a follow-up with `devboy-create-issue` instead of widening this change.
+- **Do not run the review yourself.** That is a separate skill with a separate posture.
+
+## Success criteria
+
+- The MR exists on the configured Git provider, targets `main` (or the repo's default branch), and its description references the issue.
+- The original issue has a new comment linking to the MR.
+- Local branch is pushed and tracks its remote.
+- The scope matches the issue's acceptance criteria — nothing more, nothing less.
+
+## Non-goals
+
+- **Code review.** Use `devboy-review-mr` on the resulting MR.
+- **Applying review feedback.** Use `devboy-fix-review-comments` when reviewers come back.
+- **Release / deploy coordination.** Out of scope — this skill stops at "MR open".

--- a/skills/01-issue-tracking/devboy-solve-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-solve-issue/SKILL.md
@@ -12,8 +12,6 @@ activation:
   - "ship this issue"
 tools:
   - get_issue
-  - get_issue_comments
-  - get_issue_relations
   - create_merge_request
   - add_issue_comment
 ---
@@ -64,11 +62,12 @@ Rules:
 
 ### 3. Cut the branch and implement
 
-Standard local Git flow — the skill does not wrap these in `devboy` tools:
+Standard local Git flow — the skill does not wrap these in `devboy` tools. Base the branch off the remote's default head rather than hardcoding `main`, so the flow keeps working on repos whose default is `master` or something else:
 
 ```bash
 git fetch origin
-git switch -c feat/DEV-123-add-bulk-archive origin/main
+DEFAULT_BRANCH_REF="$(git symbolic-ref refs/remotes/origin/HEAD)"   # e.g. refs/remotes/origin/main
+git switch -c feat/DEV-123-add-bulk-archive "$DEFAULT_BRANCH_REF"
 # ... write the code, run tests, verify locally ...
 git add -p
 git commit -m "feat(issues): add bulk archive (DEV-123)"
@@ -79,14 +78,14 @@ Commit messages should follow the repo's convention and end with the issue key i
 
 ### 4. Open the merge request
 
-`create_merge_request` is the unified tool — it opens a GitLab MR or a GitHub PR depending on the configured provider. Title and `source_branch` / `target_branch` are required:
+`create_merge_request` is the unified tool — it opens a GitLab MR or a GitHub PR depending on the configured provider. Title and `source_branch` / `target_branch` are required. Set `target_branch` to the repo's actual default branch — do not hardcode `main`; derive it from `git symbolic-ref refs/remotes/origin/HEAD` (strip the `refs/remotes/origin/` prefix) so the call works on repos defaulted to `master` or a custom branch:
 
 ```bash
 devboy tools call create_merge_request '{
   "title": "feat(issues): add bulk archive (DEV-123)",
   "description": "Implements DEV-123.\n\n## What changed\n- Added `bulkArchive` action to the issue list\n- New keyboard shortcut `shift+a`\n\n## How to test\n1. Select multiple issues\n2. Press `shift+a`\n3. Confirm they move to the archived state\n\nRelates to DEV-123.",
   "source_branch": "feat/DEV-123-add-bulk-archive",
-  "target_branch": "main",
+  "target_branch": "<repo-default-branch>",
   "draft": false,
   "labels": ["feature"],
   "reviewers": ["alice"]

--- a/skills/01-issue-tracking/devboy-update-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-update-issue/SKILL.md
@@ -64,8 +64,8 @@ devboy tools call update_issue '{"key": "DEV-123", "assignees": ["bob"]}'
 # Swap the label set (replaces — not additive)
 devboy tools call update_issue '{"key": "DEV-123", "labels": ["bug", "regression"]}'
 
-# Transition a ClickUp / Jira status by string — pass the literal status name
-devboy tools call update_issue '{"key": "CU-abc123", "status": "In Review"}'
+# Transition a ClickUp / Jira workflow status by string — pass the literal status name via `state`
+devboy tools call update_issue '{"key": "CU-abc123", "state": "In Review"}'
 ```
 
 Tool fields you can pass: `title`, `description`, `state`, `labels`, `assignees`, `parentId` (ClickUp subtasks), `markdown`. `labels` and `assignees` are replacements, not merges — re-send the full desired list.

--- a/skills/01-issue-tracking/devboy-update-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-update-issue/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: devboy-update-issue
+description: Change an issue's state, labels, assignees, or priority with a partial update, leaving unrelated fields untouched.
+category: issue-tracking
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "close this issue"
+  - "update the ticket"
+  - "move to done"
+  - "assign to X"
+  - "relabel issue"
+  - "reopen ticket"
+tools:
+  - get_issue
+  - update_issue
+  - add_issue_comment
+  - get_available_statuses
+---
+
+# devboy-update-issue
+
+Apply a targeted change to an existing issue — transition state, swap labels, hand it to someone else, bump priority — without disturbing fields the user did not mention. The skill always inspects the current record first so the update is informed.
+
+## When to use
+
+- The user says "close DEV-123", "move this to in progress", "assign to @alice", or similar.
+- Another skill finished work and needs to transition the originating ticket (but see the guardrail on auto-closing in `devboy-solve-issue`).
+- A label taxonomy change requires bulk relabelling — run the skill once per ticket.
+
+## Procedure
+
+### 1. Read the current state first
+
+Never update blind. Fetch the issue so you know what you are overwriting:
+
+```bash
+devboy tools call get_issue '{"key": "DEV-123"}'
+```
+
+Note the current `state`, `labels`, `assignees`, and `priority` before deciding on the diff. This also surfaces whether the issue is already in the desired state (in which case no call is needed).
+
+### 2. Understand the tracker's state vocabulary
+
+GitLab / GitHub use `open` / `closed`. ClickUp and Jira use custom workflows — "To Do", "In Progress", "In Review", "Done", "Blocked". When the user asks for something semantic ("mark it done"), check what the tracker actually offers:
+
+```bash
+devboy tools call get_available_statuses
+```
+
+Pick the status that matches the user's intent. If none fits, ask before guessing.
+
+### 3. Apply the minimal update
+
+`update_issue` is **partial** — fields you omit are preserved. Send only what actually changes:
+
+```bash
+# Close an issue
+devboy tools call update_issue '{"key": "DEV-123", "state": "closed"}'
+
+# Reassign without touching anything else
+devboy tools call update_issue '{"key": "DEV-123", "assignees": ["bob"]}'
+
+# Swap the label set (replaces — not additive)
+devboy tools call update_issue '{"key": "DEV-123", "labels": ["bug", "regression"]}'
+
+# Transition a ClickUp / Jira status by string — pass the literal status name
+devboy tools call update_issue '{"key": "CU-abc123", "status": "In Review"}'
+```
+
+Tool fields you can pass: `title`, `description`, `state`, `labels`, `assignees`, `parentId` (ClickUp subtasks), `markdown`. `labels` and `assignees` are replacements, not merges — re-send the full desired list.
+
+### 4. Narrate the change in a comment
+
+When the state change carries meaning the field itself does not capture, follow up with a comment so the history is readable:
+
+```bash
+devboy tools call add_issue_comment '{
+  "key": "DEV-123",
+  "body": "Moving to **Blocked** — waiting on vendor fix for upstream auth (ETA Friday)."
+}'
+```
+
+Good triggers for a comment: state → blocked, reassignment, priority escalation, a close-as-wontfix that needs context.
+
+### 5. Verify
+
+Re-read the issue and confirm the intended fields changed while the others did not:
+
+```bash
+devboy tools call get_issue '{"key": "DEV-123", "includeComments": false, "includeRelations": false}'
+```
+
+## Guardrails
+
+- **Never overwrite fields the user did not explicitly mention.** If the user said "close it", do not also clear labels or drop assignees. Send only the fields that matter for the stated intent.
+- **Do not batch unrelated changes into a single tool call** if the user can realistically reject one and accept the other — make each change auditable.
+- **Status names are case-sensitive** on some providers. Use the exact casing from `get_available_statuses`.
+
+## Success criteria
+
+- The targeted fields reflect the user's request after step 5.
+- All other fields remain identical to the pre-update snapshot from step 1.
+- Where the change needs context, there is a comment explaining it.


### PR DESCRIPTION
Part of #156. Depends on #168 (category 0) → #167 (infra).

Closes #160.

## Skills

| Name | Scope |
|------|-------|
| devboy-get-issues | Filter / paginate / summarise, then drill into a single issue via get_issue. |
| devboy-create-issue | Feature / Defect / Task body templates, create_issue + optional add_issue_comment. |
| devboy-update-issue | Partial field updates (state, labels, assignees, priority) with a guardrail against overwriting unrelated fields. |
| devboy-link-issues | Typed relationships (blocks / blocked-by / relates-to / duplicates / parent-subtask), dedup against get_issue. |
| devboy-solve-issue | Full cycle: get_issue → branch → implement → push → create_merge_request → add_issue_comment. Does not perform code review (that's devboy-review-mr). |

## Conventions
ADR-012: English-only, CLI-first, minimal YAML frontmatter, ~1 page bodies. Every referenced tool cross-checked against crates/devboy-executor/src/tools.rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)