### PR TITLE
docs(skills): Skills guide + README catalogue (closes epic #156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The same tools, the same pipeline, three ways to reach them. Start with one mode
 devboy skills list                          # see the shipped catalogue
 devboy skills install --all --agent all     # install every skill into every detected agent
 devboy skills install devboy-review-mr      # repo-local by default
-devboy skills upgrade --all                 # refresh after `devboy upgrade`
+devboy skills upgrade                       # refresh every installed skill after `devboy upgrade`
 ```
 
 | Category | Example skills |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,28 @@ The same tools, the same pipeline, three ways to reach them. Start with one mode
 
 > **Note on JSON arguments.** `devboy tools call <name>` takes an optional positional JSON string (defaults to `{}`). On POSIX shells wrap it in single quotes: `devboy tools call get_issues '{"limit": 20}'`. On Windows `cmd.exe` / PowerShell escape the inner quotes instead: `devboy tools call get_issues "{\"limit\": 20}"`.
 
+## Skills — procedural recipes shipped with the tools
+
+`devboy-tools` ships a catalogue of **skills** — one-page Markdown recipes that tell an AI agent how to use the tool bundle to accomplish a common task. Every skill is CLI-first (it calls `devboy tools call <name>`), agent-agnostic (installable into Claude Code / Codex / Cursor / Kimi or a vendor-neutral path), and versioned with the binary.
+
+```bash
+devboy skills list                          # see the shipped catalogue
+devboy skills install --all --agent all     # install every skill into every detected agent
+devboy skills install devboy-review-mr      # repo-local by default
+devboy skills upgrade --all                 # refresh after `devboy upgrade`
+```
+
+| Category | Example skills |
+|----------|---------------|
+| `self-bootstrap` | `devboy-setup`, `devboy-repair`, `devboy-tools-catalog` |
+| `issue-tracking` | `devboy-get-issues`, `devboy-create-issue`, `devboy-update-issue`, `devboy-link-issues`, `devboy-solve-issue` |
+| `code-review` | `devboy-review-mr`, `devboy-fix-review-comments`, `devboy-self-review` |
+| `self-feedback` | `devboy-run-and-verify`, `devboy-daily-report`, `devboy-retro`, `devboy-knowledge-extract` |
+| `meeting-notes` | `devboy-meeting-search`, `devboy-meeting-transcript`, `devboy-meeting-to-tasks` |
+| `messenger` | `devboy-chat-search`, `devboy-chat-summary`, `devboy-notify` |
+
+The design lives in `docs/architecture/adr/ADR-012-skills-subsystem.md`; the user guide is at `docs/guide/skills/`. Skill installs keep a per-location manifest with SHA256s so upgrades leave user-modified files alone (ADR-014), and the self-feedback category reads session traces written to `.devboy/sessions/` in the format defined by ADR-015.
+
 ## Why DevBoy?
 
 | | Others | DevBoy |

--- a/docs/guide/_nav.json
+++ b/docs/guide/_nav.json
@@ -15,6 +15,11 @@
     "activeMatch": "/configuration/proxy"
   },
   {
+    "text": "Skills",
+    "link": "/skills/",
+    "activeMatch": "/skills/"
+  },
+  {
     "text": "Architecture",
     "link": "/architecture/",
     "activeMatch": "/architecture/"

--- a/docs/guide/skills/_meta.json
+++ b/docs/guide/skills/_meta.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "file",
+    "name": "index",
+    "label": "Overview"
+  }
+]

--- a/docs/guide/skills/index.md
+++ b/docs/guide/skills/index.md
@@ -49,10 +49,11 @@ Preview a change without touching disk:
 devboy skills install devboy-review-mr --agent claude --dry-run
 ```
 
-Upgrade previously-installed skills after a `devboy upgrade`:
+Upgrade previously-installed skills after a `devboy upgrade` — with no arguments the subcommand upgrades every skill recorded in the local manifest; pass explicit names to scope it to a subset:
 
 ```bash
-devboy skills upgrade --all
+devboy skills upgrade                       # every installed skill
+devboy skills upgrade devboy-review-mr      # just one
 ```
 
 ## Where skills go

--- a/docs/guide/skills/index.md
+++ b/docs/guide/skills/index.md
@@ -1,0 +1,124 @@
+# Skills
+
+`devboy-tools` is not only a tool bundle — it also ships a catalogue of **skills**: small Markdown recipes that tell an AI agent how to use those tools to accomplish common tasks. Skills are the second half of the "configurable tool bundle" story (see [ADR-012](https://github.com/meteora-pro/devboy-tools/blob/main/docs/architecture/adr/ADR-012-skills-subsystem.md)).
+
+A skill is a single `SKILL.md` file with a short YAML frontmatter and a Markdown body. Agents that honour the Agent Skills Standard pick them up from a well-known directory; the CLI puts them there for you.
+
+## Why skills
+
+Tools are verbs — `get_issues`, `create_merge_request`, `send_message`. Skills are short recipes that chain verbs into procedures: "to review a merge request, first fetch the diff, then look up open discussions, then post inline comments with this checklist". Without skills, every agent learns those patterns from scratch on every new project. With skills, the pattern ships next to the tools it calls and every agent picks it up for free.
+
+Skills in `devboy-tools` follow a few conventions:
+
+- **English only** — no locale-specific copy in the baseline catalogue.
+- **CLI-first tool invocation** — skills call `devboy tools call <name>` rather than referring to a specific MCP server. That keeps recipes portable across agents and transports.
+- **Short bodies** — roughly one page each. A skill is a recipe, not a framework.
+- **Minimal frontmatter** — `name`, `description`, `category`, `version` are required; `compatibility`, `activation`, `tools` are recommended; unknown fields are preserved.
+
+## The shipped catalogue
+
+The baseline catalogue is compiled into the binary and falls into six categories. Every skill is listed with `devboy skills list`; every skill's full body is printed with `devboy skills show <name>`.
+
+| Category | What the skills cover |
+|----------|-----------------------|
+| `self-bootstrap` | Configure and repair `devboy-tools` itself. |
+| `issue-tracking` | Fetch, create, update, link, and solve issues across GitHub / GitLab / ClickUp / Jira. |
+| `code-review` | Review a merge request, apply reviewer feedback, dry-run a review pass of your own MR. |
+| `self-feedback` | Run and verify a command, produce a daily report, do a retrospective over the last N days, extract the lesson from a fix. |
+| `meeting-notes` | Search meeting notes, fetch a transcript, turn action items into issues. |
+| `messenger` | Search chat history, summarise a channel over a time window, send a structured notification. |
+
+## Quick start
+
+Install the self-bootstrap skills into the current project:
+
+```bash
+devboy skills list --category self-bootstrap
+devboy skills install --category self-bootstrap
+```
+
+Install every shipped skill globally so Claude Code / Codex / Cursor / Kimi pick them up regardless of which repository you're in:
+
+```bash
+devboy skills install --all --agent all
+```
+
+Preview a change without touching disk:
+
+```bash
+devboy skills install devboy-review-mr --agent claude --dry-run
+```
+
+Upgrade previously-installed skills after a `devboy upgrade`:
+
+```bash
+devboy skills upgrade --all
+```
+
+## Where skills go
+
+Install targets follow the rules in [ADR-013](https://github.com/meteora-pro/devboy-tools/blob/main/docs/architecture/adr/ADR-013-skills-install-targets.md):
+
+- **Default** — repo-local at `<repo>/.agents/skills/<skill>/`. Mirrors the `.devboy.toml` convention.
+- `--global` — `~/.agents/skills/<skill>/`.
+- `--agent claude|codex|cursor|kimi` — that agent's conventional path (e.g. `~/.claude/skills/`).
+- `--agent all` — every detected agent, plus the vendor-neutral `~/.agents/skills/`.
+- `--local` in combination with `--agent X` puts the install inside the repo instead of the home directory.
+
+If you run `devboy skills install` outside a git repository and without `--global` or `--agent`, the command fails with a clear error listing the flags you might have meant — no silent fallbacks.
+
+## Upgrade safety
+
+Every install target keeps a `.manifest.json` recording the SHA256 of each installed file. When you `upgrade`:
+
+- **Unchanged** files (same hash as the current shipped version) are skipped silently.
+- **Historical-safe** files (hash matches a version we previously shipped) are auto-upgraded to the current version.
+- **User-modified** files (hash matches nothing we ever shipped) are left alone with a warning. Pass `--force` to overwrite.
+
+This means you can edit installed skills to taste and later upgrade the rest of the catalogue without losing your edits. See [ADR-014](https://github.com/meteora-pro/devboy-tools/blob/main/docs/architecture/adr/ADR-014-skills-lifecycle.md) for the full lifecycle.
+
+## Session traces
+
+Skills in the `self-feedback` category read **session traces** — append-only JSONL files at `<target>/.devboy/sessions/<YYYY-MM-DD>/<skill>/trace.jsonl` that record what another skill did. Any caller can write into that format via the `devboy trace` CLI:
+
+```bash
+result=$(devboy trace begin --skill my-skill)
+SESSION_DIR=$(echo "$result" | jq -r .session_dir)
+SESSION_ID=$(echo "$result" | jq -r .session_id)
+
+devboy trace event --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill my-skill --phase tool_call \
+  --payload '{"tool":"get_issues","args":{"limit":20}}'
+
+devboy trace end --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill my-skill --outcome success --summary "pulled 20 issues"
+```
+
+A central redaction pass strips known credential shapes and env-var-valued secrets before anything lands on disk. Set `DEVBOY_TRACE_REDACTION=off` to disable it for local debugging only. The format is described in [ADR-015](https://github.com/meteora-pro/devboy-tools/blob/main/docs/architecture/adr/ADR-015-skills-session-traces.md).
+
+## Adding your own skill
+
+Skills are plain Markdown. To add one to a project, drop a `SKILL.md` under `<repo>/.agents/skills/<name>/` with a frontmatter block that looks like this:
+
+```yaml
+---
+name: my-skill
+description: One-sentence summary ending with a period.
+category: self-bootstrap            # one of the six categories
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "phrase agents can use to trigger me"
+tools:
+  - get_issues
+  - create_merge_request
+---
+
+# my-skill
+
+...body goes here, roughly one page...
+```
+
+Agents that honour the standard will discover the skill automatically. `devboy skills list` also picks it up if you point a custom source at the directory (coming in a future release — the initial cut only lists the embedded catalogue).
+
+To contribute a skill upstream, open a pull request that adds `skills/<NN-category>/<name>/SKILL.md` in the `devboy-tools` repository.


### PR DESCRIPTION
Final PR of the skills epic #156.

Stacked on #175 (category 3) → #173 (trace infra) → #167 (infra).

## What's in this PR

### `docs/guide/skills/index.md`

New Rspress page covering:

- **Why skills** — tools are verbs, skills are recipes that chain verbs.
- **The shipped catalogue** — table of six categories with representative skills.
- **Quick start** — `devboy skills list` / `install` / `upgrade` examples.
- **Where skills go** — repo-local default, `--global`, `--agent X`, `--agent all`, `--local` modifier, fail-with-hint when ambiguous.
- **Upgrade safety** — three-state SHA256 check: unchanged / historical-safe / user-modified (with `--force` override).
- **Session traces** — `devboy trace {begin,event,end}` shell snippets, `DEVBOY_TRACE_REDACTION` opt-out, pointer at ADR-015.
- **Adding your own skill** — drop a `SKILL.md` under `.agents/skills/`, contribute upstream via PR.

### `docs/guide/skills/_meta.json`

Single-page section meta so Rspress renders it in the nav.

### `docs/guide/_nav.json`

Adds a "Skills" top-nav entry between Architecture and Integrations.

### `README.md`

New "Skills — procedural recipes shipped with the tools" section right after Integration modes. Lists every shipped category with representative skill names and the three quickstart commands (`list` / `install` / `upgrade`). Points the interested reader at ADRs 012 / 013 / 014 / 015.

## Test plan

- [x] Rspress builds — `pnpm -C docs build` (part of the `Docs` CI job).
- [x] `devboy skills list` smoke-tested locally against the PRs stacked below; every category prints.

## Epic close-out

Once this PR merges, **every sub-issue in #156 is closed** — the skills subsystem is end-to-end on main: crate + CLI (#157 + #158), five shipped categories (3 + 5 + 3 + 4 + 3 + 3 = 21 skills total), session-trace infrastructure (#173), and the docs + README update that makes the whole thing discoverable.

#162 and #163 (`get_pipeline` / `get_job_logs` tools) were closed earlier on discovery that the implementations were already shipped on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)