### PR TITLE
feat(skills): session traces for the self-feedback loop (ADR-015)

### DIFF
--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -244,6 +244,12 @@ enum Commands {
         command: SkillsCommands,
     },
 
+    /// Write to a skill's self-feedback session trace (ADR-015)
+    Trace {
+        #[command(subcommand)]
+        command: TraceCommands,
+    },
+
     /// Run diagnostic checks for the local DevBoy setup
     Doctor {
         /// Output machine-readable JSON
@@ -540,6 +546,64 @@ enum SkillsCommands {
     },
 }
 
+#[derive(Subcommand)]
+enum TraceCommands {
+    /// Start a new session trace. Prints a single JSON line with
+    /// `session_id`, `session_dir`, `trace_path` — skills capture that
+    /// and pass the values to subsequent `event` / `end` invocations.
+    Begin {
+        /// Skill name. Shown as the directory under the date, also
+        /// recorded in every event.
+        #[arg(long)]
+        skill: String,
+        /// Write under `~/.devboy/sessions/` instead of the repo-local
+        /// `<repo>/.devboy/sessions/`.
+        #[arg(long, conflicts_with = "dir")]
+        global: bool,
+        /// Write under an explicit directory (mostly for testing).
+        #[arg(long)]
+        dir: Option<String>,
+    },
+    /// Append one event to an existing session.
+    Event {
+        /// Session directory printed by `trace begin`.
+        #[arg(long)]
+        session_dir: String,
+        /// Session id printed by `trace begin`.
+        #[arg(long)]
+        session_id: String,
+        /// Skill name.
+        #[arg(long)]
+        skill: String,
+        /// Event phase. Supported values: `start`, `decision`, `tool_call`,
+        /// `tool_result`, `verify`, `artifact`, `note`, `end`.
+        #[arg(long)]
+        phase: String,
+        /// JSON payload. Defaults to `{}` if omitted.
+        #[arg(long, default_value = "{}")]
+        payload: String,
+    },
+    /// Finalise a session — writes the closing event and updates
+    /// `meta.json` with the outcome + aggregated counts.
+    End {
+        /// Session directory printed by `trace begin`.
+        #[arg(long)]
+        session_dir: String,
+        /// Session id printed by `trace begin`.
+        #[arg(long)]
+        session_id: String,
+        /// Skill name.
+        #[arg(long)]
+        skill: String,
+        /// Session outcome: `success`, `failure`, `aborted`.
+        #[arg(long)]
+        outcome: String,
+        /// Human-readable summary.
+        #[arg(long, default_value = "")]
+        summary: String,
+    },
+}
+
 /// Environment variable to skip keychain operations (for CI testing).
 /// When set to "1" or "true", uses in-memory store instead of OS keychain.
 const SKIP_KEYCHAIN_ENV: &str = "DEVBOY_SKIP_KEYCHAIN";
@@ -735,6 +799,10 @@ async fn main() -> Result<()> {
 
             Some(Commands::Skills { command }) => {
                 skills_cmd::handle(command).await?;
+            }
+
+            Some(Commands::Trace { command }) => {
+                skills_cmd::handle_trace(command).await?;
             }
 
             Some(Commands::Doctor {

--- a/crates/devboy-cli/src/skills_cmd.rs
+++ b/crates/devboy-cli/src/skills_cmd.rs
@@ -10,7 +10,96 @@ use devboy_skills::{
     install_skills_to_target, remove_skills_from_target, resolve_targets,
 };
 
-use crate::SkillsCommands;
+use crate::{SkillsCommands, TraceCommands};
+
+/// Dispatch a `devboy trace` subcommand.
+pub async fn handle_trace(command: TraceCommands) -> Result<()> {
+    use devboy_skills::{TraceTarget, append_event, create_session, finalise_session};
+    match command {
+        TraceCommands::Begin { skill, global, dir } => {
+            let target = if let Some(p) = dir {
+                TraceTarget::Custom(std::path::PathBuf::from(p))
+            } else if global {
+                TraceTarget::Global
+            } else {
+                TraceTarget::RepoLocal
+            };
+            let (session_id, session_dir) =
+                create_session(&skill, &target).context("failed to begin session")?;
+            let trace_path = session_dir.join("trace.jsonl");
+            let out = serde_json::json!({
+                "session_id": session_id,
+                "session_dir": session_dir.display().to_string(),
+                "trace_path": trace_path.display().to_string(),
+            });
+            println!("{out}");
+            Ok(())
+        }
+        TraceCommands::Event {
+            session_dir,
+            session_id,
+            skill,
+            phase,
+            payload,
+        } => {
+            let phase = parse_phase(&phase)?;
+            let payload: serde_json::Value =
+                serde_json::from_str(&payload).context("invalid JSON payload")?;
+            append_event(
+                std::path::Path::new(&session_dir),
+                &session_id,
+                &skill,
+                phase,
+                payload,
+            )
+            .context("failed to append event")
+        }
+        TraceCommands::End {
+            session_dir,
+            session_id,
+            skill,
+            outcome,
+            summary,
+        } => {
+            let outcome = parse_outcome(&outcome)?;
+            finalise_session(
+                std::path::Path::new(&session_dir),
+                &session_id,
+                &skill,
+                outcome,
+                &summary,
+            )
+            .context("failed to finalise session")
+        }
+    }
+}
+
+fn parse_phase(raw: &str) -> Result<devboy_skills::TracePhase> {
+    use devboy_skills::TracePhase as P;
+    Ok(match raw {
+        "start" => P::Start,
+        "decision" => P::Decision,
+        "tool_call" => P::ToolCall,
+        "tool_result" => P::ToolResult,
+        "verify" => P::Verify,
+        "artifact" => P::Artifact,
+        "note" => P::Note,
+        "end" => P::End,
+        other => anyhow::bail!(
+            "unknown trace phase `{other}` (expected start | decision | tool_call | tool_result | verify | artifact | note | end)"
+        ),
+    })
+}
+
+fn parse_outcome(raw: &str) -> Result<devboy_skills::TraceOutcome> {
+    use devboy_skills::TraceOutcome as O;
+    Ok(match raw {
+        "success" => O::Success,
+        "failure" => O::Failure,
+        "aborted" => O::Aborted,
+        other => anyhow::bail!("unknown outcome `{other}` (expected success | failure | aborted)"),
+    })
+}
 
 /// Dispatch a `devboy skills` subcommand.
 pub async fn handle(command: SkillsCommands) -> Result<()> {

--- a/crates/devboy-cli/tests/skills_test.rs
+++ b/crates/devboy-cli/tests/skills_test.rs
@@ -243,3 +243,148 @@ fn skills_remove_deletes_files_and_manifest_entry() {
     );
     assert!(!installed.exists(), "file should be deleted");
 }
+
+#[test]
+fn trace_begin_event_end_round_trip() {
+    let home = TempDir::new().unwrap();
+    let cwd = TempDir::new().unwrap();
+    let dir_override = TempDir::new().unwrap();
+
+    let begin = spawn(
+        &home,
+        cwd.path(),
+        [
+            "trace",
+            "begin",
+            "--skill",
+            "devboy-setup",
+            "--dir",
+            dir_override.path().to_str().unwrap(),
+        ],
+    );
+    assert!(begin.status.success(), "trace begin should succeed");
+    let begin_stdout = String::from_utf8_lossy(&begin.stdout);
+    let meta: serde_json::Value = serde_json::from_str(begin_stdout.trim())
+        .expect("trace begin should print a single JSON line");
+    let session_id = meta["session_id"].as_str().unwrap().to_string();
+    let session_dir = meta["session_dir"].as_str().unwrap().to_string();
+    assert!(
+        !session_id.is_empty(),
+        "session_id is empty: {begin_stdout}"
+    );
+
+    let event = spawn(
+        &home,
+        cwd.path(),
+        [
+            "trace",
+            "event",
+            "--session-dir",
+            &session_dir,
+            "--session-id",
+            &session_id,
+            "--skill",
+            "devboy-setup",
+            "--phase",
+            "tool_call",
+            "--payload",
+            r#"{"tool":"get_issues","args":{"limit":3}}"#,
+        ],
+    );
+    assert!(
+        event.status.success(),
+        "trace event should succeed: {}",
+        String::from_utf8_lossy(&event.stderr)
+    );
+
+    let end = spawn(
+        &home,
+        cwd.path(),
+        [
+            "trace",
+            "end",
+            "--session-dir",
+            &session_dir,
+            "--session-id",
+            &session_id,
+            "--skill",
+            "devboy-setup",
+            "--outcome",
+            "success",
+            "--summary",
+            "smoke-test complete",
+        ],
+    );
+    assert!(end.status.success(), "trace end should succeed");
+
+    let trace_path = std::path::PathBuf::from(&session_dir).join("trace.jsonl");
+    let trace_body = fs::read_to_string(&trace_path).expect("trace.jsonl should exist");
+    let lines: Vec<&str> = trace_body.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        3,
+        "expected 3 events (start, tool_call, end), got: {lines:?}"
+    );
+    assert!(lines[0].contains("\"phase\":\"start\""));
+    assert!(lines[1].contains("\"phase\":\"tool_call\""));
+    assert!(lines[2].contains("\"phase\":\"end\""));
+
+    let meta_path = std::path::PathBuf::from(&session_dir).join("meta.json");
+    let meta_body = fs::read_to_string(&meta_path).expect("meta.json should exist");
+    assert!(meta_body.contains("\"outcome\": \"success\""));
+    assert!(meta_body.contains("smoke-test complete"));
+    assert!(meta_body.contains("\"tool_calls\": 1"));
+}
+
+#[test]
+fn trace_event_redacts_tokens() {
+    let home = TempDir::new().unwrap();
+    let cwd = TempDir::new().unwrap();
+    let dir_override = TempDir::new().unwrap();
+
+    let begin = spawn(
+        &home,
+        cwd.path(),
+        [
+            "trace",
+            "begin",
+            "--skill",
+            "devboy-test",
+            "--dir",
+            dir_override.path().to_str().unwrap(),
+        ],
+    );
+    assert!(begin.status.success());
+    let meta: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&begin.stdout).trim()).unwrap();
+    let session_id = meta["session_id"].as_str().unwrap().to_string();
+    let session_dir = meta["session_dir"].as_str().unwrap().to_string();
+
+    let event = spawn(
+        &home,
+        cwd.path(),
+        [
+            "trace",
+            "event",
+            "--session-dir",
+            &session_dir,
+            "--session-id",
+            &session_id,
+            "--skill",
+            "devboy-test",
+            "--phase",
+            "tool_call",
+            "--payload",
+            r#"{"args":{"token":"ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}"#,
+        ],
+    );
+    assert!(event.status.success());
+
+    let trace_path = std::path::PathBuf::from(&session_dir).join("trace.jsonl");
+    let body = fs::read_to_string(trace_path).unwrap();
+    assert!(
+        !body.contains("ghp_aaaaaaaa"),
+        "token was not redacted: {body}"
+    );
+    assert!(body.contains("<redacted"));
+}

--- a/crates/devboy-skills/Cargo.toml
+++ b/crates/devboy-skills/Cargo.toml
@@ -33,11 +33,12 @@ ulid = { version = "1.1", features = ["serde"], optional = true }
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+temp-env = "0.3"
 
 [features]
-default = []
-# Enabled by the trace module (ADR-015); reserved so that the crate can
-# grow the session-trace API without pulling in ulid for the install path.
+default = ["trace"]
+# Session-trace module (ADR-015). Pulls in `ulid` for session ids.
+# On by default — disabling it is mostly a CI knob.
 trace = ["dep:ulid"]
 
 [lints]

--- a/crates/devboy-skills/src/lib.rs
+++ b/crates/devboy-skills/src/lib.rs
@@ -32,6 +32,7 @@ pub mod install;
 pub mod manifest;
 pub mod skill;
 pub mod source;
+pub mod trace;
 
 pub use catalog::Catalog;
 pub use embedded::EmbeddedSkillSource;
@@ -46,3 +47,7 @@ pub use manifest::{
 };
 pub use skill::{Category, Frontmatter, Skill, SkillSummary};
 pub use source::SkillSource;
+pub use trace::{
+    Outcome as TraceOutcome, Phase as TracePhase, SessionMeta, SessionTracer, TraceRecord,
+    TraceTarget, append_event, create_session, finalise_session,
+};

--- a/crates/devboy-skills/src/trace.rs
+++ b/crates/devboy-skills/src/trace.rs
@@ -2,8 +2,11 @@
 //!
 //! A session is the execution of one skill (or any caller that opts in
 //! through the `devboy trace` CLI). Events land as JSON Lines at
-//! `<target>/.devboy/sessions/<YYYY-MM-DD>/<skill>/trace.jsonl`, and
-//! a sibling `meta.json` carries session-level metadata.
+//! `<target>/.devboy/sessions/<YYYY-MM-DD>/<skill>/<session_id>/trace.jsonl`,
+//! and a sibling `meta.json` in the same per-session directory carries
+//! session-level metadata. The `<session_id>` segment keeps concurrent
+//! or repeated invocations of the same skill on the same day isolated
+//! from each other (ADR-015 requires self-contained sessions).
 //!
 //! The [`SessionTracer`] writer is intentionally small — it serialises
 //! one event per line with no framing, no network I/O, and no reliance
@@ -37,7 +40,11 @@ pub mod redact;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Phase {
-    /// First event of the session — captures input, cwd, devboy version.
+    /// First event of the session, marking the start of execution.
+    /// The tracer synthesises a `start` record with an empty payload;
+    /// any input / cwd / version metadata is caller-defined — pass it
+    /// via a regular `event` call after `begin` if you want it in the
+    /// stream, or record it in `meta.json` via a later `end` call.
     Start,
     /// Skill-level reasoning outcome.
     Decision,
@@ -155,6 +162,11 @@ pub struct SessionTracer {
     started_at: DateTime<Utc>,
     tool_calls: std::sync::atomic::AtomicU64,
     errors: std::sync::atomic::AtomicU64,
+    /// Env-var snapshot captured at `begin`, reused for every
+    /// `write_event` so the redactor does not rescan `std::env::vars()`
+    /// on each record (can be tens of thousands of events in a long
+    /// session).
+    redactor: redact::Redactor,
 }
 
 impl SessionTracer {
@@ -195,6 +207,7 @@ impl SessionTracer {
             started_at,
             tool_calls: std::sync::atomic::AtomicU64::new(0),
             errors: std::sync::atomic::AtomicU64::new(0),
+            redactor: redact::Redactor::snapshot(),
         };
 
         // Emit the `start` event synthesised from the call arguments;
@@ -272,7 +285,7 @@ impl SessionTracer {
     }
 
     fn write_event(&self, phase: Phase, payload: Value) -> Result<()> {
-        let redacted = redact::sanitize(payload);
+        let redacted = self.redactor.sanitize(payload);
         let record = TraceRecord {
             ts: Utc::now(),
             skill: self.skill.clone(),

--- a/crates/devboy-skills/src/trace.rs
+++ b/crates/devboy-skills/src/trace.rs
@@ -158,13 +158,17 @@ pub struct SessionTracer {
 }
 
 impl SessionTracer {
-    /// Start a new session. Creates the dated directory + a per-skill
-    /// subdirectory and opens `trace.jsonl` for append.
+    /// Start a new session. Creates a unique directory
+    /// `<root>/<date>/<skill>/<session_id>/` and opens `trace.jsonl`
+    /// for append. The per-session directory ensures that concurrent
+    /// or repeated invocations of the same skill on the same day do
+    /// not share any files (ADR-015 requires self-contained sessions).
     pub fn begin(skill: &str, target: &TraceTarget) -> Result<Self> {
         let root = target.sessions_root()?;
         let started_at = Utc::now();
         let date = started_at.format("%Y-%m-%d").to_string();
-        let session_dir = root.join(&date).join(skill);
+        let session_id = new_session_id();
+        let session_dir = root.join(&date).join(skill).join(&session_id);
         create_dir_all(&session_dir).map_err(|source| SkillError::Io {
             path: session_dir.clone(),
             source,
@@ -180,8 +184,6 @@ impl SessionTracer {
                 path: trace_path.clone(),
                 source,
             })?;
-
-        let session_id = new_session_id();
 
         let tracer = Self {
             session_id,
@@ -357,19 +359,27 @@ pub struct SessionMeta {
 // ---------------------------------------------------------------------------
 
 /// Create the session directory, write the opening `start` event, and
-/// return the session id + absolute session directory. Callers then
-/// pass those back into [`append_event`] and [`finalise_session`] on
+/// return the session id + session directory. The returned path is the
+/// value the user passed through `TraceTarget` with the `<date>/<skill>
+/// /<session_id>` suffix appended — it is not canonicalised, so a
+/// relative `TraceTarget::Custom(".traces")` produces a relative path
+/// and an absolute target produces an absolute path. Callers pass both
+/// values back into [`append_event`] and [`finalise_session`] on
 /// subsequent CLI invocations.
+///
+/// The per-session directory level is required so that concurrent or
+/// repeated invocations of the same skill on the same day never share
+/// `trace.jsonl` or `meta.json` (ADR-015).
 pub fn create_session(skill: &str, target: &TraceTarget) -> Result<(String, PathBuf)> {
     let root = target.sessions_root()?;
     let started_at = Utc::now();
     let date = started_at.format("%Y-%m-%d").to_string();
-    let session_dir = root.join(&date).join(skill);
+    let session_id = new_session_id();
+    let session_dir = root.join(&date).join(skill).join(&session_id);
     create_dir_all(&session_dir).map_err(|source| SkillError::Io {
         path: session_dir.clone(),
         source,
     })?;
-    let session_id = new_session_id();
     append_event_inner(
         &session_dir,
         &session_id,
@@ -492,18 +502,35 @@ fn write_meta_file(path: &Path, meta: &SessionMeta) -> Result<()> {
 }
 
 fn scan_counts(trace_path: &Path) -> Result<(u64, u64, DateTime<Utc>)> {
-    let text = std::fs::read_to_string(trace_path).map_err(|source| SkillError::Io {
+    use std::io::{BufRead, BufReader};
+
+    // Stream the file line-by-line rather than reading the whole
+    // `trace.jsonl` into memory. ADR-015 explicitly flags that long
+    // sessions can produce very large traces; keeping the memory
+    // footprint bounded matters.
+    let file = std::fs::File::open(trace_path).map_err(|source| SkillError::Io {
         path: trace_path.to_path_buf(),
         source,
     })?;
+    let reader = BufReader::new(file);
+
     let mut tool_calls = 0u64;
     let mut errors = 0u64;
     let mut started_at: Option<DateTime<Utc>> = None;
-    for line in text.lines() {
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(source) => {
+                return Err(SkillError::Io {
+                    path: trace_path.to_path_buf(),
+                    source,
+                });
+            }
+        };
         if line.trim().is_empty() {
             continue;
         }
-        let record: TraceRecord = match serde_json::from_str(line) {
+        let record: TraceRecord = match serde_json::from_str(&line) {
             Ok(r) => r,
             Err(_) => continue,
         };

--- a/crates/devboy-skills/src/trace.rs
+++ b/crates/devboy-skills/src/trace.rs
@@ -1,0 +1,681 @@
+//! Session traces for the self-feedback loop (ADR-015).
+//!
+//! A session is the execution of one skill (or any caller that opts in
+//! through the `devboy trace` CLI). Events land as JSON Lines at
+//! `<target>/.devboy/sessions/<YYYY-MM-DD>/<skill>/trace.jsonl`, and
+//! a sibling `meta.json` carries session-level metadata.
+//!
+//! The [`SessionTracer`] writer is intentionally small — it serialises
+//! one event per line with no framing, no network I/O, and no reliance
+//! on the host logging stack. The companion [`devboy trace`] CLI
+//! subcommand family in `devboy-cli` lets shell-based skills write into
+//! the same format.
+//!
+//! The redaction pass in [`redact::sanitize`] strips values that match
+//! known credential shapes and values of environment variables named
+//! `*_TOKEN` / `*_SECRET` / `*_KEY` / `*_PASSWORD` / `*_PASSPHRASE` /
+//! `AUTHORIZATION` / `COOKIE` before anything is written to disk.
+
+use std::fs::{File, OpenOptions, create_dir_all};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::error::{Result, SkillError};
+
+pub mod redact;
+
+// ---------------------------------------------------------------------------
+// Phase + Outcome enums
+// ---------------------------------------------------------------------------
+
+/// Event phases. Kept small; readers must silently ignore unknown values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    /// First event of the session — captures input, cwd, devboy version.
+    Start,
+    /// Skill-level reasoning outcome.
+    Decision,
+    /// Immediately before invoking a tool.
+    ToolCall,
+    /// Immediately after a tool returns.
+    ToolResult,
+    /// A verification check ran (tests / clippy / dry-run etc.).
+    Verify,
+    /// Non-trivial file produced by the skill.
+    Artifact,
+    /// Free-form human-readable log entry.
+    Note,
+    /// Last event of the session.
+    End,
+}
+
+/// Session outcome — recorded on `End` in both the event stream and the
+/// per-session `meta.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    /// Skill completed and achieved its objective.
+    Success,
+    /// Skill ran to completion but the objective was not met.
+    Failure,
+    /// Skill stopped before completing (cancelled, interrupted).
+    Aborted,
+}
+
+// ---------------------------------------------------------------------------
+// Target resolution
+// ---------------------------------------------------------------------------
+
+/// Where to write session traces.
+#[derive(Debug, Clone)]
+pub enum TraceTarget {
+    /// Repo-local at `<repo>/.devboy/sessions/`. Default.
+    RepoLocal,
+    /// Per-user at `~/.devboy/sessions/`.
+    Global,
+    /// Explicit directory — used by tests.
+    Custom(PathBuf),
+}
+
+impl TraceTarget {
+    /// Resolve the `sessions/` root directory for this target.
+    pub fn sessions_root(&self) -> Result<PathBuf> {
+        match self {
+            Self::RepoLocal => {
+                let cwd = std::env::current_dir().map_err(|source| SkillError::Io {
+                    path: PathBuf::from("."),
+                    source,
+                })?;
+                let repo = locate_repo_root(&cwd).ok_or_else(|| SkillError::Io {
+                    path: cwd,
+                    source: std::io::Error::other(
+                        "no git repository / .devboy.toml at the current path (pass --global to write traces under ~/.devboy/sessions/)",
+                    ),
+                })?;
+                Ok(repo.join(".devboy").join("sessions"))
+            }
+            Self::Global => {
+                let home = home_dir()?;
+                Ok(home.join(".devboy").join("sessions"))
+            }
+            Self::Custom(p) => Ok(p.clone()),
+        }
+    }
+}
+
+fn locate_repo_root(start: &Path) -> Option<PathBuf> {
+    let mut cur = start;
+    loop {
+        if cur.join(".git").exists() || cur.join(".devboy.toml").exists() {
+            return Some(cur.to_path_buf());
+        }
+        match cur.parent() {
+            Some(p) => cur = p,
+            None => return None,
+        }
+    }
+}
+
+fn home_dir() -> Result<PathBuf> {
+    if let Some(p) = std::env::var_os("DEVBOY_HOME_OVERRIDE")
+        && !p.is_empty()
+    {
+        return Ok(PathBuf::from(p));
+    }
+    dirs::home_dir().ok_or_else(|| SkillError::Io {
+        path: PathBuf::from("~"),
+        source: std::io::Error::other("home directory is not set"),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// SessionTracer
+// ---------------------------------------------------------------------------
+
+/// Appends events to a session's `trace.jsonl`.
+///
+/// A new instance is built via [`SessionTracer::begin`], events are
+/// appended with [`SessionTracer::event`], and the session is finalised
+/// with [`SessionTracer::end`]. Dropping a tracer without calling `end`
+/// leaves the `trace.jsonl` intact but does not write `meta.json` — the
+/// stream still round-trips, just without the convenience summary.
+pub struct SessionTracer {
+    session_id: String,
+    skill: String,
+    session_dir: PathBuf,
+    trace_path: PathBuf,
+    meta_path: PathBuf,
+    trace_file: Mutex<File>,
+    started_at: DateTime<Utc>,
+    tool_calls: std::sync::atomic::AtomicU64,
+    errors: std::sync::atomic::AtomicU64,
+}
+
+impl SessionTracer {
+    /// Start a new session. Creates the dated directory + a per-skill
+    /// subdirectory and opens `trace.jsonl` for append.
+    pub fn begin(skill: &str, target: &TraceTarget) -> Result<Self> {
+        let root = target.sessions_root()?;
+        let started_at = Utc::now();
+        let date = started_at.format("%Y-%m-%d").to_string();
+        let session_dir = root.join(&date).join(skill);
+        create_dir_all(&session_dir).map_err(|source| SkillError::Io {
+            path: session_dir.clone(),
+            source,
+        })?;
+
+        let trace_path = session_dir.join("trace.jsonl");
+        let meta_path = session_dir.join("meta.json");
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&trace_path)
+            .map_err(|source| SkillError::Io {
+                path: trace_path.clone(),
+                source,
+            })?;
+
+        let session_id = new_session_id();
+
+        let tracer = Self {
+            session_id,
+            skill: skill.to_string(),
+            session_dir,
+            trace_path,
+            meta_path,
+            trace_file: Mutex::new(file),
+            started_at,
+            tool_calls: std::sync::atomic::AtomicU64::new(0),
+            errors: std::sync::atomic::AtomicU64::new(0),
+        };
+
+        // Emit the `start` event synthesised from the call arguments;
+        // callers can decorate it further via a regular `event` call.
+        tracer.write_event(Phase::Start, json!({}))?;
+        Ok(tracer)
+    }
+
+    /// Append one event to the trace. Payload is redacted before
+    /// writing.
+    pub fn event(&self, phase: Phase, payload: Value) -> Result<()> {
+        if phase == Phase::ToolCall {
+            self.tool_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        if phase == Phase::ToolResult
+            && payload
+                .get("ok")
+                .and_then(|v| v.as_bool())
+                .is_some_and(|ok| !ok)
+        {
+            self.errors
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        self.write_event(phase, payload)
+    }
+
+    /// Record the final `end` event and write the per-session
+    /// `meta.json`. Consumes the tracer.
+    pub fn end(self, outcome: Outcome, summary: &str) -> Result<()> {
+        let ended_at = Utc::now();
+        self.write_event(
+            Phase::End,
+            json!({ "outcome": outcome, "summary": summary }),
+        )?;
+
+        let meta = SessionMeta {
+            session_id: self.session_id.clone(),
+            skill: self.skill.clone(),
+            skill_version: None,
+            devboy_version: env!("CARGO_PKG_VERSION").to_string(),
+            started_at: self.started_at,
+            ended_at: Some(ended_at),
+            outcome: Some(outcome),
+            input_summary: None,
+            tool_calls: self.tool_calls.load(std::sync::atomic::Ordering::Relaxed),
+            errors: self.errors.load(std::sync::atomic::Ordering::Relaxed),
+            summary: Some(summary.to_string()),
+        };
+        let bytes =
+            serde_json::to_vec_pretty(&meta).map_err(|source| SkillError::InvalidManifest {
+                path: self.meta_path.clone(),
+                source,
+            })?;
+        std::fs::write(&self.meta_path, bytes).map_err(|source| SkillError::Io {
+            path: self.meta_path.clone(),
+            source,
+        })
+    }
+
+    /// The session directory on disk.
+    pub fn session_dir(&self) -> &Path {
+        &self.session_dir
+    }
+
+    /// The `trace.jsonl` path.
+    pub fn trace_path(&self) -> &Path {
+        &self.trace_path
+    }
+
+    /// The session id (ULID, or a randomly-generated fallback when the
+    /// `trace` Cargo feature is disabled).
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    fn write_event(&self, phase: Phase, payload: Value) -> Result<()> {
+        let redacted = redact::sanitize(payload);
+        let record = TraceRecord {
+            ts: Utc::now(),
+            skill: self.skill.clone(),
+            session_id: self.session_id.clone(),
+            phase,
+            payload: redacted,
+        };
+        let line =
+            serde_json::to_string(&record).map_err(|source| SkillError::InvalidManifest {
+                path: self.trace_path.clone(),
+                source,
+            })?;
+
+        let mut guard = self.trace_file.lock().map_err(|_| SkillError::Io {
+            path: self.trace_path.clone(),
+            source: std::io::Error::other("trace mutex poisoned"),
+        })?;
+        guard
+            .write_all(line.as_bytes())
+            .and_then(|()| guard.write_all(b"\n"))
+            .map_err(|source| SkillError::Io {
+                path: self.trace_path.clone(),
+                source,
+            })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// On-disk formats
+// ---------------------------------------------------------------------------
+
+/// One line of `trace.jsonl`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceRecord {
+    /// Timestamp of the event.
+    pub ts: DateTime<Utc>,
+    /// Skill name — duplicated on every event so that readers that
+    /// merge traces from different sessions can still attribute each
+    /// line.
+    pub skill: String,
+    /// Session id (ULID).
+    pub session_id: String,
+    /// Event phase.
+    pub phase: Phase,
+    /// Event payload. Redacted before writing.
+    pub payload: Value,
+}
+
+/// `meta.json` — written at session end and optionally touched during
+/// long sessions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMeta {
+    /// Session id matching every record in `trace.jsonl`.
+    pub session_id: String,
+    /// Skill name.
+    pub skill: String,
+    /// Skill version at run time, if the caller provided it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skill_version: Option<u32>,
+    /// devboy-tools version that emitted the session.
+    pub devboy_version: String,
+    /// Session start timestamp.
+    pub started_at: DateTime<Utc>,
+    /// Session end timestamp (missing on in-flight sessions).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<DateTime<Utc>>,
+    /// Outcome, if the session ended cleanly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<Outcome>,
+    /// One-line input summary recorded at start, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_summary: Option<String>,
+    /// Number of tool calls observed.
+    pub tool_calls: u64,
+    /// Number of tool calls that reported `ok: false`.
+    pub errors: u64,
+    /// Closing summary string (mirrors the `end` event payload).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Stateless helpers (used by `devboy trace` CLI subcommands)
+// ---------------------------------------------------------------------------
+
+/// Create the session directory, write the opening `start` event, and
+/// return the session id + absolute session directory. Callers then
+/// pass those back into [`append_event`] and [`finalise_session`] on
+/// subsequent CLI invocations.
+pub fn create_session(skill: &str, target: &TraceTarget) -> Result<(String, PathBuf)> {
+    let root = target.sessions_root()?;
+    let started_at = Utc::now();
+    let date = started_at.format("%Y-%m-%d").to_string();
+    let session_dir = root.join(&date).join(skill);
+    create_dir_all(&session_dir).map_err(|source| SkillError::Io {
+        path: session_dir.clone(),
+        source,
+    })?;
+    let session_id = new_session_id();
+    append_event_inner(
+        &session_dir,
+        &session_id,
+        skill,
+        Phase::Start,
+        Value::Object(Default::default()),
+    )?;
+    // Write a skeletal meta.json so long-running sessions are
+    // introspectable before `end` runs.
+    let skeleton = SessionMeta {
+        session_id: session_id.clone(),
+        skill: skill.to_string(),
+        skill_version: None,
+        devboy_version: env!("CARGO_PKG_VERSION").to_string(),
+        started_at,
+        ended_at: None,
+        outcome: None,
+        input_summary: None,
+        tool_calls: 0,
+        errors: 0,
+        summary: None,
+    };
+    write_meta_file(&session_dir.join("meta.json"), &skeleton)?;
+    Ok((session_id, session_dir))
+}
+
+/// Append one event to an existing session's `trace.jsonl`.
+pub fn append_event(
+    session_dir: &Path,
+    session_id: &str,
+    skill: &str,
+    phase: Phase,
+    payload: Value,
+) -> Result<()> {
+    append_event_inner(session_dir, session_id, skill, phase, payload)
+}
+
+fn append_event_inner(
+    session_dir: &Path,
+    session_id: &str,
+    skill: &str,
+    phase: Phase,
+    payload: Value,
+) -> Result<()> {
+    let redacted = redact::sanitize(payload);
+    let record = TraceRecord {
+        ts: Utc::now(),
+        skill: skill.to_string(),
+        session_id: session_id.to_string(),
+        phase,
+        payload: redacted,
+    };
+    let line = serde_json::to_string(&record).map_err(|source| SkillError::InvalidManifest {
+        path: session_dir.join("trace.jsonl"),
+        source,
+    })?;
+
+    let trace_path = session_dir.join("trace.jsonl");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&trace_path)
+        .map_err(|source| SkillError::Io {
+            path: trace_path.clone(),
+            source,
+        })?;
+    file.write_all(line.as_bytes())
+        .and_then(|()| file.write_all(b"\n"))
+        .map_err(|source| SkillError::Io {
+            path: trace_path.clone(),
+            source,
+        })
+}
+
+/// Write the final `end` event and refresh `meta.json` with the
+/// outcome + aggregated counts derived from the existing trace.
+pub fn finalise_session(
+    session_dir: &Path,
+    session_id: &str,
+    skill: &str,
+    outcome: Outcome,
+    summary: &str,
+) -> Result<()> {
+    append_event_inner(
+        session_dir,
+        session_id,
+        skill,
+        Phase::End,
+        json!({ "outcome": outcome, "summary": summary }),
+    )?;
+
+    let trace_path = session_dir.join("trace.jsonl");
+    let (tool_calls, errors, started_at) = scan_counts(&trace_path)?;
+
+    let meta = SessionMeta {
+        session_id: session_id.to_string(),
+        skill: skill.to_string(),
+        skill_version: None,
+        devboy_version: env!("CARGO_PKG_VERSION").to_string(),
+        started_at,
+        ended_at: Some(Utc::now()),
+        outcome: Some(outcome),
+        input_summary: None,
+        tool_calls,
+        errors,
+        summary: Some(summary.to_string()),
+    };
+    write_meta_file(&session_dir.join("meta.json"), &meta)
+}
+
+fn write_meta_file(path: &Path, meta: &SessionMeta) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(meta).map_err(|source| SkillError::InvalidManifest {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    std::fs::write(path, bytes).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn scan_counts(trace_path: &Path) -> Result<(u64, u64, DateTime<Utc>)> {
+    let text = std::fs::read_to_string(trace_path).map_err(|source| SkillError::Io {
+        path: trace_path.to_path_buf(),
+        source,
+    })?;
+    let mut tool_calls = 0u64;
+    let mut errors = 0u64;
+    let mut started_at: Option<DateTime<Utc>> = None;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: TraceRecord = match serde_json::from_str(line) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        if started_at.is_none() && record.phase == Phase::Start {
+            started_at = Some(record.ts);
+        }
+        if record.phase == Phase::ToolCall {
+            tool_calls += 1;
+        }
+        if record.phase == Phase::ToolResult
+            && record
+                .payload
+                .get("ok")
+                .and_then(|v| v.as_bool())
+                .is_some_and(|ok| !ok)
+        {
+            errors += 1;
+        }
+    }
+    Ok((tool_calls, errors, started_at.unwrap_or_else(Utc::now)))
+}
+
+// ---------------------------------------------------------------------------
+// Session id
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "trace")]
+fn new_session_id() -> String {
+    ulid::Ulid::new().to_string()
+}
+
+#[cfg(not(feature = "trace"))]
+fn new_session_id() -> String {
+    // Deterministic-enough fallback when the `trace` feature is off —
+    // time-prefixed so logs stay sortable.
+    format!(
+        "{}-{:x}",
+        Utc::now().format("%Y%m%d%H%M%S%f"),
+        std::process::id()
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn events_in(path: &Path) -> Vec<TraceRecord> {
+        let text = std::fs::read_to_string(path).unwrap();
+        text.lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn session_round_trip() {
+        let dir = tempdir().unwrap();
+        let target = TraceTarget::Custom(dir.path().to_path_buf());
+
+        let tracer = SessionTracer::begin("devboy-setup", &target).unwrap();
+        let trace_path = tracer.trace_path().to_path_buf();
+        let meta_path = tracer.session_dir().join("meta.json");
+
+        tracer
+            .event(
+                Phase::Decision,
+                json!({ "question": "provider?", "decision": "github" }),
+            )
+            .unwrap();
+        tracer
+            .event(
+                Phase::ToolCall,
+                json!({ "tool": "get_issues", "args": { "limit": 3 } }),
+            )
+            .unwrap();
+        tracer
+            .event(
+                Phase::ToolResult,
+                json!({ "tool": "get_issues", "ok": true, "duration_ms": 42 }),
+            )
+            .unwrap();
+        tracer.end(Outcome::Success, "configured github").unwrap();
+
+        let events = events_in(&trace_path);
+        // start + decision + tool_call + tool_result + end = 5
+        assert_eq!(events.len(), 5);
+        assert_eq!(events[0].phase, Phase::Start);
+        assert_eq!(events.last().unwrap().phase, Phase::End);
+        assert!(events.iter().all(|e| e.skill == "devboy-setup"));
+        assert!(events.iter().all(|e| e.session_id == events[0].session_id));
+
+        let meta_bytes = std::fs::read(&meta_path).unwrap();
+        let meta: SessionMeta = serde_json::from_slice(&meta_bytes).unwrap();
+        assert_eq!(meta.skill, "devboy-setup");
+        assert_eq!(meta.outcome, Some(Outcome::Success));
+        assert_eq!(meta.tool_calls, 1);
+        assert_eq!(meta.errors, 0);
+    }
+
+    #[test]
+    fn failed_tool_result_is_counted_as_error() {
+        let dir = tempdir().unwrap();
+        let target = TraceTarget::Custom(dir.path().to_path_buf());
+        let tracer = SessionTracer::begin("devboy-test", &target).unwrap();
+        tracer
+            .event(Phase::ToolCall, json!({ "tool": "get_issues" }))
+            .unwrap();
+        tracer
+            .event(
+                Phase::ToolResult,
+                json!({ "tool": "get_issues", "ok": false, "error": "401 Unauthorized" }),
+            )
+            .unwrap();
+        let meta_path = tracer.session_dir().join("meta.json");
+        tracer.end(Outcome::Failure, "401").unwrap();
+
+        let meta: SessionMeta = serde_json::from_slice(&std::fs::read(meta_path).unwrap()).unwrap();
+        assert_eq!(meta.tool_calls, 1);
+        assert_eq!(meta.errors, 1);
+        assert_eq!(meta.outcome, Some(Outcome::Failure));
+    }
+
+    #[test]
+    fn events_are_redacted_before_writing() {
+        let dir = tempdir().unwrap();
+        let target = TraceTarget::Custom(dir.path().to_path_buf());
+        let tracer = SessionTracer::begin("devboy-test", &target).unwrap();
+        let trace_path = tracer.trace_path().to_path_buf();
+        tracer
+            .event(
+                Phase::ToolCall,
+                json!({
+                    "tool": "create_issue",
+                    "args": { "token": "ghp_012345678901234567890123456789012345" }
+                }),
+            )
+            .unwrap();
+        tracer.end(Outcome::Success, "").unwrap();
+
+        let text = std::fs::read_to_string(&trace_path).unwrap();
+        assert!(
+            !text.contains("ghp_0123456789"),
+            "trace contained raw GitHub token: {text}"
+        );
+        assert!(
+            text.contains("<redacted"),
+            "trace did not include redaction marker: {text}"
+        );
+    }
+
+    #[test]
+    fn global_target_respects_home_override() {
+        let home = tempdir().unwrap();
+        let home_path = home.path().to_path_buf();
+        temp_env::with_var("DEVBOY_HOME_OVERRIDE", Some(home.path()), || {
+            let root = TraceTarget::Global.sessions_root().unwrap();
+            assert!(root.starts_with(&home_path));
+        });
+    }
+
+    #[test]
+    fn custom_target_writes_exactly_where_asked() {
+        let dir = tempdir().unwrap();
+        let target = TraceTarget::Custom(dir.path().to_path_buf());
+        let tracer = SessionTracer::begin("x", &target).unwrap();
+        let trace_path = tracer.trace_path().to_path_buf();
+        assert!(trace_path.starts_with(dir.path()));
+        tracer.end(Outcome::Success, "").unwrap();
+    }
+}

--- a/crates/devboy-skills/src/trace/redact.rs
+++ b/crates/devboy-skills/src/trace/redact.rs
@@ -1,0 +1,254 @@
+//! Redaction of sensitive values before traces hit disk.
+//!
+//! Two mechanisms are layered:
+//!
+//! 1. Known credential shapes are masked regardless of where they
+//!    appear in the tree. Currently: `ghp_`, `glpat-`, `pk_live_`,
+//!    `pk_test_`, `sk-`, `xoxb-`/`xoxa-`/`xapp-`, `Bearer `, plus a
+//!    few other common prefixes. These all survive without knowing
+//!    the configured credential set — useful when a token leaks into
+//!    an error message, a git URL, or a user-supplied prompt.
+//! 2. Values of any string-valued environment variable whose name
+//!    matches a sensitive suffix (`*_TOKEN` / `*_SECRET` / `*_KEY` /
+//!    `*_PASSWORD` / `*_PASSPHRASE` / `AUTHORIZATION` / `COOKIE`) are
+//!    masked — the redactor snapshots those at call time.
+//!
+//! Setting the `DEVBOY_TRACE_REDACTION=off` environment variable
+//! disables both passes for local debugging. Never default to off.
+
+use std::collections::HashSet;
+
+use serde_json::Value;
+
+/// Redact sensitive data in `value`. Recursively walks maps and
+/// arrays. Strings are rewritten; numbers / bools / null pass through
+/// unchanged.
+pub fn sanitize(value: Value) -> Value {
+    if redaction_disabled() {
+        return value;
+    }
+    let secrets = known_env_secrets();
+    sanitize_with(&secrets, value)
+}
+
+fn redaction_disabled() -> bool {
+    match std::env::var("DEVBOY_TRACE_REDACTION") {
+        Ok(v) => matches!(v.to_lowercase().as_str(), "off" | "0" | "false" | "no"),
+        Err(_) => false,
+    }
+}
+
+fn sanitize_with(secrets: &HashSet<String>, value: Value) -> Value {
+    match value {
+        Value::String(s) => Value::String(redact_string(secrets, &s)),
+        Value::Array(xs) => {
+            Value::Array(xs.into_iter().map(|x| sanitize_with(secrets, x)).collect())
+        }
+        Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                // If the key itself hints at a secret, redact the whole
+                // value to prevent `{"auth": "Bearer abc"}` style leaks
+                // when the string does not match a known prefix.
+                let key_is_secret_name = key_looks_secret(&k);
+                let new_val = if key_is_secret_name && v.is_string() {
+                    Value::String("<redacted:secret-field>".to_string())
+                } else {
+                    sanitize_with(secrets, v)
+                };
+                out.insert(k, new_val);
+            }
+            Value::Object(out)
+        }
+        other => other,
+    }
+}
+
+fn redact_string(secrets: &HashSet<String>, s: &str) -> String {
+    // 1. Exact env-var match.
+    if !s.is_empty() && secrets.contains(s) {
+        return "<redacted:credential>".to_string();
+    }
+    // 2. Known token prefixes. We search case-sensitively because every
+    //    supported prefix is case-sensitive in practice.
+    if has_known_prefix(s) {
+        return "<redacted:token-pattern>".to_string();
+    }
+    // 3. Bearer / Basic schemes embedded inside a larger string. Don't
+    //    rewrite the whole string — replace only the credential segment.
+    if let Some(rewritten) = mask_auth_header_segment(s) {
+        return rewritten;
+    }
+    s.to_string()
+}
+
+fn has_known_prefix(s: &str) -> bool {
+    const PREFIXES: &[&str] = &[
+        // GitHub PATs
+        "ghp_",
+        "github_pat_",
+        "gho_",
+        "ghu_",
+        "ghs_",
+        "ghr_",
+        // GitLab PATs
+        "glpat-",
+        // Stripe-ish shapes, also matches ClickUp `pk_`
+        "pk_live_",
+        "pk_test_",
+        "sk_live_",
+        "sk_test_",
+        // OpenAI-ish
+        "sk-",
+        // Slack
+        "xoxb-",
+        "xoxa-",
+        "xoxp-",
+        "xapp-",
+        // Anthropic
+        "sk-ant-",
+        // Generic bearer markers users sometimes paste as a raw value.
+        "Bearer ",
+        "Basic ",
+    ];
+    PREFIXES
+        .iter()
+        .any(|p| s.starts_with(p) && s.len() > p.len() + 8)
+}
+
+fn mask_auth_header_segment(s: &str) -> Option<String> {
+    // e.g. "Authorization: Bearer ghp_…" embedded inside a log line.
+    let needles = ["Bearer ", "Basic "];
+    for needle in needles {
+        if let Some(idx) = s.find(needle) {
+            let head = &s[..idx];
+            // Credential runs until whitespace, comma, or semicolon.
+            let rest = &s[idx + needle.len()..];
+            let end = rest
+                .find(|c: char| c.is_whitespace() || c == ',' || c == ';')
+                .unwrap_or(rest.len());
+            if end >= 8 {
+                let tail = &rest[end..];
+                return Some(format!("{head}{needle}<redacted:auth>{tail}"));
+            }
+        }
+    }
+    None
+}
+
+fn key_looks_secret(key: &str) -> bool {
+    let upper = key.to_ascii_uppercase();
+    const SUFFIXES: &[&str] = &[
+        "_TOKEN",
+        "_SECRET",
+        "_KEY",
+        "_PASSWORD",
+        "_PASSPHRASE",
+        "_AUTH",
+    ];
+    const EXACT: &[&str] = &["AUTHORIZATION", "COOKIE", "TOKEN", "SECRET", "PASSWORD"];
+    if EXACT.contains(&upper.as_str()) {
+        return true;
+    }
+    if SUFFIXES.iter().any(|suf| upper.ends_with(suf)) {
+        return true;
+    }
+    // Common devboy conventions.
+    if key.contains("password") || key.contains("secret") || key.contains("token") {
+        return true;
+    }
+    false
+}
+
+fn known_env_secrets() -> HashSet<String> {
+    let mut out = HashSet::new();
+    for (name, value) in std::env::vars() {
+        if value.is_empty() {
+            continue;
+        }
+        if key_looks_secret(&name) {
+            out.insert(value);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn masks_github_pat() {
+        let v = json!({ "args": { "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } });
+        let out = sanitize(v);
+        let s = serde_json::to_string(&out).unwrap();
+        assert!(!s.contains("ghp_aaaaaaaa"));
+        assert!(s.contains("<redacted"));
+    }
+
+    #[test]
+    fn masks_bearer_scheme_in_header_string() {
+        let v = json!("Authorization: Bearer xxxxxxxxxxxxyyyyyyyyyyyy");
+        let out = sanitize(v);
+        let s = out.as_str().unwrap();
+        assert!(!s.contains("xxxxxxxxxxxxyyyyyyyyyyyy"), "got: {s}");
+        assert!(s.contains("<redacted"), "got: {s}");
+    }
+
+    #[test]
+    fn masks_by_key_name_even_when_value_looks_harmless() {
+        // A value that does not match any known prefix but lives under
+        // a key called `password` must still be redacted.
+        let v = json!({ "password": "not-a-prefix" });
+        let out = sanitize(v);
+        assert_eq!(
+            out.get("password").and_then(|v| v.as_str()),
+            Some("<redacted:secret-field>")
+        );
+    }
+
+    #[test]
+    fn env_var_values_are_redacted_when_they_match_exactly() {
+        temp_env::with_var(
+            "DEVBOY_TEST_TOKEN",
+            Some("super-secret-value-nothing-matches"),
+            || {
+                let v = json!({ "note": "leaked: super-secret-value-nothing-matches" });
+                let out = sanitize(v);
+                // The exact-match secret replacement only fires when the
+                // value IS the secret — not when it's embedded in a
+                // larger string. Embedded leakage is the DLP case we do
+                // not attempt to solve (see the doc comment). Assert the
+                // exact-value case instead.
+                let note = out.get("note").and_then(|v| v.as_str()).unwrap();
+                assert_eq!(note, "leaked: super-secret-value-nothing-matches");
+
+                let v = json!({ "raw": "super-secret-value-nothing-matches" });
+                let out = sanitize(v);
+                assert_eq!(
+                    out.get("raw").and_then(|v| v.as_str()),
+                    Some("<redacted:credential>")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn short_strings_are_not_redacted_by_prefix_check() {
+        // `ghp_` alone must not be redacted — only long PAT-shaped
+        // strings are. This matters for documentation and for the
+        // redaction marker itself.
+        let v = json!("ghp_");
+        assert_eq!(sanitize(v).as_str(), Some("ghp_"));
+    }
+
+    #[test]
+    fn redaction_can_be_disabled_via_env() {
+        temp_env::with_var("DEVBOY_TRACE_REDACTION", Some("off"), || {
+            let v = json!({ "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
+            let out = sanitize(v.clone());
+            assert_eq!(out, v);
+        });
+    }
+}

--- a/crates/devboy-skills/src/trace/redact.rs
+++ b/crates/devboy-skills/src/trace/redact.rs
@@ -3,11 +3,12 @@
 //! Two mechanisms are layered:
 //!
 //! 1. Known credential shapes are masked regardless of where they
-//!    appear in the tree. Currently: `ghp_`, `glpat-`, `pk_live_`,
-//!    `pk_test_`, `sk-`, `xoxb-`/`xoxa-`/`xapp-`, `Bearer `, plus a
-//!    few other common prefixes. These all survive without knowing
-//!    the configured credential set — useful when a token leaks into
-//!    an error message, a git URL, or a user-supplied prompt.
+//!    appear in the tree. Currently: `ghp_`, `glpat-`, `pk_`, `sk-`,
+//!    `xoxb-` / `xoxa-` / `xapp-`, `Bearer ` / `Basic ` (case-
+//!    insensitive), plus a few other common prefixes. These all
+//!    survive without knowing the configured credential set — useful
+//!    when a token leaks into an error message, a git URL, or a
+//!    user-supplied prompt.
 //! 2. Values of any string-valued environment variable whose name
 //!    matches a sensitive suffix (`*_TOKEN` / `*_SECRET` / `*_KEY` /
 //!    `*_PASSWORD` / `*_PASSPHRASE` / `AUTHORIZATION` / `COOKIE`) are
@@ -15,6 +16,15 @@
 //!
 //! Setting the `DEVBOY_TRACE_REDACTION=off` environment variable
 //! disables both passes for local debugging. Never default to off.
+//!
+//! ## Amortizing the env snapshot
+//!
+//! The top-level [`sanitize`] helper walks `std::env::vars()` on every
+//! call — fine for one-shot CLI invocations but wasteful inside a
+//! long-running producer like [`super::SessionTracer`] that writes
+//! many events. Build a [`Redactor`] once with
+//! [`Redactor::snapshot`] and reuse it for every event in the same
+//! session to pay the env scan just once.
 
 use std::collections::HashSet;
 
@@ -23,12 +33,49 @@ use serde_json::Value;
 /// Redact sensitive data in `value`. Recursively walks maps and
 /// arrays. Strings are rewritten; numbers / bools / null pass through
 /// unchanged.
+///
+/// Each call snapshots `*_TOKEN` / `*_SECRET` / … env vars afresh so
+/// that tests using `temp_env::with_var` (and production callers that
+/// legitimately mutate the environment) see up-to-date state. Inside
+/// a long session, prefer [`Redactor::snapshot`] + [`Redactor::sanitize`].
 pub fn sanitize(value: Value) -> Value {
-    if redaction_disabled() {
-        return value;
+    Redactor::snapshot().sanitize(value)
+}
+
+/// A reusable redactor that holds one env-var snapshot. Created via
+/// [`Redactor::snapshot`]; use once per long-running producer (e.g.
+/// one per `SessionTracer`) to avoid rescanning the environment on
+/// every event.
+#[derive(Debug, Clone)]
+pub struct Redactor {
+    enabled: bool,
+    secrets: HashSet<String>,
+}
+
+impl Redactor {
+    /// Capture the current set of sensitive env-var values and the
+    /// `DEVBOY_TRACE_REDACTION=off` opt-out state. Cheap to clone.
+    pub fn snapshot() -> Self {
+        if redaction_disabled() {
+            Self {
+                enabled: false,
+                secrets: HashSet::new(),
+            }
+        } else {
+            Self {
+                enabled: true,
+                secrets: known_env_secrets(),
+            }
+        }
     }
-    let secrets = known_env_secrets();
-    sanitize_with(&secrets, value)
+
+    /// Sanitize a single value using the captured env-var snapshot.
+    pub fn sanitize(&self, value: Value) -> Value {
+        if !self.enabled {
+            return value;
+        }
+        sanitize_with(&self.secrets, value)
+    }
 }
 
 fn redaction_disabled() -> bool {
@@ -84,7 +131,11 @@ fn redact_string(secrets: &HashSet<String>, s: &str) -> String {
 }
 
 fn has_known_prefix(s: &str) -> bool {
-    const PREFIXES: &[&str] = &[
+    // Case-sensitive prefixes. The publisher-defined provider tokens
+    // are all case-sensitive in the wild, so matching them strictly
+    // avoids redacting words that merely share the letters (e.g. an
+    // English sentence starting with "Ghp").
+    const CASE_SENSITIVE: &[&str] = &[
         // GitHub PATs
         "ghp_",
         "github_pat_",
@@ -94,35 +145,46 @@ fn has_known_prefix(s: &str) -> bool {
         "ghr_",
         // GitLab PATs
         "glpat-",
-        // Stripe-ish shapes, also matches ClickUp `pk_`
-        "pk_live_",
-        "pk_test_",
-        "sk_live_",
-        "sk_test_",
-        // OpenAI-ish
+        // Publishable / secret key families shared across a few
+        // providers (Stripe, ClickUp, etc.). ADR-015 spec calls these
+        // out as a single `pk_` / `sk_` group — keep them generic.
+        "pk_",
+        "sk_",
+        // OpenAI-ish (also covers sk-ant-… via the `sk-` prefix).
         "sk-",
         // Slack
         "xoxb-",
         "xoxa-",
         "xoxp-",
         "xapp-",
-        // Anthropic
-        "sk-ant-",
-        // Generic bearer markers users sometimes paste as a raw value.
-        "Bearer ",
-        "Basic ",
     ];
-    PREFIXES
+    if CASE_SENSITIVE
         .iter()
         .any(|p| s.starts_with(p) && s.len() > p.len() + 8)
+    {
+        return true;
+    }
+    // Case-insensitive auth-scheme prefixes: HTTP scheme tokens are
+    // case-insensitive per RFC 7235, so `Bearer <tok>`, `bearer <tok>`
+    // and `BEARER <tok>` should all redact.
+    const SCHEME_CI: &[&str] = &["bearer ", "basic "];
+    let lower = s.to_ascii_lowercase();
+    SCHEME_CI
+        .iter()
+        .any(|p| lower.starts_with(p) && s.len() > p.len() + 8)
 }
 
 fn mask_auth_header_segment(s: &str) -> Option<String> {
     // e.g. "Authorization: Bearer ghp_…" embedded inside a log line.
-    let needles = ["Bearer ", "Basic "];
+    // HTTP auth schemes are case-insensitive (RFC 7235), so locate the
+    // needle in the lowercased copy but preserve the original casing
+    // of the scheme token in the rewritten output.
+    let lower = s.to_ascii_lowercase();
+    let needles = ["bearer ", "basic "];
     for needle in needles {
-        if let Some(idx) = s.find(needle) {
+        if let Some(idx) = lower.find(needle) {
             let head = &s[..idx];
+            let scheme = &s[idx..idx + needle.len()]; // original case preserved
             // Credential runs until whitespace, comma, or semicolon.
             let rest = &s[idx + needle.len()..];
             let end = rest
@@ -130,7 +192,7 @@ fn mask_auth_header_segment(s: &str) -> Option<String> {
                 .unwrap_or(rest.len());
             if end >= 8 {
                 let tail = &rest[end..];
-                return Some(format!("{head}{needle}<redacted:auth>{tail}"));
+                return Some(format!("{head}{scheme}<redacted:auth>{tail}"));
             }
         }
     }
@@ -253,6 +315,92 @@ mod tests {
             let v = json!({ "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
             let out = sanitize(v.clone());
             assert_eq!(out, v);
+        });
+    }
+
+    #[test]
+    fn masks_bearer_scheme_case_insensitive() {
+        // HTTP schemes are case-insensitive per RFC 7235, so all of
+        // these variants must redact.
+        for header in [
+            "Authorization: Bearer xxxxxxxxxxxxyyyyyyyyyyyy",
+            "authorization: bearer xxxxxxxxxxxxyyyyyyyyyyyy",
+            "AUTHORIZATION: BEARER xxxxxxxxxxxxyyyyyyyyyyyy",
+            "authorization: BeArEr xxxxxxxxxxxxyyyyyyyyyyyy",
+        ] {
+            let out = sanitize(json!(header));
+            let s = out.as_str().unwrap();
+            assert!(
+                !s.contains("xxxxxxxxxxxxyyyyyyyyyyyy"),
+                "token leaked for header `{header}` → `{s}`"
+            );
+            assert!(
+                s.contains("<redacted"),
+                "no redaction marker for header `{header}` → `{s}`"
+            );
+        }
+    }
+
+    #[test]
+    fn masks_bare_bearer_value_case_insensitive() {
+        // When the caller pasted just the `Bearer <token>` segment as
+        // a standalone value, the prefix check (not the header scanner)
+        // fires — must also be case-insensitive.
+        for raw in [
+            "Bearer abcdefghijklmnopqrstuvwx",
+            "bearer abcdefghijklmnopqrstuvwx",
+            "BEARER abcdefghijklmnopqrstuvwx",
+            "Basic YWxpY2U6aHVudGVyMjpkcmFnb24=",
+        ] {
+            let out = sanitize(json!(raw));
+            let s = out.as_str().unwrap();
+            assert!(s.contains("<redacted"), "not redacted: `{raw}` → `{s}`");
+        }
+    }
+
+    #[test]
+    fn masks_generic_pk_prefix() {
+        // ADR-015 calls out a generic `pk_` prefix (not just
+        // `pk_live_` / `pk_test_`). Enough bytes after the prefix to
+        // clear the length guard so a bare `pk_` literal is left alone.
+        let v = json!({ "clickup_pk": "pk_abcdefghijklmnop" });
+        let out = sanitize(v);
+        assert_eq!(
+            out.get("clickup_pk").and_then(|v| v.as_str()),
+            Some("<redacted:token-pattern>"),
+            "generic pk_ prefix should redact"
+        );
+
+        // Short `pk_` literal stays untouched (e.g. in docs).
+        let doc = json!("pk_");
+        assert_eq!(sanitize(doc).as_str(), Some("pk_"));
+    }
+
+    #[test]
+    fn redactor_snapshot_amortizes_env_scan() {
+        // The Redactor captures the env-var set at snapshot time and
+        // keeps redacting the snapshotted value even after the source
+        // env var has been unset — this is what makes reuse inside a
+        // long session cheap and consistent.
+        let redactor = temp_env::with_var(
+            "DEVBOY_REDACTOR_CACHE_TOKEN",
+            Some("cached-token-zzzzzzzz"),
+            Redactor::snapshot,
+        );
+        // The env var is gone at this point, but the snapshot remembers.
+        let out = redactor.sanitize(json!({ "raw": "cached-token-zzzzzzzz" }));
+        assert_eq!(
+            out.get("raw").and_then(|v| v.as_str()),
+            Some("<redacted:credential>")
+        );
+    }
+
+    #[test]
+    fn redactor_snapshot_respects_disable_env() {
+        temp_env::with_var("DEVBOY_TRACE_REDACTION", Some("off"), || {
+            let redactor = Redactor::snapshot();
+            let v = json!({ "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
+            assert_eq!(redactor.sanitize(v.clone()), v);
         });
     }
 }

--- a/crates/devboy-skills/src/trace/redact.rs
+++ b/crates/devboy-skills/src/trace/redact.rs
@@ -48,10 +48,11 @@ fn sanitize_with(secrets: &HashSet<String>, value: Value) -> Value {
             let mut out = serde_json::Map::with_capacity(map.len());
             for (k, v) in map {
                 // If the key itself hints at a secret, redact the whole
-                // value to prevent `{"auth": "Bearer abc"}` style leaks
-                // when the string does not match a known prefix.
-                let key_is_secret_name = key_looks_secret(&k);
-                let new_val = if key_is_secret_name && v.is_string() {
+                // value regardless of its type. This prevents structured
+                // leaks like `{"authorization": {"scheme": "Bearer",
+                // "value": "…"}}` where nested field names may not
+                // themselves trip the secret-key heuristic.
+                let new_val = if key_looks_secret(&k) {
                     Value::String("<redacted:secret-field>".to_string())
                 } else {
                     sanitize_with(secrets, v)
@@ -154,7 +155,10 @@ fn key_looks_secret(key: &str) -> bool {
         return true;
     }
     // Common devboy conventions.
-    if key.contains("password") || key.contains("secret") || key.contains("token") {
+    // Use the upper-cased copy for the substring heuristic too, so
+    // mixed-case keys like `Password` / `Token` / `Secret` are caught
+    // consistently with the EXACT / SUFFIX branches above.
+    if upper.contains("PASSWORD") || upper.contains("SECRET") || upper.contains("TOKEN") {
         return true;
     }
     false


### PR DESCRIPTION
Part of #156. Stacked on #167 (infra).

Introduces the on-disk session-trace format from ADR-015 that the category-3 self-feedback skills need. Opens the path to the final skill category and the self-feedback loop as a whole.

## New module `devboy-skills::trace`

- **TraceTarget** — repo-local default (`<repo>/.devboy/sessions/`), `--global` → `~/.devboy/sessions/`, `Custom(dir)` for tests. Honours `DEVBOY_HOME_OVERRIDE` for cross-platform testability (Windows CI).
- **SessionTracer** — long-lived writer; tracks tool-call / error counts; writes `meta.json` on end.
- **Stateless helpers** (`create_session` / `append_event` / `finalise_session`) — each CLI invocation opens, appends one line, closes. That's what the `devboy trace` CLI shims below use.
- **Phase enum** (start / decision / tool_call / tool_result / verify / artifact / note / end). Readers ignore unknown phases.
- **Outcome enum** (success / failure / aborted).
- **Redactor** — three layers: known prefixes (`ghp_`, `glpat-`, `pk_live_`, `sk-`, `xoxb-`, `Bearer …`, …), env-var exact-value match, and key-name heuristics (`*_TOKEN` / `*_SECRET` / `*_KEY` / `*_PASSWORD` / `_AUTH` / `authorization`). `DEVBOY_TRACE_REDACTION=off` turns it off for debugging. Never defaults to off.
- ULID session ids via the `trace` Cargo feature (on by default).

## New CLI family `devboy trace`

```
devboy trace begin --skill <name> [--global | --dir <path>]
  → prints {"session_id": …, "session_dir": …, "trace_path": …}

devboy trace event --session-dir <p> --session-id <id> --skill <n> --phase <phase> [--payload <json>]

devboy trace end --session-dir <p> --session-id <id> --skill <n> --outcome <success|failure|aborted> [--summary <text>]
```

## Tests

- **39 unit tests** in `devboy-skills` (28 prior + 11 new for trace + redact) — session round-trip, failed-tool counter, redaction of GitHub PATs / Bearer schemes / key-name heuristics, env-var exact matches, `DEVBOY_TRACE_REDACTION=off` opt-out, home-override.
- **12 integration tests** in `devboy-cli` (10 prior + 2 new) — `trace begin → event → end` round-trip via the shipped binary, and a redaction test that confirms tokens never reach disk even through the CLI shim.

## Test plan

- [x] `cargo test -p devboy-skills` — 39/39 pass
- [x] `cargo test -p devboy-cli --test skills_test` — 12/12 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Unblocks

PR-J (category-3 skills: `devboy-run-and-verify`, `devboy-daily-report`, `devboy-retro`, `devboy-knowledge-extract`) will be stacked on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)