### PR TITLE
feat(skills): category 4 — meeting notes via Fireflies (3 skills, #164)

### DIFF
--- a/skills/04-meeting-notes/devboy-meeting-search/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-search/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: devboy-meeting-search
+description: Find meetings by keyword, participant, host, or date range and surface a short, rankable hit list.
+category: meeting-notes
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "find meeting about"
+  - "when did we discuss"
+  - "list meetings last week"
+  - "search meetings"
+  - "find calls with"
+tools:
+  - search_meeting_notes
+  - get_meeting_notes
+---
+
+# devboy-meeting-search
+
+Answer "which meeting did we talk about X?" without making the user scroll through a calendar. The skill narrows a corpus of meeting notes down to a short hit list the user can act on — drill-down into a single meeting's metadata is a follow-up step, and pulling the full transcript is the job of `devboy-meeting-transcript`.
+
+## When to use
+
+- The user names a topic, keyword, or phrase ("the migration call", "anything about SSO") and wants to locate the meeting.
+- The user wants a window of recent meetings ("what did we have this week?", "list calls with Alice last month").
+- Before running `devboy-meeting-to-tasks` or `devboy-meeting-transcript`, confirm the target meeting id.
+
+If no search term is given — just a window or a participant — skip the keyword search and go straight to `get_meeting_notes` with the filter.
+
+## Procedure
+
+### 1. Keyword search
+
+Use `search_meeting_notes` when the user supplied a topic. All filters (date range, participants, host) combine with the keyword on the provider side — there is no client-side filter.
+
+```bash
+devboy tools call search_meeting_notes '{
+  "query": "migration",
+  "from_date": "2026-03-01T00:00:00Z",
+  "to_date":   "2026-04-17T00:00:00Z",
+  "limit": 20
+}'
+```
+
+Dates are ISO 8601. The tool caps `limit` at 50 per call; paginate with `offset` if you need a deeper sweep.
+
+### 2. Filter-only listing (no keyword)
+
+```bash
+devboy tools call get_meeting_notes '{
+  "from_date": "2026-04-10T00:00:00Z",
+  "participants": ["alice@example.com"],
+  "limit": 20
+}'
+```
+
+Use this for "last N days" or "calls with Alice" — no keyword means do not invent one.
+
+### 3. Rank the hits
+
+The provider returns meetings newest-first but is not topic-ranked. When several hits look plausible, resolve ties by:
+
+1. **Recency** — the user usually wants the most recent occurrence.
+2. **Participant overlap** — prefer meetings whose attendees match the user's context (the person they are collaborating with, the team they asked about).
+3. **Keyword density** — if the provider surfaces `summary`, `keywords`, or `topics_discussed`, a meeting that hits multiple of them is a stronger match than one that mentions the term in passing.
+
+Present at most 5–10 candidates. If more exist, say so and offer to narrow by date or participant rather than dumping them all.
+
+### 4. Drill down to one meeting
+
+Once the user picks a hit, fetch its metadata for a short card — title, date, duration, participants, action-items count, a one-line summary:
+
+```bash
+devboy tools call get_meeting_notes '{
+  "from_date": "<date of the hit>",
+  "to_date":   "<+1 day>",
+  "limit": 5
+}'
+```
+
+(There is no single-meeting "get by id" helper — narrow the date window and match on `id`.)
+
+## Success criteria
+
+- The user can name the meeting they meant without reading a transcript.
+- For every hit the agent shows, at minimum: title, date, 1-line summary or top keyword.
+- If zero hits come back, the skill suggests a broader filter (wider date range, different keyword) rather than inventing a meeting.
+
+## Guardrails
+
+- **Do not dump transcripts here.** A search result is metadata + a one-line summary. Full transcript retrieval lives in `devboy-meeting-transcript`.
+- **Do not paraphrase the summary.** Quote the provider's summary verbatim — it is short and PII-sensitive; rewording risks distortion.
+- **Participants are emails.** When the user says "calls with Alice", ask for the email before filtering — display names from the provider are not guaranteed unique.
+
+## Non-goals
+
+- Ranking by semantic similarity beyond what the provider returns. The tool is a keyword search, not a vector search.
+- Cross-provider search. Only the meeting-notes provider that is configured (e.g. Fireflies) is queried.

--- a/skills/04-meeting-notes/devboy-meeting-to-tasks/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-to-tasks/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: devboy-meeting-to-tasks
+description: Extract deduplicated action items from a meeting, confirm with the user, then create issues in the configured tracker.
+category: meeting-notes
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "turn this meeting into tickets"
+  - "create tasks from the meeting"
+  - "extract action items"
+  - "file tickets from the call"
+  - "make issues from the transcript"
+tools:
+  - get_meeting_notes
+  - get_meeting_transcript
+  - create_issue
+  - link_issues
+---
+
+# devboy-meeting-to-tasks
+
+Convert a meeting into concrete, trackable work. The skill is deliberately conservative: extract → deduplicate → **confirm with the user** → create. Automatic creation from a transcript produces nonsense tickets far too often — human review before the first `create_issue` is not optional.
+
+## When to use
+
+- The user references a meeting that produced to-dos and wants them in the tracker.
+- A standup, planning, or retro transcript exists and the commitments need a paper trail.
+- Follow-up from `devboy-meeting-search` when the user says "file tickets for this one".
+
+## Procedure
+
+### 1. Pin the meeting
+
+The skill operates on one meeting at a time. If the id is not known, fetch the short metadata list and confirm with the user:
+
+```bash
+devboy tools call get_meeting_notes '{
+  "from_date": "<window start ISO>",
+  "to_date":   "<window end ISO>",
+  "limit": 10
+}'
+```
+
+### 2. Prefer the provider's action items
+
+`get_meeting_notes` returns an `action_items` array populated by the provider's summariser. When it is non-empty, use it — it is already filtered to imperative commitments:
+
+```bash
+devboy tools call get_meeting_notes '{
+  "from_date": "<narrow window around the meeting>",
+  "to_date":   "<+1 day>",
+  "limit": 5
+}'
+```
+
+Take the `action_items` field from the matching meeting. This is cheaper and more reliable than parsing a transcript.
+
+### 3. Fallback: parse the transcript
+
+If `action_items` is empty or missing, fetch the transcript and extract candidates manually:
+
+```bash
+devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' --budget 6000
+```
+
+Look for:
+
+- Imperative verb phrases attributed to a specific participant ("I'll draft the RFC", "Alice will open a ticket about X").
+- "Let's…" / "We need to…" statements where someone assented.
+
+Skip hypotheticals, questions, and vague intentions ("we should probably look into that" with no commitment attached).
+
+### 4. Deduplicate ruthlessly
+
+A 45-minute call will restate the same commitment three or four times. Before creating anything, collapse the list:
+
+- Normalise the verb + object (e.g. "update the docs", "fix docs", "I'll update the documentation" → one item).
+- Merge paraphrases of the same commitment made by the same person.
+- Keep distinct items when the owner differs, even if the action is similar.
+
+The deduplicated list is what the user will see next.
+
+### 5. Confirm with the user before creating
+
+**Show the dedup'd list and wait for a go-ahead.** Offer three options:
+
+1. Create all of them as-is.
+2. Create a named subset.
+3. Edit titles / owners / descriptions first.
+
+Never skip this step — automatic creation from a transcript is the single biggest source of tracker clutter this skill can cause.
+
+### 6. Create one issue per item
+
+Keep each ticket small — **one action, one ticket**. For each approved item:
+
+```bash
+devboy tools call create_issue '{
+  "title": "Short imperative title (one line)",
+  "description": "Source: meeting \"<meeting title>\" on <ISO date>.\nOwner committed: <name>.\n\nContext:\n<2–4 lines from the transcript or action_items entry>",
+  "assignees": ["<handle>"],
+  "labels": ["from-meeting"]
+}'
+```
+
+Guidelines:
+
+- Title is imperative and under ~80 chars. "Draft RFC for auth migration" not "We should probably think about the RFC".
+- Description always cites the meeting title + date so the ticket is traceable back to its source.
+- Assign to the committed owner when known. If unknown, leave unassigned and note the speaker in the body.
+
+### 7. Optional: link issues that share a parent
+
+If several of the new issues clearly belong to one epic the user named, link them:
+
+```bash
+devboy tools call link_issues '{
+  "sourceIssueKey": "<new issue key>",
+  "targetIssueKey": "<epic key>",
+  "linkType": "relates_to"
+}'
+```
+
+Use `relates_to` by default; only use `blocks` when the user stated an ordering.
+
+### 8. Report back
+
+Reply with:
+
+- The meeting source (title + date).
+- The deduplicated list of created tickets (one line each: `KEY — title`).
+- Items that were discussed but **not** created (because the user dropped them), so the audit trail is complete.
+
+## Success criteria
+
+- Zero tickets are created before the user confirms the deduplicated list.
+- Every created ticket cites the source meeting in its description.
+- Each ticket is one action (no multi-bullet tickets). If the extracted item has two distinct actions, it was two items and should have been split during dedup.
+- The count of created tickets matches the count of approved items — no silent drops, no silent extras.
+
+## Guardrails
+
+- **Never auto-create.** Even when the user says "just do it", show the list once and wait for one-key confirmation. One extra round-trip beats filing 20 bad tickets.
+- **Do not re-create on re-run.** If the user re-runs the skill on the same meeting, check for existing tickets with the `from-meeting` label plus the source-meeting citation before creating duplicates.
+- **Respect privacy.** Do not paste full transcript quotes into ticket descriptions — 2–4 lines of context is enough, more is a PII leak in a system that is often more widely shared than the meeting itself.
+
+## Non-goals
+
+- Estimating or prioritising the created tickets. The skill files them; triage is a separate step.
+- Cross-meeting aggregation. One meeting → one batch of tickets.
+- Updating existing tickets based on a meeting. Use `update_issue` directly for that — this skill only creates.

--- a/skills/04-meeting-notes/devboy-meeting-to-tasks/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-to-tasks/SKILL.md
@@ -13,6 +13,7 @@ activation:
 tools:
   - get_meeting_notes
   - get_meeting_transcript
+  - get_issues
   - create_issue
   - link_issues
 ---
@@ -141,7 +142,7 @@ Reply with:
 ## Guardrails
 
 - **Never auto-create.** Even when the user says "just do it", show the list once and wait for one-key confirmation. One extra round-trip beats filing 20 bad tickets.
-- **Do not re-create on re-run.** If the user re-runs the skill on the same meeting, check for existing tickets with the `from-meeting` label plus the source-meeting citation before creating duplicates.
+- **Do not re-create on re-run.** If the user re-runs the skill on the same meeting, use `get_issues` with the `from-meeting` label (plus the source-meeting citation in the body) to find already-created tickets before creating duplicates.
 - **Respect privacy.** Do not paste full transcript quotes into ticket descriptions — 2–4 lines of context is enough, more is a PII leak in a system that is often more widely shared than the meeting itself.
 
 ## Non-goals

--- a/skills/04-meeting-notes/devboy-meeting-transcript/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-transcript/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: devboy-meeting-transcript
+description: Fetch a meeting transcript — full, paginated, or filtered to a single speaker or phrase — without leaking raw PII into long-term storage.
+category: meeting-notes
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "transcript of meeting"
+  - "what did Alice say about"
+  - "show the meeting transcript"
+  - "quote from the meeting"
+  - "what was said about"
+tools:
+  - get_meeting_transcript
+  - get_meeting_notes
+---
+
+# devboy-meeting-transcript
+
+Retrieve the speaker-attributed, timestamped transcript for a single meeting. Transcripts are routinely large (thousands of sentences for a one-hour call), so the skill is built around pulling only what the question actually needs rather than the whole thing.
+
+## When to use
+
+- The user asks for a transcript by meeting title, id, or relative reference ("the call yesterday", "the one with Alice on Tuesday").
+- The user wants a specific quote ("what did Bob say about the migration?").
+- A follow-up skill (`devboy-meeting-to-tasks`) needs the raw text to extract action items that are not already in `action_items`.
+
+If the user does not yet know which meeting — route through `devboy-meeting-search` first.
+
+## Procedure
+
+### 1. Resolve the meeting id
+
+You need a `meeting_id`. If the user already pasted one, skip this step. Otherwise confirm the id via `get_meeting_notes` (or via `devboy-meeting-search` for a keyword lookup) and pin the id before fetching:
+
+```bash
+devboy tools call get_meeting_notes '{
+  "from_date": "2026-04-16T00:00:00Z",
+  "to_date":   "2026-04-17T00:00:00Z",
+  "limit": 10
+}'
+```
+
+Confirm the title and date with the user before proceeding — pulling the wrong transcript is an irreversible PII leak into the chat.
+
+### 2. Fetch the transcript with a budget
+
+```bash
+devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' --budget 4000
+```
+
+`--budget` is the format pipeline's token cap. A full-length call does not fit in a single chunk — the response comes back with:
+
+- `truncated: true` and a pagination hint when there is more to fetch.
+- `chunked: true` + `total_chunks` + `chunk_number` when the output was split.
+
+### 3. Navigate chunks, do not re-fetch the whole thing
+
+If chunk 1 is not the interesting bit, ask for the next chunk rather than re-running the call with a higher budget:
+
+```bash
+devboy tools call get_meeting_transcript '{"meeting_id": "<id>", "chunk": 2}' --budget 4000
+```
+
+`chunk` is the enricher's universal navigation parameter — it is added to every tool, not specific to transcripts. Chunk 1 is the default.
+
+### 4. Prefer a targeted fetch over a full dump
+
+When the question is specific ("what did Alice say about X?"), do not scroll the whole transcript in the chat. Two patterns:
+
+1. **Search first, transcript second.** Run `devboy-meeting-search` with the topic word, confirm this is the right meeting, then open the relevant chunk.
+2. **Grep the chunk.** Once you have the transcript text, filter locally to sentences from the speaker of interest. The transcript output is speaker-attributed (`speaker_name`, `speaker_id`, `text`, `start_time`), so a simple line filter works:
+
+   ```bash
+   devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' --budget 6000 \
+     | jq '.[] | select(.speaker_name == "Alice")'
+   ```
+
+### 5. Quote, do not paste
+
+When you respond to the user, reply with the minimum quote that answers the question — typically one to three sentences plus the speaker and timestamp. Never paste the full transcript into the chat unless the user explicitly asked for it.
+
+## Success criteria
+
+- The user gets an answer grounded in the transcript, with speaker + timestamp, in fewer than 10 lines for a targeted question.
+- For a "give me the whole transcript" request, the skill streams chunk 1, reports `total_chunks`, and waits for the user to ask for more rather than pre-fetching all chunks.
+- No untrimmed transcript content is copy-pasted into files the user did not name.
+
+## Guardrails
+
+- **PII.** Transcripts contain names, emails, internal project names, and sometimes customer data. Do not write them to long-term storage (new docs, new issues, commit messages) unless the user explicitly asks for a specific excerpt. Summarise; do not mirror.
+- **Do not translate or edit quotes.** If the user asks "what did Alice say?", answer with her words, not a paraphrase — downstream uses (legal, HR, customer conversations) rely on the exact phrasing.
+- **Confirm the meeting before fetching.** A wrong `meeting_id` leaks a different meeting's contents into the chat and is not retractable.
+
+## Non-goals
+
+- Editing or redacting transcripts. The skill is read-only.
+- Summarising a full meeting. Use the `summary` and `action_items` fields returned by `get_meeting_notes` — those are provider-generated and cheaper to fetch than the full transcript.
+- Cross-meeting aggregation. One transcript at a time.

--- a/skills/04-meeting-notes/devboy-meeting-transcript/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-transcript/SKILL.md
@@ -43,37 +43,34 @@ devboy tools call get_meeting_notes '{
 
 Confirm the title and date with the user before proceeding — pulling the wrong transcript is an irreversible PII leak into the chat.
 
-### 2. Fetch the transcript with a budget
+### 2. Fetch the transcript
 
 ```bash
-devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' --budget 4000
+devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}'
 ```
 
-`--budget` is the format pipeline's token cap. A full-length call does not fit in a single chunk — the response comes back with:
+`devboy tools call` takes a tool name + a JSON argument object — it does not accept `--budget` (or any other CLI flag) for the tool itself. The format-pipeline budget is applied inside the tool runtime. The transcript output is rendered as plain text, not JSON; a long transcript may be shortened by the pipeline and picked up again via a subsequent call.
 
-- `truncated: true` and a pagination hint when there is more to fetch.
-- `chunked: true` + `total_chunks` + `chunk_number` when the output was split.
+### 3. If the rendered transcript is incomplete, fetch the next chunk
 
-### 3. Navigate chunks, do not re-fetch the whole thing
-
-If chunk 1 is not the interesting bit, ask for the next chunk rather than re-running the call with a higher budget:
+If the response ends mid-thought, pull the next segment:
 
 ```bash
-devboy tools call get_meeting_transcript '{"meeting_id": "<id>", "chunk": 2}' --budget 4000
+devboy tools call get_meeting_transcript '{"meeting_id": "<id>", "chunk": 2}'
 ```
 
-`chunk` is the enricher's universal navigation parameter — it is added to every tool, not specific to transcripts. Chunk 1 is the default.
+`chunk` is a per-call argument understood by the transcript tool (the default is 1). The response is still text — do not expect a JSON body with fields like `total_chunks` or `chunk_number`. The tell for "more to fetch" is that the text ends mid-sentence, not a structured field.
 
 ### 4. Prefer a targeted fetch over a full dump
 
 When the question is specific ("what did Alice say about X?"), do not scroll the whole transcript in the chat. Two patterns:
 
 1. **Search first, transcript second.** Run `devboy-meeting-search` with the topic word, confirm this is the right meeting, then open the relevant chunk.
-2. **Grep the chunk.** Once you have the transcript text, filter locally to sentences from the speaker of interest. The transcript output is speaker-attributed (`speaker_name`, `speaker_id`, `text`, `start_time`), so a simple line filter works:
+2. **Grep the chunk.** The transcript is rendered as text lines shaped like `[mm:ss] <speaker>: <sentence>`, so filter with `grep` / `ripgrep`:
 
    ```bash
-   devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' --budget 6000 \
-     | jq '.[] | select(.speaker_name == "Alice")'
+   devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' \
+     | grep -F '] Alice: '
    ```
 
 ### 5. Quote, do not paste


### PR DESCRIPTION
Part of #156. Depends on #168 (category 0) → #167 (infra).

Closes #164.

## Skills

| Name | Scope |
|------|-------|
| devboy-meeting-search | Find meetings by keyword / participant / host / date range via search_meeting_notes. Drill-down uses a narrow date window + id match (there is no get_meeting_note(id) — only a filtered list endpoint). |
| devboy-meeting-transcript | Full / paginated / filtered transcript fetch via get_meeting_transcript. Uses the executor-wide budget / chunk pagination parameters rather than a non-existent speaker filter on the tool itself. Pipes speaker-attributed sentences through jq for speaker-specific extraction. PII guardrail. |
| devboy-meeting-to-tasks | Extract deduplicated action items, confirm with the user before creating, then create_issue per unique item with optional link_issues. Prefers the provider-supplied action_items field; falls back to transcript parsing only when empty. |

## Conventions
ADR-012. Tools confirmed: search_meeting_notes, get_meeting_notes, get_meeting_transcript, create_issue, link_issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)