### PR TITLE
feat(skills): category 2 — code review (3 skills, #161)

### DIFF
--- a/skills/02-code-review/devboy-fix-review-comments/SKILL.md
+++ b/skills/02-code-review/devboy-fix-review-comments/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: devboy-fix-review-comments
+description: Apply reviewer feedback on an MR — fix the code, run local checks, commit, push, and reply to each discussion.
+category: code-review
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "fix review comments"
+  - "address MR review"
+  - "apply reviewer feedback"
+  - "address PR feedback"
+tools:
+  - get_merge_request_discussions
+  - get_merge_request_diffs
+  - create_merge_request_comment
+---
+
+# devboy-fix-review-comments
+
+Address a reviewer's feedback on one MR / PR. For every unresolved discussion: decide whether to accept, push back, or clarify; if accepting, make the change locally and verify it; then reply to the thread with a short acknowledgement.
+
+## When to use
+
+- A reviewer left comments on your MR and you are ready to address them.
+- The user says "fix review comments", "apply reviewer feedback", or similar with an MR key.
+- You are the author of the MR. For reviewing **someone else's** MR use `devboy-review-mr`.
+
+## Procedure
+
+### 1. Pull every open discussion
+
+```bash
+devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
+```
+
+Filter to unresolved threads. Each discussion returns a list of notes and — for inline discussions — a file path, line number, and `discussion_id`. The `discussion_id` is what you reply to later.
+
+### 2. Pull the current diff for context
+
+```bash
+devboy tools call get_merge_request_diffs '{"key": "mr#374"}'
+```
+
+You need the diff to reason about where each comment applies — reviewers sometimes comment on context lines, not changed lines.
+
+### 3. Classify each discussion
+
+Walk the discussions in the order the reviewer posted them. For each one, pick exactly one disposition:
+
+- **Accept** — the reviewer is right; apply the fix locally.
+- **Push back** — you disagree or the suggestion is out of scope; reply with a one- or two-sentence reason and keep the scope to this thread.
+- **Clarify** — the comment is ambiguous; reply asking for the specific piece of information you need.
+
+Do not batch dispositions. Decide per discussion.
+
+### 4. Apply fixes (for "accept")
+
+Edit the files locally. Keep the change minimal — a review fix is a fix, not a refactor (see guardrails below). After **each** logical fix, run the local checks appropriate for the stack touched. For `devboy-tools`:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test -p <the-crate-you-touched>
+```
+
+If any of those fails, fix the root cause before moving on — do not commit a half-green state.
+
+### 5. Commit and push
+
+Group related fixes into one commit where it reads naturally. Commit messages reference the scope, not the reviewer:
+
+```bash
+git add -- <paths>
+git commit -m "fix(cli): surface a real error when the env var is unset (DEV-XXX)"
+git push
+```
+
+Note the commit SHA of each fix — you will reference it in the reply. For fixes that span multiple discussions, one commit covering several threads is fine as long as the body of the commit lists them.
+
+### 6. Reply to each discussion
+
+Use `create_merge_request_comment` in **reply mode** by passing the `discussion_id`. Keep the reply one or two sentences.
+
+- **Accepted**: `fixed in <sha>` or `fixed in <sha> — <one-line what changed>`.
+- **Pushed back**: `keeping as-is because <specific technical reason>`.
+- **Clarified**: `could you clarify <specific point>? <short reason you're asking>`.
+
+```bash
+devboy tools call create_merge_request_comment '{
+  "key": "mr#374",
+  "discussion_id": "abc123",
+  "body": "fixed in 9f2a1e4 — switched to `Error::Config` so the CLI prints a real message."
+}'
+```
+
+Do not pass `file_path` / `line` when replying — the discussion already owns a position.
+
+### 7. Verify
+
+```bash
+devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
+```
+
+Every thread you handled should now have your reply as the latest note. If a thread is missing your reply, the call either targeted the wrong `discussion_id` or the provider rejected the body — re-try.
+
+## Success criteria
+
+- Every previously-unresolved discussion has a reply from you.
+- Every "accept" reply names the SHA that contains the fix.
+- Local `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the relevant `cargo test` pass.
+- The branch is pushed; the MR shows the new commits.
+- No discussion is left silent because you "could not figure it out" — clarify instead.
+
+## Guardrails
+
+- **Never mark a discussion resolved for a reviewer who did not ask you to.** Some hosts expose a "resolve" action; do not call it. Resolution is the reviewer's prerogative on their next pass. Your job ends at replying.
+- **Keep the push-back scoped to the thread it belongs to.** If the reviewer is wrong across several threads, reply per thread — do not escalate in a single omnibus comment.
+- **Do not amend past commits from the branch** unless the reviewer explicitly asked for a squash. New commits are easier to review.
+- **Do not change the MR target branch, title, or description** as part of a "fix comments" pass unless the reviewer asked for exactly that.
+- **Do not introduce unrelated cleanup.** A review fix touches the lines under discussion and whatever is strictly required to make them work. Larger refactors get their own MR.
+
+## Non-goals
+
+- Approving or closing the MR. Resolution and merge remain with the reviewer / author's separate actions.
+- Running CI for the reviewer. Pushing commits is enough — the pipeline will trigger on its own.

--- a/skills/02-code-review/devboy-fix-review-comments/SKILL.md
+++ b/skills/02-code-review/devboy-fix-review-comments/SKILL.md
@@ -33,7 +33,14 @@ Address a reviewer's feedback on one MR / PR. For every unresolved discussion: d
 devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
 ```
 
-Filter to unresolved threads. Each discussion returns a list of notes and — for inline discussions — a file path, line number, and `discussion_id`. The `discussion_id` is what you reply to later.
+The tool returns `Discussion { id, resolved, comments, position }`. `comments` is the thread's list of messages; `position` carries the file path + line number for inline discussions. Reply later using the discussion's `id` (for GitLab) or the numeric id of one of `comments[*]` (for GitHub — see the reply section below).
+
+**Do not rely on `resolved` alone to pick threads that need a reply.** On GitHub the provider has no reliable resolved-state signal in the REST data it reads, so `resolved` is always `false` — treating "unresolved" as "needs reply" will pick every thread and produce infinite reply loops on re-runs. Use a deterministic filter instead:
+
+- threads where the latest comment is not authored by the MR author, **or**
+- threads where the MR author has not replied since the reviewer's last comment.
+
+On GitLab the `resolved` field is populated correctly and you may lean on it as a hint, but keep the author-based check as a fallback — it works across providers.
 
 ### 2. Pull the current diff for context
 
@@ -79,13 +86,21 @@ Note the commit SHA of each fix — you will reference it in the reply. For fixe
 
 ### 6. Reply to each discussion
 
-Use `create_merge_request_comment` in **reply mode** by passing the `discussion_id`. Keep the reply one or two sentences.
+Use `create_merge_request_comment` in **reply mode**. The right reply id depends on the provider:
+
+- **GitLab** — reply with the discussion's `id` as `discussion_id`. GitLab threads are first-class objects and the `Discussion.id` is what you pass back.
+- **GitHub** — GitHub's REST reply goes through `in_reply_to` on a **review comment id**, which is numeric. The provider packs that into a `Discussion.comments[*].id`; pass the id of the comment you are replying to (typically the last one in the thread) as `discussion_id`.
+
+If you get a 404 on reply, the value was the wrong one for the provider — fall back to a top-level comment rather than looping.
+
+Keep the reply one or two sentences:
 
 - **Accepted**: `fixed in <sha>` or `fixed in <sha> — <one-line what changed>`.
 - **Pushed back**: `keeping as-is because <specific technical reason>`.
 - **Clarified**: `could you clarify <specific point>? <short reason you're asking>`.
 
 ```bash
+# GitLab example
 devboy tools call create_merge_request_comment '{
   "key": "mr#374",
   "discussion_id": "abc123",
@@ -93,7 +108,7 @@ devboy tools call create_merge_request_comment '{
 }'
 ```
 
-Do not pass `file_path` / `line` when replying — the discussion already owns a position.
+Do not pass `file_path` / `line` when replying — the thread already owns a position.
 
 ### 7. Verify
 

--- a/skills/02-code-review/devboy-review-mr/SKILL.md
+++ b/skills/02-code-review/devboy-review-mr/SKILL.md
@@ -93,7 +93,9 @@ devboy tools call create_merge_request_comment '{
 }'
 ```
 
-For a comment on an unchanged (context) line, use `"line_type": "old"`. If the provider requires a `commit_sha`, pick the head SHA from `get_merge_request_diffs` output.
+`line_type` is an `old` / `new` selector for which side of the diff the `line` number refers to: `"new"` for added or unchanged (context) lines, `"old"` only for deleted lines. Using `"old"` on a context line can place the comment on the wrong side or fail outright. Default to `"new"`.
+
+Do not pass `commit_sha` unless you already have a concrete SHA from outside this skill's tool set. `get_merge_request_diffs` returns `FileDiff` without a head SHA, so there is no head commit to lift from the tool output. On GitHub the provider fills in the PR head SHA automatically when `commit_sha` is omitted; on GitLab it is not required for line-scoped comments.
 
 ### 8. Post the summary comment
 

--- a/skills/02-code-review/devboy-review-mr/SKILL.md
+++ b/skills/02-code-review/devboy-review-mr/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: devboy-review-mr
+description: Strict but calibrated code review of a single MR or PR — checklist, inline comments, one overall summary.
+category: code-review
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "review this MR"
+  - "review this PR"
+  - "do a code review"
+  - "check this PR"
+tools:
+  - get_merge_requests
+  - get_merge_request_diffs
+  - get_merge_request_discussions
+  - create_merge_request_comment
+---
+
+# devboy-review-mr
+
+Perform a strict, calibrated code review of a single merge request / pull request. Output is one summary comment plus a handful of targeted inline comments — each tagged with `[nit]`, `[suggestion]`, or `[issue]` so the author can triage quickly.
+
+## When to use
+
+- The user asks "review this MR / PR" and gives an identifier (e.g. `mr#374`, `pr#128`) or a URL.
+- The user pastes an MR URL without further instructions — default to this skill.
+- You have been asked to gate-keep a branch before merge.
+
+For reviewing your **own** MR before asking a human reviewer, use `devboy-self-review` — it keeps findings private instead of posting them.
+
+## Procedure
+
+### 1. Resolve the MR key
+
+The tools take a key in the form `mr#<n>` (GitLab) or `pr#<n>` (GitHub). If the user gave a URL, extract the numeric id and prefix accordingly. If the user only said "this MR", ask for the key — do not guess.
+
+### 2. Pull the MR metadata
+
+```bash
+devboy tools call get_merge_requests '{"state": "open", "limit": 50}'
+```
+
+Use this to confirm the MR exists and to pick up title, author, target branch, and labels. If only one MR is in question, you can skip this and go straight to diffs.
+
+### 3. Pull the diff
+
+```bash
+devboy tools call get_merge_request_diffs '{"key": "mr#374"}'
+```
+
+Record every changed file and the line ranges that moved. Diffs are the primary review surface — read them before anything else.
+
+### 4. Pull existing discussions
+
+```bash
+devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
+```
+
+Skim every thread. Do not duplicate a comment that a previous reviewer already left — if the same concern is still unresolved, reference the existing thread in your summary instead of opening a new inline.
+
+### 5. Walk the checklist
+
+For every changed file, ask the following questions in order. Stop early on a file once you find one serious finding — the goal is signal, not exhaustive noise.
+
+- **Type safety.** Are new public APIs fully typed? Are `unwrap()` / `expect()` calls justified by a local invariant, or are they latent panics? Are `Option` / `Result` chained with combinators rather than unwrapped?
+- **Error handling.** Do new error paths surface a useful message the caller can act on? Are errors propagated with `?` rather than swallowed with `let _ = …` or `.ok()`? Are new error variants added to the relevant enum?
+- **Tests.** Is every new behaviour covered by a unit test or an integration test? Are edge cases (empty input, provider-unsupported, parse failure) exercised? Do the new tests actually assert on meaningful output, not just "did not panic"?
+- **Docs.** Are new public items documented with a short rustdoc / JSDoc block? Does the `README` or relevant `docs/` page change when the public surface changes?
+- **i18n / user-facing copy.** If the diff touches a `SKILL.md` body, a CLI message, or any user-facing string, is it English? Mixed-language strings do not ship.
+- **Cross-platform.** Does anything assume POSIX paths (hard-coded `/`), the presence of `bash`, or Unix-only tools? `std::path::Path` and portable commands are required.
+
+### 6. Draft the inline comments
+
+For each finding that deserves inline attention, prepare a short comment. Keep each one under ~150 words and start with a severity tag:
+
+- `[nit]` — cosmetic, take-it-or-leave-it (whitespace, naming, tiny refactor).
+- `[suggestion]` — real improvement that is not strictly blocking.
+- `[issue]` — blocking; the reviewer wants this fixed before merge.
+
+Long explanations, context, or cross-file reasoning belong in the summary comment, not inline.
+
+### 7. Post the inline comments
+
+One tool call per inline comment. File path and line must match the diff exactly.
+
+```bash
+devboy tools call create_merge_request_comment '{
+  "key": "mr#374",
+  "file_path": "crates/devboy-core/src/provider.rs",
+  "line": 142,
+  "line_type": "new",
+  "body": "[issue] `unwrap()` on the env-var lookup will panic when the variable is unset. Return `Err(Error::Config(...))` instead so the caller can surface a useful message."
+}'
+```
+
+For a comment on an unchanged (context) line, use `"line_type": "old"`. If the provider requires a `commit_sha`, pick the head SHA from `get_merge_request_diffs` output.
+
+### 8. Post the summary comment
+
+One final, top-level comment. Structure it so the author can skim in ten seconds:
+
+```
+### Review summary
+
+- Strengths: <one or two short bullets>
+- Blocking issues: <count>  (see inline [issue] tags)
+- Suggestions: <count>      (see inline [suggestion] tags)
+- Nits: <count>             (see inline [nit] tags)
+
+Overall: <approve / needs changes / comment>, because <one sentence>.
+```
+
+```bash
+devboy tools call create_merge_request_comment '{
+  "key": "mr#374",
+  "body": "### Review summary\n\n- Strengths: …\n- Blocking issues: 1 (see inline [issue])\n- Suggestions: 2\n- Nits: 0\n\nOverall: needs changes, because the new provider path panics on missing env."
+}'
+```
+
+Do not pass `file_path` / `line` here — a top-level comment has no position.
+
+## Success criteria
+
+- Every `[issue]` you raise points at a line the author can act on, with a concrete fix path.
+- The summary is a single comment, not one per finding.
+- No duplicate comments — you read prior discussions before posting.
+- Inline comments are short; long prose lives in the summary.
+- No language other than English in any posted body.
+
+## Guardrails
+
+- **Do not approve or merge.** This skill posts comments only. Approval is a human action.
+- **Do not resolve other reviewers' threads.** Reply if you have an opinion, but leave resolution to the person who opened the thread.
+- **Do not review your own MR with this skill.** Use `devboy-self-review` instead — self-comments clutter the reviewer's view.
+
+## Non-goals
+
+- Running the tests yourself. The review is based on the diff and whatever CI signal is visible; actually executing the code is `devboy-self-review`'s job for the author, not the reviewer's.
+- Refactoring suggestions that are out of scope for the MR. Flag them as `[suggestion]` and let the author decide.

--- a/skills/02-code-review/devboy-self-review/SKILL.md
+++ b/skills/02-code-review/devboy-self-review/SKILL.md
@@ -46,7 +46,11 @@ Read every changed file end-to-end. This is the only piece of ground truth you n
 devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
 ```
 
-Flag any thread that is still unresolved. Self-review is incomplete as long as an open discussion exists — either reply to it (see `devboy-fix-review-comments`) or, if you are pushing back, at least have the reasoning ready so the reviewer is not left waiting.
+Flag any thread that is clearly awaiting your response — for example, the latest comment was not authored by you, or it contains an explicit request for changes / clarification / follow-up.
+
+If the provider exposes a reliable `resolved` field you may use it as a hint (GitLab does), but do not treat `unresolved` on its own as a universal blocking signal: on GitHub the provider has no reliable resolved-state signal in the REST data and `resolved` is always `false`, so a naive check would tag every thread and make self-review impossible on GitHub-hosted PRs.
+
+Self-review is incomplete while a reviewer is still waiting on you — either reply to the thread (see `devboy-fix-review-comments`) or, if you are pushing back, have the reasoning ready so the reviewer is not left waiting.
 
 ### 4. Walk the checklist
 

--- a/skills/02-code-review/devboy-self-review/SKILL.md
+++ b/skills/02-code-review/devboy-self-review/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: devboy-self-review
+description: Dry-run a review pass over your own MR before asking a human reviewer — local checklist, no inline posting.
+category: code-review
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "self review my MR"
+  - "self review my PR"
+  - "check my own PR"
+  - "dry-run review before requesting"
+tools:
+  - get_merge_request_diffs
+  - get_merge_request_discussions
+---
+
+# devboy-self-review
+
+Run the `devboy-review-mr` checklist over your **own** MR before handing it to a reviewer. Findings stay local — the output is a plain-text report to the user, not comments on the MR. If anything serious turns up, you fix it and amend the branch first.
+
+## When to use
+
+- You are about to mark an MR as "ready for review" and want a sanity pass.
+- A previous review round finished; you want to confirm nothing new slipped in while addressing the comments.
+- The user says "self-review my PR" or similar.
+
+For reviewing **someone else's** MR, use `devboy-review-mr` — it posts inline comments and a summary. Self-review deliberately does not.
+
+## Procedure
+
+### 1. Resolve the MR key
+
+`mr#<n>` or `pr#<n>`. If the user did not give one, ask — do not guess from branch state.
+
+### 2. Pull the diff
+
+```bash
+devboy tools call get_merge_request_diffs '{"key": "mr#374"}'
+```
+
+Read every changed file end-to-end. This is the only piece of ground truth you need — metadata (title, labels, target branch) is out of scope for self-review.
+
+### 3. Pull existing discussions
+
+```bash
+devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
+```
+
+Flag any thread that is still unresolved. Self-review is incomplete as long as an open discussion exists — either reply to it (see `devboy-fix-review-comments`) or, if you are pushing back, at least have the reasoning ready so the reviewer is not left waiting.
+
+### 4. Walk the checklist
+
+Same list as `devboy-review-mr`, applied to your own code. For each item, record one of three outcomes: `ok`, `minor` (note it for the reviewer), `fix-before-review` (you are going to change the code right now).
+
+- **Type safety.** Are new public APIs fully typed? Are `unwrap()` / `expect()` calls justified? Option / Result combinators rather than unwrapped access?
+- **Error handling.** Do new error paths surface a useful message? Errors propagated rather than swallowed? New variants added to the right enum?
+- **Tests.** Is every new behaviour covered? Edge cases (empty input, provider-unsupported, parse failure)? Assertions meaningful, not just "did not panic"?
+- **Docs.** Public items documented? README / `docs/` change if the public surface changes?
+- **i18n / user-facing copy.** Any `SKILL.md` body, CLI output, error message — English only?
+- **Cross-platform.** No POSIX-only paths, no `bash`-only scripting, no Unix-only tools?
+
+### 5. If any item is `fix-before-review` — fix it
+
+Make the change, then re-run the local checks appropriate for the stack touched. For `devboy-tools`:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test -p <the-crate-you-touched>
+```
+
+Amend the branch — a new commit is fine, a squash is fine, whatever matches the project's convention. Push. Then **go back to step 2** and re-read the diff. Self-review is iterative; do not short-circuit after a fix.
+
+### 6. Produce the report
+
+When the list has no `fix-before-review` items left, emit a compact text report to the user. Example shape:
+
+```
+Self-review — mr#374
+
+Type safety:         ok
+Error handling:      minor — new variant `Error::ProviderStale` is not in the README table yet
+Tests:               ok
+Docs:                minor — new --remote-config-url flag missing from README cheatsheet
+i18n:                ok
+Cross-platform:      ok
+
+Open discussions:    0
+Recommendation:      ready for review — two minor notes to call out in the MR description
+```
+
+The report goes to the user in the chat. **Do not** post it as an MR comment. Any item flagged `minor` is something you mention in the MR description or a cover letter to the reviewer, not a self-posted review.
+
+## Success criteria
+
+- The report covers every checklist item with one of `ok` / `minor` / `fix-before-review`.
+- No `fix-before-review` item is left unfixed by the time the report is written.
+- Open discussions from previous rounds are counted and acknowledged.
+- Nothing was posted to the MR as part of this skill.
+
+## Guardrails
+
+- **Never post inline comments on your own MR.** Self-posted comments clutter the reviewer's view and muddy the signal about what a fresh pair of eyes actually flagged.
+- **Do not mark anything as resolved.** Resolution belongs to whichever reviewer opened the thread.
+- **Do not approve, merge, or change MR state.** This skill is strictly a dry-run.
+- **Do not expand scope during the fix pass.** A self-review fix is still a fix — refactors belong in a separate MR.
+
+## Non-goals
+
+- Replacing a human reviewer. Self-review catches the obvious; the human still needs to sign off.
+- Running the full CI pipeline locally. Local checks (`cargo fmt`, `cargo clippy`, targeted `cargo test`) are enough for a self-review pass — CI is what the reviewer sees.


### PR DESCRIPTION
Part of #156. Depends on #168 (category 0) → #167 (infra).

Closes #161.

## Skills

| Name | Scope |
|------|-------|
| devboy-review-mr | Strict but calibrated review of a single MR/PR. get_merge_requests + get_merge_request_diffs + get_merge_request_discussions, calibrated checklist (type safety, error handling, tests, docs, i18n, cross-platform). One summary comment + short [nit]/[suggestion]/[issue] inline comments via create_merge_request_comment. |
| devboy-fix-review-comments | Apply reviewer feedback. Re-run cargo clippy/fmt/tests before replying. Never mark a reviewer's discussion resolved on their behalf. |
| devboy-self-review | Dry-run a review pass over your own MR before asking for review. Outputs plain text to the user — does not post inline comments to your own PR. |

## Conventions
ADR-012: English-only, CLI-first. Every tool cross-checked against tools.rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)