### PR TITLE
feat(skills): category 3 — self feedback loop (4 skills, #174)

### DIFF
--- a/skills/03-self-feedback/devboy-daily-report/SKILL.md
+++ b/skills/03-self-feedback/devboy-daily-report/SKILL.md
@@ -53,25 +53,35 @@ SESSION_ID=$(echo "$result" | jq -r .session_id)
 This skill is itself traceable — retro runs will see that a daily
 report ran, how long it took, and whether it succeeded.
 
-### 3. Walk the per-skill subdirectories
+### 3. Walk the per-session subdirectories
 
-For each `<skill>/` directory under the day:
+Each session lives under `<YYYY-MM-DD>/<skill>/<session_id>/`, so a
+skill that ran four times today produces four `session_id/` folders
+under that day's `<skill>/` directory. For every
+`<skill>/<session_id>/` directory under the day:
 
-1. If `meta.json` is missing, skip the directory — the session is
-   still in flight. Record a single `note` event listing the skipped
+1. Inspect session completion state instead of using the presence of
+   `meta.json` as the signal. `devboy trace begin` writes a skeletal
+   `meta.json` up front, so an in-flight session still has the file.
+   Read `meta.json` if it exists; if `ended_at` and `outcome` are not
+   yet set, treat the session as still in flight. If `meta.json` is
+   missing or does not parse, fall back to `trace.jsonl` and treat
+   the session as still in flight when no terminal `end` event is
+   present. Record a single `note` event listing the skipped
    sessions so they show up in the report as "in progress".
-2. Otherwise, read `meta.json` and pull:
+2. For completed sessions, read `meta.json` and pull:
    - `skill`, `outcome`, `tool_calls`, `errors`,
    - `summary`, `started_at`, `ended_at`.
-3. Aggregate per-skill counts: total runs, success / failure /
-   aborted, total tool-calls, total errors, average duration.
+3. Aggregate per-skill counts only from completed sessions: total
+   runs, success / failure / aborted, total tool-calls, total
+   errors, average duration.
 
-Emit an `artifact` event per skill directory so the retro skill can
-later find the raw data:
+Emit an `artifact` event per session directory so the retro skill
+can later find the raw data:
 
 ```bash
 devboy trace event ... --phase artifact \
-  --payload "$(jq -nc --arg path "$SKILL_DIR" '{path:$path,kind:"session-dir"}')"
+  --payload "$(jq -nc --arg path "$SESSION_PATH" '{path:$path,kind:"session-dir"}')"
 ```
 
 ### 4. Cross-reference with the provider
@@ -135,8 +145,9 @@ Print the assembled Markdown to stdout and exit.
 
 - The report lists one line per skill that ran today, with accurate
   counts drawn from `meta.json`.
-- In-flight sessions (no `meta.json`) are listed under "in progress"
-  rather than silently dropped.
+- In-flight sessions (those with `ended_at` / `outcome` unset in
+  `meta.json`, or without a terminal `end` event in `trace.jsonl`)
+  are listed under "in progress" rather than silently dropped.
 - MRs and issues with a date-stamp outside the target day are not
   shown.
 - The skill never mutates anything — no comments posted, no issues

--- a/skills/03-self-feedback/devboy-daily-report/SKILL.md
+++ b/skills/03-self-feedback/devboy-daily-report/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: devboy-daily-report
+description: Summarise today's trace activity, merged MRs, and closed issues into a single report.
+category: self-feedback
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "daily report"
+  - "what did I do today"
+  - "summarise today"
+tools:
+  - trace
+  - get_merge_requests
+  - get_issues
+---
+
+# devboy-daily-report
+
+Reads today's session traces and cross-references them with the git
+provider's recent activity to produce a short Markdown report. The
+output goes to stdout — nothing is posted anywhere. Users who want the
+report delivered to a chat pipe it into `devboy-notify` (category 5).
+
+## When to use
+
+- At the end of a working day, to answer "what did I actually do
+  today?".
+- Before a standup, to compile a from-the-trace view of yesterday's
+  activity (run with `--date 2026-04-16`).
+- Any time an auditor wants a reproducible summary of session outcomes
+  against real git-provider events.
+
+## Procedure
+
+### 1. Resolve the sessions directory for the day
+
+Pick the date (default: today in the local timezone) and the scope:
+
+- Repo-local (default): `<repo>/.devboy/sessions/<YYYY-MM-DD>/`.
+- Global (`--global`): `~/.devboy/sessions/<YYYY-MM-DD>/`.
+
+If neither directory exists, exit with an error that tells the user
+which path was checked.
+
+### 2. Begin a trace for this report
+
+```bash
+result=$(devboy trace begin --skill devboy-daily-report)
+SESSION_DIR=$(echo "$result" | jq -r .session_dir)
+SESSION_ID=$(echo "$result" | jq -r .session_id)
+```
+
+This skill is itself traceable — retro runs will see that a daily
+report ran, how long it took, and whether it succeeded.
+
+### 3. Walk the per-skill subdirectories
+
+For each `<skill>/` directory under the day:
+
+1. If `meta.json` is missing, skip the directory — the session is
+   still in flight. Record a single `note` event listing the skipped
+   sessions so they show up in the report as "in progress".
+2. Otherwise, read `meta.json` and pull:
+   - `skill`, `outcome`, `tool_calls`, `errors`,
+   - `summary`, `started_at`, `ended_at`.
+3. Aggregate per-skill counts: total runs, success / failure /
+   aborted, total tool-calls, total errors, average duration.
+
+Emit an `artifact` event per skill directory so the retro skill can
+later find the raw data:
+
+```bash
+devboy trace event ... --phase artifact \
+  --payload "$(jq -nc --arg path "$SKILL_DIR" '{path:$path,kind:"session-dir"}')"
+```
+
+### 4. Cross-reference with the provider
+
+Two tool calls, each wrapped in a `tool_call` / `tool_result` pair:
+
+```bash
+devboy tools call get_merge_requests \
+  '{"state":"merged","limit":50}'
+devboy tools call get_issues \
+  '{"state":"closed","limit":50}'
+```
+
+Filter the returned lists down to items whose merge / close timestamp
+falls on the report's date. Neither `get_merge_requests` nor
+`get_issues` has a first-class `since` parameter in the current
+schema — do the date filter in the skill, not on the provider side.
+
+Record `ok:false` on the `tool_result` if the call fails, but keep
+going; a daily report is useful even if the tracker is offline.
+
+### 5. Assemble the Markdown report
+
+Structure:
+
+```markdown
+# Daily report — <YYYY-MM-DD>
+
+## Sessions
+- devboy-run-and-verify — 8 runs (7 success, 1 failure, avg 4.2s)
+- devboy-solve-issue — 2 runs (2 success, avg 2m31s)
+...
+
+## Merged MRs
+- mr#482 — "fix(auth): refresh token rotation"
+- mr#485 — "refactor(api): split user service"
+
+## Closed issues
+- DEV-411 — "Cannot invite user with plus-sign email"
+
+## Notable failures
+- devboy-run-and-verify 14:02 — "cargo test" failed on integration::auth
+```
+
+Skip any section that has no entries. Keep the report short — a
+hundred lines at most.
+
+### 6. End the trace
+
+```bash
+devboy trace end \
+  --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill devboy-daily-report \
+  --outcome "$OUTCOME" \
+  --summary "<N> sessions, <M> MRs merged, <K> issues closed"
+```
+
+Print the assembled Markdown to stdout and exit.
+
+## Success criteria
+
+- The report lists one line per skill that ran today, with accurate
+  counts drawn from `meta.json`.
+- In-flight sessions (no `meta.json`) are listed under "in progress"
+  rather than silently dropped.
+- MRs and issues with a date-stamp outside the target day are not
+  shown.
+- The skill never mutates anything — no comments posted, no issues
+  touched.
+
+## Guardrails
+
+- Redacted trace payloads stay opaque. If a trace line contains
+  `<redacted:...>`, carry it into the report verbatim; do not try to
+  reconstruct the original value.
+- If both the repo-local and `--global` trace directories are absent,
+  exit with a non-zero status rather than producing an empty report.
+
+## Non-goals
+
+- This skill does not post the report. Use `devboy-notify` from
+  category 5 if delivery is needed.
+- It does not create issues, update tickets, or touch git in any way.
+- It does not analyse long-term trends — that is `devboy-retro`.

--- a/skills/03-self-feedback/devboy-knowledge-extract/SKILL.md
+++ b/skills/03-self-feedback/devboy-knowledge-extract/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: devboy-knowledge-extract
+description: Extract the lesson from a session that failed, then succeeded, and propose where to codify it.
+category: self-feedback
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "extract the lesson"
+  - "what did we learn"
+  - "codify this fix"
+tools:
+  - trace
+---
+
+# devboy-knowledge-extract
+
+Inspects a single session trace that went from a failure streak to a
+clean success, pulls out what changed between "not working" and
+"working", and proposes where the lesson belongs — a SKILL.md edit, an
+`AGENTS.md` / `CLAUDE.md` bullet, or a ticket. **The skill is
+read-only.** It prints a proposal to stdout; the user decides whether
+to act on it.
+
+## When to use
+
+- Right after a painful debug that eventually passed — the shape of
+  what worked is still fresh, but will fade within a day.
+- On a session that `devboy-daily-report` flagged as "recovered after
+  multiple failures".
+- When reviewing a teammate's trace to understand how they unblocked
+  themselves.
+
+## Procedure
+
+### 1. Locate the session
+
+Accept one of:
+
+- `--session-dir <path>` — absolute or relative path to a
+  `.devboy/sessions/<YYYY-MM-DD>/<skill>/` directory. If the directory
+  contains `meta.json` and `trace.jsonl`, use it directly.
+- `--pick` — interactive mode: list today's sessions where `outcome
+  = success` but `errors > 0` and let the user pick one. This is the
+  common follow-up after `devboy-daily-report`.
+
+Exit with a clear error if neither flag is set or the directory is
+not a well-formed session.
+
+### 2. Begin the meta-trace
+
+The extract itself is traced — retros care about how often the team
+reaches for this skill.
+
+```bash
+result=$(devboy trace begin --skill devboy-knowledge-extract)
+SESSION_DIR=$(echo "$result" | jq -r .session_dir)
+SESSION_ID=$(echo "$result" | jq -r .session_id)
+```
+
+Record a `decision` event naming the target session dir.
+
+### 3. Parse the target trace
+
+Read `trace.jsonl` line by line. Lines that fail to deserialise as
+JSON are skipped with a single `note` event — do not abort. For each
+valid record keep: `ts`, `phase`, `payload`.
+
+Compute three spans:
+
+- **Failure streak.** A contiguous run of events where either
+  `tool_result.ok = false` or `verify.ok = false` — possibly
+  interleaved with `note`, `decision`, or further `tool_call` events
+  that target the same tool or check.
+- **Flip point.** The first event after the streak where
+  `tool_result.ok = true` or `verify.ok = true` on the same tool or
+  check as the streak.
+- **Setup delta.** The `decision` and `note` events that appear
+  between the last failing event and the flip point — those record
+  what the agent or user tried differently.
+
+If the trace has no failure streak (only clean successes), print a
+short message saying there is nothing to extract and end the meta-
+trace with `outcome: aborted`.
+
+### 4. Draft the lesson
+
+One short paragraph, plain English. Template:
+
+> After failing `<tool-or-check>` `<N>` times with `<common-error>`,
+> switching to `<approach-described-in-setup-delta>` fixed it
+> because `<why, if the decision/note events state it>`.
+
+If the trace does not justify the "because" clause, leave it out
+rather than making something up.
+
+### 5. Suggest where to codify the lesson
+
+Classify the fix and propose exactly one home:
+
+- **Tool invocation pattern** (e.g. "call `get_pipeline` with
+  `includeFailedLogs: false` when the MR is large") — propose a
+  SKILL.md edit on the skill that owns the call. Name the file
+  (`skills/<category>/<skill>/SKILL.md`) and quote the exact
+  sentence to add.
+- **Project convention** (e.g. "this repo requires migrations in
+  snake_case") — propose a bullet for `CLAUDE.md`, `AGENTS.md`, or
+  the project's own guide, quoting the sentence.
+- **Systemic infra bug** (e.g. "CI cache corrupts itself on
+  concurrent merges") — propose a ticket via
+  `devboy-create-issue`, including a draft title and two-sentence
+  reproduction, but do not create it.
+
+Only one home per lesson. If the fix really belongs in two places,
+split the extraction into two successive invocations.
+
+### 6. Emit the proposal
+
+Print to stdout:
+
+```markdown
+# Lesson extracted from <session-dir>
+
+## What happened
+<one paragraph>
+
+## Lesson
+<one paragraph>
+
+## Proposed codification
+Target: skills/02-code-review/devboy-review-mr/SKILL.md
+Edit:
+> Add the following to the "Procedure" section, after step 3:
+> "When the MR touches more than 50 files, pass
+>  includeFailedLogs: false to get_pipeline — otherwise the response
+>  overflows the context window."
+```
+
+Do **not** apply the edit. Do **not** open the file. Do **not** create
+the ticket.
+
+### 7. End the meta-trace
+
+```bash
+devboy trace end \
+  --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill devboy-knowledge-extract \
+  --outcome "$OUTCOME" \
+  --summary "lesson proposal for <original-skill>"
+```
+
+## Success criteria
+
+- Every proposal cites a specific file path or a concrete ticket
+  target — no "maybe add a note somewhere".
+- The "What happened" paragraph points at real `tool_call` /
+  `tool_result` / `verify` events with timestamps from the trace.
+- Running the skill twice on the same session produces the same
+  proposal.
+
+## Guardrails
+
+- **Read-only.** The skill never writes into another skill's
+  `SKILL.md`, never opens a PR, never calls `create_issue` or
+  `add_issue_comment`. Proposals are text on stdout.
+- Redacted trace fields are opaque. If the failure streak's error
+  message was redacted, quote it verbatim (`<redacted:token-pattern>
+  in response body`). Do not guess at the underlying value.
+- If the trace is malformed or the session has no failure-to-success
+  transition, say so and end with `outcome: aborted`.
+
+## Non-goals
+
+- Does not build a knowledge base or index of past lessons.
+- Does not rank lessons by importance.
+- Does not replace a human reviewer — the user still decides whether
+  the proposed edit is worth making.

--- a/skills/03-self-feedback/devboy-knowledge-extract/SKILL.md
+++ b/skills/03-self-feedback/devboy-knowledge-extract/SKILL.md
@@ -37,11 +37,14 @@ to act on it.
 Accept one of:
 
 - `--session-dir <path>` — absolute or relative path to a
-  `.devboy/sessions/<YYYY-MM-DD>/<skill>/` directory. If the directory
-  contains `meta.json` and `trace.jsonl`, use it directly.
-- `--pick` — interactive mode: list today's sessions where `outcome
-  = success` but `errors > 0` and let the user pick one. This is the
-  common follow-up after `devboy-daily-report`.
+  `.devboy/sessions/<YYYY-MM-DD>/<skill>/<session_id>/` directory. If
+  the directory contains `meta.json` and `trace.jsonl`, use it
+  directly.
+- `--pick` — interactive mode: enumerate today's per-session
+  directories (`.devboy/sessions/<YYYY-MM-DD>/<skill>/<session_id>/`)
+  whose `meta.json` reports `outcome = success` and `errors > 0`,
+  and let the user pick one. This is the common follow-up after
+  `devboy-daily-report`.
 
 Exit with a clear error if neither flag is set or the directory is
 not a well-formed session.
@@ -107,8 +110,8 @@ Classify the fix and propose exactly one home:
   the project's own guide, quoting the sentence.
 - **Systemic infra bug** (e.g. "CI cache corrupts itself on
   concurrent merges") — propose a ticket via
-  `devboy-create-issue`, including a draft title and two-sentence
-  reproduction, but do not create it.
+  `devboy tools call create_issue` (draft only), including a draft
+  title and two-sentence reproduction, but do not create it.
 
 Only one home per lesson. If the fix really belongs in two places,
 split the extraction into two successive invocations.

--- a/skills/03-self-feedback/devboy-retro/SKILL.md
+++ b/skills/03-self-feedback/devboy-retro/SKILL.md
@@ -14,6 +14,7 @@ tools:
   - get_merge_request_discussions
   - get_pipeline
   - get_job_logs
+  - get_issues
 ---
 
 # devboy-retro
@@ -56,10 +57,16 @@ Emit a `decision` event recording the window and the scope.
 
 ### 3. Aggregate per-skill session stats
 
-Walk every `<date>/<skill>/meta.json` in the window. Per skill,
-collect: total runs, success / failure / aborted counts, total
-`tool_calls`, total `errors`, total duration, average duration, and
-the most common `summary` strings for failing runs.
+Walk every `<date>/<skill>/<session_id>/meta.json` in the window —
+each session lives in its own subdirectory, so a skill that ran four
+times on one day produces four `meta.json` files under that day's
+`<skill>/` folder. Per skill, aggregate across every completed
+session in the window: total runs, success / failure / aborted
+counts, total `tool_calls`, total `errors`, total duration, average
+duration per run, and the most common `summary` strings for failing
+runs. Skip any session whose `meta.json` has not yet recorded
+`ended_at` / `outcome` — that run is still in flight and should not
+skew the numbers.
 
 Additionally, read each failing session's `trace.jsonl` to find
 retry loops — sequences of `verify` events with `ok: false` followed
@@ -72,14 +79,16 @@ future retros have a stable trail.
 
 ### 4. Cross-reference CI history
 
-For every merged MR in the window:
+Pull the recent merged MRs with a single list call, then iterate the
+filtered result client-side — `get_merge_requests` returns a list, not
+one MR at a time:
 
 ```bash
 devboy tools call get_merge_requests '{"state":"merged","limit":100}'
 ```
 
-Filter the result to merge timestamps inside the window, then for the
-first ~20 call:
+Filter the returned list to merge timestamps inside the window, then
+for the first ~20 entries call `get_pipeline` per MR:
 
 ```bash
 devboy tools call get_pipeline \

--- a/skills/03-self-feedback/devboy-retro/SKILL.md
+++ b/skills/03-self-feedback/devboy-retro/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: devboy-retro
+description: Aggregate the last N days of traces, MRs, and CI runs to surface patterns worth fixing.
+category: self-feedback
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "weekly retro"
+  - "what patterns are there"
+  - "where should I improve"
+tools:
+  - trace
+  - get_merge_requests
+  - get_merge_request_discussions
+  - get_pipeline
+  - get_job_logs
+---
+
+# devboy-retro
+
+Looks back over the last N days of session traces, recent merge
+requests, and CI pipelines to surface recurring patterns: skills whose
+success rate slipped, review feedback that keeps coming back, flaky
+jobs. The output is a user-facing report with suggestions — the skill
+never files tickets, never edits other skills, and never opens MRs.
+
+## When to use
+
+- At a weekly or bi-weekly retro, to anchor the conversation in
+  evidence instead of anecdote.
+- When a skill seems unreliable and you want to quantify the failure
+  shape before rewriting it.
+- Before an upgrade, to see which tool calls are most at risk if
+  something changes.
+
+## Procedure
+
+### 1. Pick the window
+
+- `--days 7` (default). Collect traces from the last N calendar days
+  under `<scope>/.devboy/sessions/<YYYY-MM-DD>/` where `<scope>` is
+  either the repo root (default) or `~/.devboy/` when `--global` is
+  passed.
+- If fewer than two days of data exist, warn on stderr — retros over
+  a tiny window are noisy.
+
+### 2. Begin the trace
+
+```bash
+result=$(devboy trace begin --skill devboy-retro)
+SESSION_DIR=$(echo "$result" | jq -r .session_dir)
+SESSION_ID=$(echo "$result" | jq -r .session_id)
+```
+
+Emit a `decision` event recording the window and the scope.
+
+### 3. Aggregate per-skill session stats
+
+Walk every `<date>/<skill>/meta.json` in the window. Per skill,
+collect: total runs, success / failure / aborted counts, total
+`tool_calls`, total `errors`, total duration, average duration, and
+the most common `summary` strings for failing runs.
+
+Additionally, read each failing session's `trace.jsonl` to find
+retry loops — sequences of `verify` events with `ok: false` followed
+by more `tool_call` attempts. A skill with many retry loops is a
+skill that could benefit from a stronger precondition check; record
+the ratio `retried / total_failures` per skill.
+
+Emit one `note` event per skill containing the aggregate numbers so
+future retros have a stable trail.
+
+### 4. Cross-reference CI history
+
+For every merged MR in the window:
+
+```bash
+devboy tools call get_merge_requests '{"state":"merged","limit":100}'
+```
+
+Filter the result to merge timestamps inside the window, then for the
+first ~20 call:
+
+```bash
+devboy tools call get_pipeline \
+  '{"mrKey":"mr#482","includeFailedLogs":true}'
+```
+
+Collect failing-job frequency keyed by job name. For the top three
+failing jobs, call `get_job_logs` in search mode to pull the most
+common error signature:
+
+```bash
+devboy tools call get_job_logs \
+  '{"jobId":"<id>","pattern":"error|fail|panic","context":2,"maxMatches":10}'
+```
+
+Keep only the error shapes that repeat across multiple runs — a
+single broken job is signal for the developer, not a pattern.
+
+### 5. Cross-reference review feedback
+
+For the same merged MRs:
+
+```bash
+devboy tools call get_merge_request_discussions \
+  '{"key":"mr#482","limit":50}'
+```
+
+Group the discussion bodies by naïve keyword bucket (type-safety,
+error-handling, testing, naming, i18n, performance, security). Count
+how often each bucket appears across MRs. The top three buckets go
+into the report.
+
+### 6. Produce the report
+
+Markdown to stdout:
+
+```markdown
+# Retro — last 7 days
+
+## Skills with degraded success rate
+- devboy-solve-issue — 6/10 success (was 9/10 the previous week);
+  60% of failures retry more than twice; top summary:
+  "gitlab returned 429".
+
+## Frequent review feedback
+- testing (mentioned in 9 MRs)
+- error-handling (mentioned in 5 MRs)
+- type-safety (mentioned in 4 MRs)
+
+## Flaky CI signal
+- integration::auth — 5/20 runs failed with "connection refused"
+- clippy — 3/20 runs failed with "-D warnings" on a single rule
+
+## Suggestions
+- Add a 429 back-off to the get_issues call inside devboy-solve-issue.
+- Update devboy-review-mr's checklist to call out type-safety explicitly.
+- Investigate integration::auth — likely a race on the test fixture.
+```
+
+Omit sections with no entries. Keep the report tight; two screens of
+text at most.
+
+### 7. End the trace
+
+```bash
+devboy trace end \
+  --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill devboy-retro \
+  --outcome "$OUTCOME" \
+  --summary "<N> sessions, <M> MRs, <K> jobs analysed"
+```
+
+## Success criteria
+
+- The report is driven entirely by numbers pulled from traces, MR
+  history, and pipeline data — no hand-waving.
+- Every suggestion points at a concrete skill, job, or feedback
+  bucket.
+- The skill is idempotent: running it twice over the same window
+  produces the same report (modulo clock drift in timestamps).
+
+## Guardrails
+
+- Never auto-create issues, never edit a `SKILL.md`, never post a
+  comment. The suggestions are text for a human to read.
+- Redacted trace payloads (`<redacted:credential>`, `<redacted:token-pattern>`)
+  are treated as opaque. Count them, do not try to un-redact them.
+- If `get_pipeline` or `get_merge_request_discussions` fails, note
+  the degradation in the report ("CI section omitted — pipeline
+  lookup failed") rather than pretending everything is fine.
+
+## Non-goals
+
+- Does not compare across projects or repositories.
+- Does not score individual developers; retros look at skills and
+  systems, not people.
+- Does not overlap with `devboy-daily-report` — that is a single-day
+  summary, this one is a multi-day pattern detector.

--- a/skills/03-self-feedback/devboy-run-and-verify/SKILL.md
+++ b/skills/03-self-feedback/devboy-run-and-verify/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: devboy-run-and-verify
+description: Run a command, trace every step, verify the expected outcome, and retry on failure.
+category: self-feedback
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "run and verify"
+  - "verify this command worked"
+  - "retry until green"
+tools:
+  - trace
+---
+
+# devboy-run-and-verify
+
+The opinionated wrapper that the other skills in this category assume.
+It runs one command, emits a structured session trace for every attempt,
+checks the expected outcome, and decides whether to retry. Downstream
+skills (`devboy-daily-report`, `devboy-retro`,
+`devboy-knowledge-extract`) consume the trace this skill produces.
+
+## When to use
+
+- You need to run a shell command whose success is not obvious from the
+  exit code alone (e.g. "the build exited 0 but printed WARNING lines we
+  want to catch").
+- You want a trace that later skills can read to understand what
+  happened and how long it took.
+- You want one, predictable retry policy rather than hand-rolling
+  retries inside each calling skill.
+
+## Procedure
+
+### 1. Parse the caller's intent
+
+Collect the following arguments from the caller:
+
+- `--command "<shell command>"` — the command to execute.
+- An expected-outcome specification. One of:
+  - `--expect-exit 0` — exact exit code.
+  - `--expect-stdout "<substring>"` — stdout must contain this string.
+  - `--expect-file "<path>"` — this path must exist after the run.
+  - `--expect-check "<verification command>"` — a shell command whose
+    exit code 0 means "the main command did what it was supposed to".
+- `--max-retries 2` (default `2`). The command runs up to
+  `1 + max-retries` times.
+- `--skill-name <name>` — the name of the skill that invoked this
+  wrapper. Traces are written under
+  `.devboy/sessions/<YYYY-MM-DD>/<skill-name>/` so downstream readers
+  attribute the work correctly.
+- `--allow-destructive` — required before running anything that matches
+  the destructive-command guardrail (see below).
+
+If an expected-outcome flag is missing, the skill exits with an error —
+there is nothing to verify against.
+
+### 2. Begin the session
+
+```bash
+result=$(devboy trace begin --skill "$SKILL_NAME")
+SESSION_DIR=$(echo "$result" | jq -r .session_dir)
+SESSION_ID=$(echo "$result" | jq -r .session_id)
+```
+
+Emit a `decision` event that records what the caller asked for:
+
+```bash
+devboy trace event \
+  --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill "$SKILL_NAME" --phase decision \
+  --payload "$(jq -nc --arg cmd "$COMMAND" --arg expect "$EXPECT" \
+               '{question:"what to run",decision:$cmd,expected:$expect}')"
+```
+
+### 3. Per-attempt loop
+
+For `attempt` in `1..=1+max_retries`:
+
+1. Emit a `tool_call` event describing the command about to run and
+   the attempt number.
+2. Run the command with stdout + stderr captured to a temporary file.
+   Record the start time, the end time, and the exit status.
+3. Summarise the output: keep the first 20 lines, the last 20 lines,
+   and every line matching `ERROR|WARN|FAIL|panic`. Everything else
+   can be dropped — trace payloads should stay small (ADR-015 risks).
+4. Emit a `tool_result` event with `{ok, exit, duration_ms, summary}`.
+5. Run the expected-outcome check. Emit a `verify` event with
+   `{check, ok, detail}`. The check is:
+   - exit code comparison, or
+   - substring search in the captured stdout, or
+   - `test -e <path>`, or
+   - the `--expect-check` shell command.
+6. If the verify event is `ok: true`, break out of the loop.
+7. Otherwise, if retries remain, emit a `note` event explaining why
+   the next attempt is happening ("expect-exit 0 but got 1; retrying"),
+   and continue. If retries are exhausted, fall through to step 4.
+
+### 4. End the session
+
+Pick the outcome:
+
+- `success` — some attempt produced `ok: true` on both tool-result and
+  verify.
+- `failure` — every attempt failed the verification.
+- `aborted` — the caller interrupted mid-run, or a destructive command
+  was rejected by the guardrail.
+
+```bash
+devboy trace end \
+  --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill "$SKILL_NAME" --outcome "$OUTCOME" \
+  --summary "$SHORT_SUMMARY"
+```
+
+### 5. Surface the result
+
+Print a 3-to-5-line summary to stdout naming: the command, attempts
+used, final outcome, and the path to the trace directory. Do not
+reprint the full captured output — the caller can `cat` the trace if
+they want it.
+
+## Success criteria
+
+- Exactly one `start` and one `end` event per invocation.
+- Every attempt contributes a matching `tool_call` / `tool_result` /
+  `verify` trio.
+- `meta.json` lands with `outcome` set to one of `success | failure |
+  aborted`.
+- A failing run still produces a complete, well-formed trace.
+
+## Guardrails
+
+Destructive commands are refused unless the caller passes
+`--allow-destructive`. The refusal path still opens a session, emits a
+`note` event describing the rejection, and ends with
+`outcome: aborted` so downstream skills can see what happened.
+
+Treat the following substrings (case-insensitive) as destructive:
+
+- `git push --force`, `git push -f`, `git reset --hard`,
+  `git clean -fdx`, `git branch -D`
+- `rm -rf`
+- `drop table`, `drop database`, `truncate`
+- `kubectl delete`, `helm uninstall`
+
+## Non-goals
+
+- This skill does not parse structured output to extract metrics; the
+  trace summary is intentionally textual.
+- It does not chain multiple commands. A pipeline of commands is
+  multiple invocations of this skill, one per step.
+- It does not post results anywhere. Notification belongs to
+  `devboy-notify` (category 5).


### PR DESCRIPTION
Part of #156. Closes #174. Stacked on #173 (session trace infra) → #167 (infra).

## Skills

| Name | Scope |
|------|-------|
| `devboy-run-and-verify` | Opinionated wrapper the other three assume. Runs a command, traces every step (`decision` / `tool_call` / `tool_result` / `verify` / `note`), verifies the expected outcome, retries with structured reasons. Destructive commands require `--allow-destructive`. |
| `devboy-daily-report` | Scans today's sessions + recent merged MRs + closed issues, produces a short Markdown report. Does **not** post anywhere — that's `devboy-notify`. |
| `devboy-retro` | Aggregates last N days of traces + MR discussions + `get_pipeline` / `get_job_logs` history. Surfaces patterns (degraded skill success rates, repeated review feedback, flaky CI). Outputs a user-facing report; does not auto-file or auto-edit. |
| `devboy-knowledge-extract` | Read-only. Given a session-dir, identifies failure-streak + fix moment and proposes where to codify the lesson (SKILL.md edit / CLAUDE.md bullet / `create_issue`). Never writes without explicit user ask. |

## Conventions

ADR-012: English-only, CLI-first (`devboy tools call` + `devboy trace {begin,event,end}`), minimal frontmatter, ~1 page bodies.

Every referenced tool cross-checked against `crates/devboy-executor/src/tools.rs` — notably `get_issues` and `get_merge_requests` have no `since` parameter in the authoritative schema, so `devboy-daily-report` does its date filter inside the skill rather than inventing a tool argument.

**Redaction guarantee:** the three reader skills treat redacted tokens in traces as opaque evidence. Never attempt to un-redact.

## Test plan

- [x] `cargo run -q -p devboy-cli -- skills list --category self-feedback` lists all four.
- [x] `cargo run -q -p devboy-cli -- skills show <name>` parses each SKILL.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)