### PR TITLE
feat(jira): add Structure plugin MCP tools

### DIFF
--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -44,14 +44,18 @@ pub use provider::{
 
 // Re-export all types
 pub use types::{
-    CodePosition, Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput,
-    Discussion, FailedJob, FileDiff, GetChatsParams, GetMessagesParams, GetPipelineInput,
-    GetUsersOptions, Issue, IssueFilter, IssueLink, IssueRelations, IssueStatus, JobLogMode,
-    JobLogOptions, JobLogOutput, MeetingFilter, MeetingNote, MeetingSpeaker, MeetingTranscript,
-    MergeRequest, MessageAttachment, MessageAuthor, MessengerChat, MessengerMessage, MrFilter,
-    Pagination, PipelineInfo, PipelineJob, PipelineStage, PipelineStatus, PipelineSummary,
-    ProviderResult, Release, ReleaseAsset, SearchMessagesParams, SendMessageParams, SortInfo,
-    SortOrder, TranscriptSentence, UpdateIssueInput, UpdateMergeRequestInput, User,
+    AddStructureRowsInput, CodePosition, Comment, CreateCommentInput, CreateIssueInput,
+    CreateMergeRequestInput, CreateStructureInput, Discussion, FailedJob, FileDiff,
+    ForestModifyResult, GetChatsParams, GetForestOptions, GetMessagesParams, GetPipelineInput,
+    GetStructureValuesInput, GetUsersOptions, Issue, IssueFilter, IssueLink, IssueRelations,
+    IssueStatus, JobLogMode, JobLogOptions, JobLogOutput, MeetingFilter, MeetingNote,
+    MeetingSpeaker, MeetingTranscript, MergeRequest, MessageAttachment, MessageAuthor,
+    MessengerChat, MessengerMessage, MoveStructureRowsInput, MrFilter, Pagination, PipelineInfo,
+    PipelineJob, PipelineStage, PipelineStatus, PipelineSummary, ProviderResult, Release,
+    ReleaseAsset, SaveStructureViewInput, SearchMessagesParams, SendMessageParams, SortInfo,
+    SortOrder, Structure, StructureColumnValue, StructureForest, StructureNode, StructureRowItem,
+    StructureRowValues, StructureValues, StructureView, StructureViewColumn, TranscriptSentence,
+    UpdateIssueInput, UpdateMergeRequestInput, User,
 };
 
 // Re-export enricher traits and utilities

--- a/crates/devboy-core/src/provider.rs
+++ b/crates/devboy-core/src/provider.rs
@@ -8,12 +8,14 @@ use async_trait::async_trait;
 use crate::asset::{AssetCapabilities, AssetMeta};
 use crate::error::{Error, Result};
 use crate::types::{
-    Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, Discussion, FileDiff,
-    GetChatsParams, GetMessagesParams, GetPipelineInput, GetUsersOptions, Issue, IssueFilter,
-    IssueRelations, IssueStatus, JobLogOptions, JobLogOutput, MeetingFilter, MeetingNote,
-    MeetingTranscript, MergeRequest, MessengerChat, MessengerMessage, MrFilter, PipelineInfo,
-    ProviderResult, Release, SearchMessagesParams, SendMessageParams, UpdateIssueInput,
-    UpdateMergeRequestInput, User,
+    AddStructureRowsInput, Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput,
+    CreateStructureInput, Discussion, FileDiff, ForestModifyResult, GetChatsParams,
+    GetForestOptions, GetMessagesParams, GetPipelineInput, GetStructureValuesInput,
+    GetUsersOptions, Issue, IssueFilter, IssueRelations, IssueStatus, JobLogOptions, JobLogOutput,
+    MeetingFilter, MeetingNote, MeetingTranscript, MergeRequest, MessengerChat, MessengerMessage,
+    MoveStructureRowsInput, MrFilter, PipelineInfo, ProviderResult, Release,
+    SaveStructureViewInput, SearchMessagesParams, SendMessageParams, Structure, StructureForest,
+    StructureValues, StructureView, UpdateIssueInput, UpdateMergeRequestInput, User,
 };
 
 /// Provider for working with issues.
@@ -156,6 +158,100 @@ pub trait IssueProvider: Send + Sync {
         Err(Error::ProviderUnsupported {
             provider: self.provider_name().to_string(),
             operation: "get_issue_relations".to_string(),
+        })
+    }
+
+    // --- Jira Structure plugin methods ---
+    // Default: ProviderUnsupported. Only JiraClient overrides these.
+
+    /// List all available structures.
+    async fn get_structures(&self) -> Result<ProviderResult<Structure>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "get_structures".to_string(),
+        })
+    }
+
+    /// Get a structure's forest (hierarchy tree).
+    async fn get_structure_forest(
+        &self,
+        _structure_id: u64,
+        _options: GetForestOptions,
+    ) -> Result<StructureForest> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "get_structure_forest".to_string(),
+        })
+    }
+
+    /// Add rows to a structure's forest.
+    async fn add_structure_rows(
+        &self,
+        _structure_id: u64,
+        _input: AddStructureRowsInput,
+    ) -> Result<ForestModifyResult> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "add_structure_rows".to_string(),
+        })
+    }
+
+    /// Move rows within a structure's forest.
+    async fn move_structure_rows(
+        &self,
+        _structure_id: u64,
+        _input: MoveStructureRowsInput,
+    ) -> Result<ForestModifyResult> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "move_structure_rows".to_string(),
+        })
+    }
+
+    /// Remove a row from a structure's forest.
+    async fn remove_structure_row(&self, _structure_id: u64, _row_id: u64) -> Result<()> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "remove_structure_row".to_string(),
+        })
+    }
+
+    /// Batch-read column values (including formulas) for structure rows.
+    async fn get_structure_values(
+        &self,
+        _input: GetStructureValuesInput,
+    ) -> Result<StructureValues> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "get_structure_values".to_string(),
+        })
+    }
+
+    /// Get views for a structure, optionally a specific view by ID.
+    async fn get_structure_views(
+        &self,
+        _structure_id: u64,
+        _view_id: Option<u64>,
+    ) -> Result<Vec<StructureView>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "get_structure_views".to_string(),
+        })
+    }
+
+    /// Create or update a structure view.
+    async fn save_structure_view(&self, _input: SaveStructureViewInput) -> Result<StructureView> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "save_structure_view".to_string(),
+        })
+    }
+
+    /// Create a new structure.
+    async fn create_structure(&self, _input: CreateStructureInput) -> Result<Structure> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "create_structure".to_string(),
         })
     }
 

--- a/crates/devboy-core/src/tool_category.rs
+++ b/crates/devboy-core/src/tool_category.rs
@@ -34,4 +34,8 @@ pub enum ToolCategory {
     /// Messenger tools: chats, messages, search, sending.
     /// Providers: Slack
     Messenger,
+
+    /// Jira Structure plugin tools: hierarchies, views, formulas.
+    /// Providers: Jira (requires Structure plugin)
+    JiraStructure,
 }

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -1136,3 +1136,213 @@ pub struct SendMessageParams {
     /// Optional attachments to include or reference.
     pub attachments: Vec<MessageAttachment>,
 }
+
+// =============================================================================
+// Jira Structure (plugin)
+// =============================================================================
+
+/// A Jira Structure container.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Structure {
+    /// Structure ID
+    pub id: u64,
+    /// Structure name
+    pub name: String,
+    /// Structure description
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// A node in a Structure forest tree.
+///
+/// Transformed from the compact `rows[] + depths[]` API format
+/// into a nested tree with `children` for LLM readability.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct StructureNode {
+    /// Row ID within the structure
+    pub row_id: u64,
+    /// Item identifier (e.g., Jira issue key "PROJ-123")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item_id: Option<String>,
+    /// Item type (e.g., "issue", "folder")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item_type: Option<String>,
+    /// Child nodes
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<StructureNode>,
+}
+
+/// A Structure forest — the hierarchy tree for a Structure.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct StructureForest {
+    /// Forest version (for optimistic concurrency)
+    pub version: u64,
+    /// Structure ID
+    pub structure_id: u64,
+    /// Root nodes of the tree
+    pub tree: Vec<StructureNode>,
+    /// Total number of rows in the structure
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_count: Option<u64>,
+}
+
+/// Result of a forest modification (add/move rows).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ForestModifyResult {
+    /// New forest version after modification
+    pub version: u64,
+    /// Number of rows affected
+    pub affected_count: usize,
+}
+
+/// A saved view for a Structure.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct StructureView {
+    /// View ID
+    pub id: u64,
+    /// View name
+    pub name: String,
+    /// Structure ID this view belongs to
+    pub structure_id: u64,
+    /// Column definitions
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub columns: Vec<StructureViewColumn>,
+    /// Group by field
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_by: Option<String>,
+    /// Sort by field
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sort_by: Option<String>,
+    /// JQL filter
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter: Option<String>,
+}
+
+/// A column in a Structure view.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct StructureViewColumn {
+    /// Column ID
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Jira field name (e.g., "summary", "status")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    /// Structure Expr formula (e.g., "SUM(\"Story Points\")")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub formula: Option<String>,
+    /// Column width in pixels
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<u32>,
+}
+
+/// Batch values for Structure rows × columns.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct StructureValues {
+    /// Structure ID
+    pub structure_id: u64,
+    /// Values matrix: row_id → column values
+    pub values: Vec<StructureRowValues>,
+}
+
+/// Values for a single row.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct StructureRowValues {
+    /// Row ID
+    pub row_id: u64,
+    /// Column values (column_id/field → value)
+    pub columns: Vec<StructureColumnValue>,
+}
+
+/// A single column value.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct StructureColumnValue {
+    /// Column identifier (field name or formula)
+    pub column: String,
+    /// The value (can be string, number, null, etc.)
+    pub value: Value,
+}
+
+// --- Structure input types ---
+
+/// Options for getting a structure forest.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GetForestOptions {
+    /// Offset for pagination
+    pub offset: Option<u64>,
+    /// Max rows to return (default: 200)
+    pub limit: Option<u64>,
+}
+
+/// Input for adding rows to a structure.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AddStructureRowsInput {
+    /// Items to add
+    pub items: Vec<StructureRowItem>,
+    /// Parent row ID (items become children)
+    pub under: Option<u64>,
+    /// Sibling row ID (items placed after)
+    pub after: Option<u64>,
+    /// Forest version for optimistic locking
+    pub forest_version: Option<u64>,
+}
+
+/// A single item to add to a structure.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StructureRowItem {
+    /// Jira issue key or folder name
+    pub item_id: String,
+    /// Item type: "issue" (default) or "folder"
+    pub item_type: Option<String>,
+}
+
+/// Input for moving rows within a structure.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MoveStructureRowsInput {
+    /// Row IDs to move
+    pub row_ids: Vec<u64>,
+    /// New parent row ID
+    pub under: Option<u64>,
+    /// Sibling row ID (placed after)
+    pub after: Option<u64>,
+    /// Forest version for optimistic locking
+    pub forest_version: Option<u64>,
+}
+
+/// Input for reading structure values.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GetStructureValuesInput {
+    /// Structure ID
+    pub structure_id: u64,
+    /// Row IDs to read
+    pub rows: Vec<u64>,
+    /// Columns to read
+    pub columns: Vec<StructureViewColumn>,
+}
+
+/// Input for saving a structure view.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SaveStructureViewInput {
+    /// View ID (omit to create new)
+    pub id: Option<u64>,
+    /// Structure ID
+    pub structure_id: u64,
+    /// View name
+    pub name: String,
+    /// Column definitions
+    pub columns: Option<Vec<StructureViewColumn>>,
+    /// Group by field
+    pub group_by: Option<String>,
+    /// Sort by field
+    pub sort_by: Option<String>,
+    /// JQL filter
+    pub filter: Option<String>,
+}
+
+/// Input for creating a new structure.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CreateStructureInput {
+    /// Structure name
+    pub name: String,
+    /// Structure description
+    pub description: Option<String>,
+}

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -2137,6 +2137,82 @@ mod tests {
                 ..Default::default()
             })
         }
+        async fn get_structures(
+            &self,
+        ) -> devboy_core::Result<devboy_core::ProviderResult<devboy_core::Structure>> {
+            Ok(vec![sample_structure()].into())
+        }
+        async fn get_structure_forest(
+            &self,
+            structure_id: u64,
+            _options: devboy_core::GetForestOptions,
+        ) -> devboy_core::Result<devboy_core::StructureForest> {
+            Ok(sample_forest(structure_id))
+        }
+        async fn add_structure_rows(
+            &self,
+            _structure_id: u64,
+            input: devboy_core::AddStructureRowsInput,
+        ) -> devboy_core::Result<devboy_core::ForestModifyResult> {
+            Ok(devboy_core::ForestModifyResult {
+                version: 2,
+                affected_count: input.items.len(),
+            })
+        }
+        async fn move_structure_rows(
+            &self,
+            _structure_id: u64,
+            input: devboy_core::MoveStructureRowsInput,
+        ) -> devboy_core::Result<devboy_core::ForestModifyResult> {
+            Ok(devboy_core::ForestModifyResult {
+                version: 3,
+                affected_count: input.row_ids.len(),
+            })
+        }
+        async fn remove_structure_row(
+            &self,
+            _structure_id: u64,
+            _row_id: u64,
+        ) -> devboy_core::Result<()> {
+            Ok(())
+        }
+        async fn get_structure_values(
+            &self,
+            input: devboy_core::GetStructureValuesInput,
+        ) -> devboy_core::Result<devboy_core::StructureValues> {
+            Ok(devboy_core::StructureValues {
+                structure_id: input.structure_id,
+                values: vec![],
+            })
+        }
+        async fn get_structure_views(
+            &self,
+            structure_id: u64,
+            _view_id: Option<u64>,
+        ) -> devboy_core::Result<Vec<devboy_core::StructureView>> {
+            Ok(vec![sample_view(structure_id)])
+        }
+        async fn save_structure_view(
+            &self,
+            input: devboy_core::SaveStructureViewInput,
+        ) -> devboy_core::Result<devboy_core::StructureView> {
+            Ok(devboy_core::StructureView {
+                id: input.id.unwrap_or(99),
+                name: input.name,
+                structure_id: input.structure_id,
+                ..Default::default()
+            })
+        }
+        async fn create_structure(
+            &self,
+            input: devboy_core::CreateStructureInput,
+        ) -> devboy_core::Result<devboy_core::Structure> {
+            Ok(devboy_core::Structure {
+                id: 42,
+                name: input.name,
+                description: input.description,
+            })
+        }
         fn provider_name(&self) -> &'static str {
             "mock"
         }
@@ -2725,5 +2801,167 @@ mod tests {
         let provider = MockMeetingProvider;
         let result = dispatch_meeting_tool("nonexistent_tool", &Value::Null, &provider).await;
         assert!(result.is_err());
+    }
+
+    // =========================================================================
+    // Structure tool dispatch tests
+    // =========================================================================
+
+    fn sample_structure() -> devboy_core::Structure {
+        devboy_core::Structure {
+            id: 1,
+            name: "Q1 Plan".into(),
+            description: Some("Quarter 1 planning".into()),
+        }
+    }
+
+    fn sample_forest(structure_id: u64) -> devboy_core::StructureForest {
+        devboy_core::StructureForest {
+            version: 1,
+            structure_id,
+            tree: vec![devboy_core::StructureNode {
+                row_id: 100,
+                item_id: Some("PROJ-1".into()),
+                item_type: Some("issue".into()),
+                children: vec![],
+            }],
+            total_count: Some(1),
+        }
+    }
+
+    fn sample_view(structure_id: u64) -> devboy_core::StructureView {
+        devboy_core::StructureView {
+            id: 10,
+            name: "Default".into(),
+            structure_id,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_get_structures() {
+        let provider = MockProvider;
+        let result = dispatch_tool("get_structures", &Value::Null, &provider, None)
+            .await
+            .unwrap();
+        assert!(matches!(result, ToolOutput::Structures(ref items, _) if items.len() == 1));
+        assert_eq!(result.type_name(), "structures");
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_get_structure_forest() {
+        let provider = MockProvider;
+        let args = serde_json::json!({"structureId": 1});
+        let result = dispatch_tool("get_structure_forest", &args, &provider, None)
+            .await
+            .unwrap();
+        assert!(matches!(result, ToolOutput::StructureForest(_)));
+        assert_eq!(result.type_name(), "structure_forest");
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_get_structure_forest_missing_id() {
+        let provider = MockProvider;
+        let result = dispatch_tool("get_structure_forest", &Value::Null, &provider, None).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_add_structure_rows() {
+        let provider = MockProvider;
+        let args = serde_json::json!({
+            "structureId": 1,
+            "items": ["PROJ-1", "PROJ-2"],
+            "under": 100
+        });
+        let result = dispatch_tool("add_structure_rows", &args, &provider, None)
+            .await
+            .unwrap();
+        match result {
+            ToolOutput::ForestModified(r) => {
+                assert_eq!(r.version, 2);
+                assert_eq!(r.affected_count, 2);
+            }
+            _ => panic!("expected ForestModified"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_move_structure_rows() {
+        let provider = MockProvider;
+        let args = serde_json::json!({
+            "structureId": 1,
+            "rowIds": [100, 101],
+            "under": 200
+        });
+        let result = dispatch_tool("move_structure_rows", &args, &provider, None)
+            .await
+            .unwrap();
+        assert!(matches!(result, ToolOutput::ForestModified(_)));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_remove_structure_row() {
+        let provider = MockProvider;
+        let args = serde_json::json!({"structureId": 1, "rowId": 100});
+        let result = dispatch_tool("remove_structure_row", &args, &provider, None)
+            .await
+            .unwrap();
+        assert!(matches!(result, ToolOutput::Text(_)));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_get_structure_values() {
+        let provider = MockProvider;
+        let args = serde_json::json!({
+            "structureId": 1,
+            "rows": [100],
+            "columns": ["summary", {"field": "status"}]
+        });
+        let result = dispatch_tool("get_structure_values", &args, &provider, None)
+            .await
+            .unwrap();
+        assert!(matches!(result, ToolOutput::StructureValues(_)));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_get_structure_views() {
+        let provider = MockProvider;
+        let args = serde_json::json!({"structureId": 1});
+        let result = dispatch_tool("get_structure_views", &args, &provider, None)
+            .await
+            .unwrap();
+        assert!(matches!(result, ToolOutput::StructureViews(views, _) if views.len() == 1));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_save_structure_view() {
+        let provider = MockProvider;
+        let args = serde_json::json!({
+            "structureId": 1,
+            "name": "Sprint View"
+        });
+        let result = dispatch_tool("save_structure_view", &args, &provider, None)
+            .await
+            .unwrap();
+        assert!(
+            matches!(result, ToolOutput::StructureViews(views, _) if views[0].name == "Sprint View")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_create_structure() {
+        let provider = MockProvider;
+        let args = serde_json::json!({"name": "New Structure", "description": "Test"});
+        let result = dispatch_tool("create_structure", &args, &provider, None)
+            .await
+            .unwrap();
+        match result {
+            ToolOutput::Structures(items, _) => {
+                assert_eq!(items[0].name, "New Structure");
+                assert_eq!(items[0].id, 42);
+            }
+            _ => panic!("expected Structures"),
+        }
     }
 }

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -1799,6 +1799,57 @@ struct AddStructureRowsParams {
     forest_version: Option<u64>,
 }
 
+/// Turn a single `items[]` entry from `add_structure_rows` into a
+/// `StructureRowItem`. The tool schema can only express a list of
+/// strings, so callers wanting to set `item_type` or nested fields
+/// are forced to pass JSON inside a string. Accept both:
+///
+/// - bare string → `{ item_id: s, item_type: None }`
+/// - JSON object (either as a real object or a string that parses as
+///   one) → `serde_json::from_value`
+///
+/// Malformed input surfaces as `InvalidData` rather than silently
+/// dropping values through `unwrap_or_default()`.
+fn parse_structure_row_item(v: Value) -> Result<StructureRowItem> {
+    if let Some(s) = v.as_str() {
+        if let Ok(parsed) = serde_json::from_str::<Value>(s)
+            && parsed.is_object()
+        {
+            return serde_json::from_value(parsed)
+                .map_err(|e| Error::InvalidData(format!("invalid structure row item JSON: {e}")));
+        }
+        return Ok(StructureRowItem {
+            item_id: s.to_string(),
+            item_type: None,
+        });
+    }
+    serde_json::from_value(v)
+        .map_err(|e| Error::InvalidData(format!("invalid structure row item: {e}")))
+}
+
+/// Turn a `columns[]` entry from `get_structure_values` /
+/// `save_structure_view` into a `StructureViewColumn`. Same dual
+/// shape as `parse_structure_row_item`: bare string means
+/// `{ field: Some(s) }`, anything else (or a JSON-object string) is
+/// deserialised as a full spec. Errors propagate.
+fn parse_structure_column_spec(v: Value) -> Result<StructureViewColumn> {
+    if let Some(s) = v.as_str() {
+        if let Ok(parsed) = serde_json::from_str::<Value>(s)
+            && parsed.is_object()
+        {
+            return serde_json::from_value(parsed).map_err(|e| {
+                Error::InvalidData(format!("invalid structure column spec JSON: {e}"))
+            });
+        }
+        return Ok(StructureViewColumn {
+            field: Some(s.to_string()),
+            ..Default::default()
+        });
+    }
+    serde_json::from_value(v)
+        .map_err(|e| Error::InvalidData(format!("invalid structure column spec: {e}")))
+}
+
 async fn execute_add_structure_rows(
     provider: &dyn devboy_core::Provider,
     args: &Value,
@@ -1809,17 +1860,8 @@ async fn execute_add_structure_rows(
     let items: Vec<StructureRowItem> = params
         .items
         .into_iter()
-        .map(|v| {
-            if let Some(s) = v.as_str() {
-                StructureRowItem {
-                    item_id: s.to_string(),
-                    item_type: None,
-                }
-            } else {
-                serde_json::from_value(v).unwrap_or_default()
-            }
-        })
-        .collect();
+        .map(parse_structure_row_item)
+        .collect::<Result<Vec<_>>>()?;
 
     let result = provider
         .add_structure_rows(
@@ -1905,17 +1947,8 @@ async fn execute_get_structure_values(
     let columns: Vec<StructureViewColumn> = params
         .columns
         .into_iter()
-        .map(|v| {
-            if let Some(s) = v.as_str() {
-                StructureViewColumn {
-                    field: Some(s.to_string()),
-                    ..Default::default()
-                }
-            } else {
-                serde_json::from_value(v).unwrap_or_default()
-            }
-        })
-        .collect();
+        .map(parse_structure_column_spec)
+        .collect::<Result<Vec<_>>>()?;
 
     let result = provider
         .get_structure_values(GetStructureValuesInput {
@@ -1965,11 +1998,14 @@ async fn execute_save_structure_view(
     let params: SaveStructureViewParams = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("invalid save_structure_view params: {e}")))?;
 
-    let columns: Option<Vec<StructureViewColumn>> = params.columns.map(|cols| {
-        cols.into_iter()
-            .map(|v| serde_json::from_value(v).unwrap_or_default())
-            .collect()
-    });
+    let columns: Option<Vec<StructureViewColumn>> = params
+        .columns
+        .map(|cols| {
+            cols.into_iter()
+                .map(parse_structure_column_spec)
+                .collect::<Result<Vec<_>>>()
+        })
+        .transpose()?;
 
     let view = provider
         .save_structure_view(SaveStructureViewInput {
@@ -2963,5 +2999,59 @@ mod tests {
             }
             _ => panic!("expected Structures"),
         }
+    }
+
+    // -------------------------------------------------------------------
+    // Regression: structure-specific arg parsing
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn parse_row_item_bare_string_becomes_item_id() {
+        let item = parse_structure_row_item(serde_json::json!("PROJ-1")).unwrap();
+        assert_eq!(item.item_id, "PROJ-1");
+        assert!(item.item_type.is_none());
+    }
+
+    #[test]
+    fn parse_row_item_json_object_string_parses_fields() {
+        let item = parse_structure_row_item(serde_json::json!(
+            "{\"item_id\":\"PROJ-2\",\"item_type\":\"issue\"}"
+        ))
+        .unwrap();
+        assert_eq!(item.item_id, "PROJ-2");
+        assert_eq!(item.item_type.as_deref(), Some("issue"));
+    }
+
+    #[test]
+    fn parse_row_item_malformed_json_object_is_error() {
+        // Valid JSON object but fields do not match StructureRowItem.
+        let err = parse_structure_row_item(serde_json::json!("{\"wrong\":true}")).unwrap_err();
+        assert!(matches!(err, Error::InvalidData(_)));
+    }
+
+    #[test]
+    fn parse_column_spec_bare_string_sets_field() {
+        let col = parse_structure_column_spec(serde_json::json!("summary")).unwrap();
+        assert_eq!(col.field.as_deref(), Some("summary"));
+        assert!(col.formula.is_none());
+    }
+
+    #[test]
+    fn parse_column_spec_formula_json_string_parses() {
+        let col = parse_structure_column_spec(serde_json::json!(
+            "{\"formula\":\"SUM(\\\"Story Points\\\")\"}"
+        ))
+        .unwrap();
+        assert!(col.field.is_none());
+        assert_eq!(col.formula.as_deref(), Some("SUM(\"Story Points\")"));
+    }
+
+    #[test]
+    fn parse_column_spec_object_value_is_deserialised() {
+        // A real JSON object (not a stringified one) should also work.
+        let col = parse_structure_column_spec(serde_json::json!({"field": "status", "width": 120}))
+            .unwrap();
+        assert_eq!(col.field.as_deref(), Some("status"));
+        assert_eq!(col.width, Some(120));
     }
 }

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -1,10 +1,12 @@
 use devboy_core::types::ChatType;
 use devboy_core::{
-    CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, Error, GetChatsParams,
-    GetMessagesParams, GetPipelineInput, GetUsersOptions, IssueFilter, IssueProvider, JobLogMode,
-    JobLogOptions, MeetingFilter, MeetingNotesProvider, MergeRequestProvider, MessengerProvider,
-    MrFilter, PipelineProvider, Result, SearchMessagesParams, SendMessageParams, ToolCategory,
-    UpdateIssueInput,
+    AddStructureRowsInput, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput,
+    CreateStructureInput, Error, GetChatsParams, GetForestOptions, GetMessagesParams,
+    GetPipelineInput, GetStructureValuesInput, GetUsersOptions, IssueFilter, IssueProvider,
+    JobLogMode, JobLogOptions, MeetingFilter, MeetingNotesProvider, MergeRequestProvider,
+    MessengerProvider, MoveStructureRowsInput, MrFilter, PipelineProvider, Result,
+    SaveStructureViewInput, SearchMessagesParams, SendMessageParams, StructureRowItem,
+    StructureViewColumn, ToolCategory, UpdateIssueInput,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -410,6 +412,17 @@ async fn dispatch_tool(
         "upload_asset" => execute_upload_asset(provider, args).await,
         "download_asset" => execute_download_asset(provider, args, asset_manager).await,
         "delete_asset" => execute_delete_asset(provider, args, asset_manager).await,
+
+        // Jira Structure tools
+        "get_structures" => execute_get_structures(provider).await,
+        "get_structure_forest" => execute_get_structure_forest(provider, args).await,
+        "add_structure_rows" => execute_add_structure_rows(provider, args).await,
+        "move_structure_rows" => execute_move_structure_rows(provider, args).await,
+        "remove_structure_row" => execute_remove_structure_row(provider, args).await,
+        "get_structure_values" => execute_get_structure_values(provider, args).await,
+        "get_structure_views" => execute_get_structure_views(provider, args).await,
+        "save_structure_view" => execute_save_structure_view(provider, args).await,
+        "create_structure" => execute_create_structure(provider, args).await,
 
         _ => Err(Error::NotFound(format!("unknown tool: {tool}"))),
     }
@@ -1735,6 +1748,262 @@ fn base64_decode(input: &str) -> Result<Vec<u8>> {
 fn base64_encode(data: &[u8]) -> String {
     use base64::Engine;
     base64::engine::general_purpose::STANDARD.encode(data)
+}
+
+// =============================================================================
+// Jira Structure tool handlers
+// =============================================================================
+
+async fn execute_get_structures(provider: &dyn devboy_core::Provider) -> Result<ToolOutput> {
+    let result = provider.get_structures().await?;
+    let meta = ResultMeta {
+        pagination: result.pagination,
+        sort_info: result.sort_info,
+    };
+    Ok(ToolOutput::Structures(result.items, Some(meta)))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GetStructureForestParams {
+    structure_id: u64,
+    offset: Option<u64>,
+    limit: Option<u64>,
+}
+
+async fn execute_get_structure_forest(
+    provider: &dyn devboy_core::Provider,
+    args: &Value,
+) -> Result<ToolOutput> {
+    let params: GetStructureForestParams = serde_json::from_value(args.clone())
+        .map_err(|e| Error::InvalidData(format!("missing 'structureId': {e}")))?;
+    let forest = provider
+        .get_structure_forest(
+            params.structure_id,
+            GetForestOptions {
+                offset: params.offset,
+                limit: Some(params.limit.unwrap_or(200)),
+            },
+        )
+        .await?;
+    Ok(ToolOutput::StructureForest(Box::new(forest)))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AddStructureRowsParams {
+    structure_id: u64,
+    items: Vec<Value>,
+    under: Option<u64>,
+    after: Option<u64>,
+    forest_version: Option<u64>,
+}
+
+async fn execute_add_structure_rows(
+    provider: &dyn devboy_core::Provider,
+    args: &Value,
+) -> Result<ToolOutput> {
+    let params: AddStructureRowsParams = serde_json::from_value(args.clone())
+        .map_err(|e| Error::InvalidData(format!("invalid add_structure_rows params: {e}")))?;
+
+    let items: Vec<StructureRowItem> = params
+        .items
+        .into_iter()
+        .map(|v| {
+            if let Some(s) = v.as_str() {
+                StructureRowItem {
+                    item_id: s.to_string(),
+                    item_type: None,
+                }
+            } else {
+                serde_json::from_value(v).unwrap_or_default()
+            }
+        })
+        .collect();
+
+    let result = provider
+        .add_structure_rows(
+            params.structure_id,
+            AddStructureRowsInput {
+                items,
+                under: params.under,
+                after: params.after,
+                forest_version: params.forest_version,
+            },
+        )
+        .await?;
+    Ok(ToolOutput::ForestModified(result))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MoveStructureRowsParams {
+    structure_id: u64,
+    row_ids: Vec<u64>,
+    under: Option<u64>,
+    after: Option<u64>,
+    forest_version: Option<u64>,
+}
+
+async fn execute_move_structure_rows(
+    provider: &dyn devboy_core::Provider,
+    args: &Value,
+) -> Result<ToolOutput> {
+    let params: MoveStructureRowsParams = serde_json::from_value(args.clone())
+        .map_err(|e| Error::InvalidData(format!("invalid move_structure_rows params: {e}")))?;
+    let result = provider
+        .move_structure_rows(
+            params.structure_id,
+            MoveStructureRowsInput {
+                row_ids: params.row_ids,
+                under: params.under,
+                after: params.after,
+                forest_version: params.forest_version,
+            },
+        )
+        .await?;
+    Ok(ToolOutput::ForestModified(result))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RemoveStructureRowParams {
+    structure_id: u64,
+    row_id: u64,
+}
+
+async fn execute_remove_structure_row(
+    provider: &dyn devboy_core::Provider,
+    args: &Value,
+) -> Result<ToolOutput> {
+    let params: RemoveStructureRowParams = serde_json::from_value(args.clone())
+        .map_err(|e| Error::InvalidData(format!("invalid remove_structure_row params: {e}")))?;
+    provider
+        .remove_structure_row(params.structure_id, params.row_id)
+        .await?;
+    Ok(ToolOutput::Text(format!(
+        "Row {} removed from structure {}",
+        params.row_id, params.structure_id
+    )))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GetStructureValuesParams {
+    structure_id: u64,
+    rows: Vec<u64>,
+    columns: Vec<Value>,
+}
+
+async fn execute_get_structure_values(
+    provider: &dyn devboy_core::Provider,
+    args: &Value,
+) -> Result<ToolOutput> {
+    let params: GetStructureValuesParams = serde_json::from_value(args.clone())
+        .map_err(|e| Error::InvalidData(format!("invalid get_structure_values params: {e}")))?;
+
+    let columns: Vec<StructureViewColumn> = params
+        .columns
+        .into_iter()
+        .map(|v| {
+            if let Some(s) = v.as_str() {
+                StructureViewColumn {
+                    field: Some(s.to_string()),
+                    ..Default::default()
+                }
+            } else {
+                serde_json::from_value(v).unwrap_or_default()
+            }
+        })
+        .collect();
+
+    let result = provider
+        .get_structure_values(GetStructureValuesInput {
+            structure_id: params.structure_id,
+            rows: params.rows,
+            columns,
+        })
+        .await?;
+    Ok(ToolOutput::StructureValues(Box::new(result)))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GetStructureViewsParams {
+    structure_id: u64,
+    view_id: Option<u64>,
+}
+
+async fn execute_get_structure_views(
+    provider: &dyn devboy_core::Provider,
+    args: &Value,
+) -> Result<ToolOutput> {
+    let params: GetStructureViewsParams = serde_json::from_value(args.clone())
+        .map_err(|e| Error::InvalidData(format!("invalid get_structure_views params: {e}")))?;
+    let views = provider
+        .get_structure_views(params.structure_id, params.view_id)
+        .await?;
+    Ok(ToolOutput::StructureViews(views, None))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SaveStructureViewParams {
+    id: Option<u64>,
+    structure_id: u64,
+    name: String,
+    columns: Option<Vec<Value>>,
+    group_by: Option<String>,
+    sort_by: Option<String>,
+    filter: Option<String>,
+}
+
+async fn execute_save_structure_view(
+    provider: &dyn devboy_core::Provider,
+    args: &Value,
+) -> Result<ToolOutput> {
+    let params: SaveStructureViewParams = serde_json::from_value(args.clone())
+        .map_err(|e| Error::InvalidData(format!("invalid save_structure_view params: {e}")))?;
+
+    let columns: Option<Vec<StructureViewColumn>> = params.columns.map(|cols| {
+        cols.into_iter()
+            .map(|v| serde_json::from_value(v).unwrap_or_default())
+            .collect()
+    });
+
+    let view = provider
+        .save_structure_view(SaveStructureViewInput {
+            id: params.id,
+            structure_id: params.structure_id,
+            name: params.name,
+            columns,
+            group_by: params.group_by,
+            sort_by: params.sort_by,
+            filter: params.filter,
+        })
+        .await?;
+    Ok(ToolOutput::StructureViews(vec![view], None))
+}
+
+#[derive(Deserialize)]
+struct CreateStructureParams {
+    name: String,
+    description: Option<String>,
+}
+
+async fn execute_create_structure(
+    provider: &dyn devboy_core::Provider,
+    args: &Value,
+) -> Result<ToolOutput> {
+    let params: CreateStructureParams = serde_json::from_value(args.clone())
+        .map_err(|e| Error::InvalidData(format!("missing 'name': {e}")))?;
+    let structure = provider
+        .create_structure(CreateStructureInput {
+            name: params.name,
+            description: params.description,
+        })
+        .await?;
+    Ok(ToolOutput::Structures(vec![structure], None))
 }
 
 #[cfg(test)]

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -322,25 +322,43 @@ pub fn format_output(
                 None,
             ))
         }
-        // Jira Structure outputs — serialize as JSON
+        // Jira Structure outputs — serialize as JSON. Match the
+        // `Relations` branch above: surface serialisation errors as
+        // `InvalidData` rather than silently emitting an empty body.
         ToolOutput::Structures(items, _meta) => {
-            let json = serde_json::to_string_pretty(&items).unwrap_or_default();
+            let json = serde_json::to_string_pretty(&items).map_err(|e| {
+                devboy_core::Error::InvalidData(format!("failed to serialize structures: {e}"))
+            })?;
             Ok(text_result(json, None, None))
         }
         ToolOutput::StructureForest(forest) => {
-            let json = serde_json::to_string_pretty(&*forest).unwrap_or_default();
+            let json = serde_json::to_string_pretty(&*forest).map_err(|e| {
+                devboy_core::Error::InvalidData(format!(
+                    "failed to serialize structure forest: {e}"
+                ))
+            })?;
             Ok(text_result(json, None, None))
         }
         ToolOutput::StructureValues(values) => {
-            let json = serde_json::to_string_pretty(&*values).unwrap_or_default();
+            let json = serde_json::to_string_pretty(&*values).map_err(|e| {
+                devboy_core::Error::InvalidData(format!(
+                    "failed to serialize structure values: {e}"
+                ))
+            })?;
             Ok(text_result(json, None, None))
         }
         ToolOutput::StructureViews(views, _meta) => {
-            let json = serde_json::to_string_pretty(&views).unwrap_or_default();
+            let json = serde_json::to_string_pretty(&views).map_err(|e| {
+                devboy_core::Error::InvalidData(format!("failed to serialize structure views: {e}"))
+            })?;
             Ok(text_result(json, None, None))
         }
         ToolOutput::ForestModified(result) => {
-            let json = serde_json::to_string_pretty(&result).unwrap_or_default();
+            let json = serde_json::to_string_pretty(&result).map_err(|e| {
+                devboy_core::Error::InvalidData(format!(
+                    "failed to serialize forest modification result: {e}"
+                ))
+            })?;
             Ok(text_result(json, None, None))
         }
         ToolOutput::Text(text) => Ok(text_result(text, None, None)),

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -322,6 +322,27 @@ pub fn format_output(
                 None,
             ))
         }
+        // Jira Structure outputs — serialize as JSON
+        ToolOutput::Structures(items, _meta) => {
+            let json = serde_json::to_string_pretty(&items).unwrap_or_default();
+            Ok(text_result(json, None, None))
+        }
+        ToolOutput::StructureForest(forest) => {
+            let json = serde_json::to_string_pretty(&*forest).unwrap_or_default();
+            Ok(text_result(json, None, None))
+        }
+        ToolOutput::StructureValues(values) => {
+            let json = serde_json::to_string_pretty(&*values).unwrap_or_default();
+            Ok(text_result(json, None, None))
+        }
+        ToolOutput::StructureViews(views, _meta) => {
+            let json = serde_json::to_string_pretty(&views).unwrap_or_default();
+            Ok(text_result(json, None, None))
+        }
+        ToolOutput::ForestModified(result) => {
+            let json = serde_json::to_string_pretty(&result).unwrap_or_default();
+            Ok(text_result(json, None, None))
+        }
         ToolOutput::Text(text) => Ok(text_result(text, None, None)),
     }
 }

--- a/crates/devboy-executor/src/output.rs
+++ b/crates/devboy-executor/src/output.rs
@@ -324,12 +324,12 @@ mod tests {
             1
         );
         assert_eq!(
-            ToolOutput::StructureForest(Box::new(devboy_core::StructureForest::default()))
+            ToolOutput::StructureForest(Box::<devboy_core::StructureForest>::default())
                 .item_count(),
             1
         );
         assert_eq!(
-            ToolOutput::StructureValues(Box::new(devboy_core::StructureValues::default()))
+            ToolOutput::StructureValues(Box::<devboy_core::StructureValues>::default())
                 .item_count(),
             1
         );
@@ -401,13 +401,11 @@ mod tests {
             "structures"
         );
         assert_eq!(
-            ToolOutput::StructureForest(Box::new(devboy_core::StructureForest::default()))
-                .type_name(),
+            ToolOutput::StructureForest(Box::<devboy_core::StructureForest>::default()).type_name(),
             "structure_forest"
         );
         assert_eq!(
-            ToolOutput::StructureValues(Box::new(devboy_core::StructureValues::default()))
-                .type_name(),
+            ToolOutput::StructureValues(Box::<devboy_core::StructureValues>::default()).type_name(),
             "structure_values"
         );
         assert_eq!(
@@ -493,7 +491,7 @@ mod tests {
                 .is_none()
         );
         assert!(
-            ToolOutput::StructureForest(Box::new(devboy_core::StructureForest::default()))
+            ToolOutput::StructureForest(Box::<devboy_core::StructureForest>::default())
                 .result_meta()
                 .is_none()
         );

--- a/crates/devboy-executor/src/output.rs
+++ b/crates/devboy-executor/src/output.rs
@@ -310,6 +310,34 @@ mod tests {
         );
         assert_eq!(ToolOutput::Users(vec![], None).item_count(), 0);
         assert_eq!(ToolOutput::Relations(Box::default()).item_count(), 1);
+        assert_eq!(ToolOutput::Structures(vec![], None).item_count(), 0);
+        assert_eq!(
+            ToolOutput::Structures(
+                vec![devboy_core::Structure {
+                    id: 1,
+                    name: "S".into(),
+                    description: None
+                }],
+                None
+            )
+            .item_count(),
+            1
+        );
+        assert_eq!(
+            ToolOutput::StructureForest(Box::new(devboy_core::StructureForest::default()))
+                .item_count(),
+            1
+        );
+        assert_eq!(
+            ToolOutput::StructureValues(Box::new(devboy_core::StructureValues::default()))
+                .item_count(),
+            1
+        );
+        assert_eq!(ToolOutput::StructureViews(vec![], None).item_count(), 0);
+        assert_eq!(
+            ToolOutput::ForestModified(devboy_core::ForestModifyResult::default()).item_count(),
+            1
+        );
         assert_eq!(ToolOutput::Text("x".into()).item_count(), 1);
     }
 
@@ -368,6 +396,28 @@ mod tests {
             "issue_relations"
         );
         assert_eq!(ToolOutput::Text("x".into()).type_name(), "text");
+        assert_eq!(
+            ToolOutput::Structures(vec![], None).type_name(),
+            "structures"
+        );
+        assert_eq!(
+            ToolOutput::StructureForest(Box::new(devboy_core::StructureForest::default()))
+                .type_name(),
+            "structure_forest"
+        );
+        assert_eq!(
+            ToolOutput::StructureValues(Box::new(devboy_core::StructureValues::default()))
+                .type_name(),
+            "structure_values"
+        );
+        assert_eq!(
+            ToolOutput::StructureViews(vec![], None).type_name(),
+            "structure_views"
+        );
+        assert_eq!(
+            ToolOutput::ForestModified(devboy_core::ForestModifyResult::default()).type_name(),
+            "forest_modified"
+        );
     }
 
     #[test]
@@ -433,6 +483,17 @@ mod tests {
         assert!(ToolOutput::Users(vec![], None).result_meta().is_none());
         assert!(
             ToolOutput::MeetingNotes(vec![], None)
+                .result_meta()
+                .is_none()
+        );
+        assert!(ToolOutput::Structures(vec![], None).result_meta().is_none());
+        assert!(
+            ToolOutput::StructureViews(vec![], None)
+                .result_meta()
+                .is_none()
+        );
+        assert!(
+            ToolOutput::StructureForest(Box::new(devboy_core::StructureForest::default()))
                 .result_meta()
                 .is_none()
         );

--- a/crates/devboy-executor/src/output.rs
+++ b/crates/devboy-executor/src/output.rs
@@ -1,7 +1,8 @@
 use devboy_core::{
-    Comment, Discussion, FileDiff, Issue, IssueRelations, IssueStatus, JobLogOutput, MeetingNote,
-    MeetingTranscript, MergeRequest, MessengerChat, MessengerMessage, Pagination, PipelineInfo,
-    SortInfo, User,
+    Comment, Discussion, FileDiff, ForestModifyResult, Issue, IssueRelations, IssueStatus,
+    JobLogOutput, MeetingNote, MeetingTranscript, MergeRequest, MessengerChat, MessengerMessage,
+    Pagination, PipelineInfo, SortInfo, Structure, StructureForest, StructureValues, StructureView,
+    User,
 };
 
 /// Metadata from provider result (pagination + sort info).
@@ -90,6 +91,16 @@ pub enum ToolOutput {
         /// Human-readable confirmation message.
         message: String,
     },
+    /// List of Jira Structures
+    Structures(Vec<Structure>, Option<ResultMeta>),
+    /// Structure forest (hierarchy tree)
+    StructureForest(Box<StructureForest>),
+    /// Structure column values
+    StructureValues(Box<StructureValues>),
+    /// Structure views
+    StructureViews(Vec<StructureView>, Option<ResultMeta>),
+    /// Forest modification result (add/move rows)
+    ForestModified(ForestModifyResult),
     /// Plain text result (e.g., "Comment created successfully")
     Text(String),
 }
@@ -108,6 +119,8 @@ impl ToolOutput {
             Self::MeetingNotes(v, _) => v.len(),
             Self::MessengerChats(v, _) => v.len(),
             Self::MessengerMessages(v, _) => v.len(),
+            Self::Structures(v, _) => v.len(),
+            Self::StructureViews(v, _) => v.len(),
             Self::AssetList { count, .. } => *count,
             Self::SingleMergeRequest(_)
             | Self::SingleIssue(_)
@@ -116,6 +129,9 @@ impl ToolOutput {
             | Self::MeetingTranscript(_)
             | Self::Relations(_)
             | Self::SingleMessage(_)
+            | Self::StructureForest(_)
+            | Self::StructureValues(_)
+            | Self::ForestModified(_)
             | Self::AssetDownloaded { .. }
             | Self::AssetUploaded { .. }
             | Self::AssetDeleted { .. }
@@ -143,6 +159,11 @@ impl ToolOutput {
             Self::MessengerChats(..) => "messenger_chats",
             Self::MessengerMessages(..) => "messenger_messages",
             Self::SingleMessage(_) => "messenger_message",
+            Self::Structures(..) => "structures",
+            Self::StructureForest(_) => "structure_forest",
+            Self::StructureValues(_) => "structure_values",
+            Self::StructureViews(..) => "structure_views",
+            Self::ForestModified(_) => "forest_modified",
             Self::AssetList { .. } => "asset_list",
             Self::AssetDownloaded { .. } => "asset_downloaded",
             Self::AssetUploaded { .. } => "asset_uploaded",
@@ -163,7 +184,9 @@ impl ToolOutput {
             | Self::Users(_, meta)
             | Self::MeetingNotes(_, meta)
             | Self::MessengerChats(_, meta)
-            | Self::MessengerMessages(_, meta) => meta.as_ref(),
+            | Self::MessengerMessages(_, meta)
+            | Self::Structures(_, meta)
+            | Self::StructureViews(_, meta) => meta.as_ref(),
             _ => None,
         }
     }

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -605,7 +605,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                     "Row IDs to read values for",
                 ));
                 s.add_property("columns", PropertySchema::array(
-                    PropertySchema::string("Column spec: field name (e.g. 'summary'), or JSON {\"field\":\"status\"} or {\"formula\":\"SUM(\\\"Story Points\\\")\"})"),
+                    PropertySchema::string("Column spec: field name (e.g. 'summary'), or JSON {\"field\":\"status\"} or {\"formula\":\"SUM(\\\"Story Points\\\")\"}"),
                     "Columns to read",
                 ));
                 s.set_required("structureId", true);

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -522,6 +522,143 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s
             },
         },
+        // Jira Structure plugin tools
+        ToolDefinition {
+            name: "get_structures".into(),
+            description: "List all available Jira Structures. Returns structure ID, name, and description. Requires Jira with Structure plugin.".into(),
+            category: ToolCategory::JiraStructure,
+            input_schema: ToolSchema::new(),
+        },
+        ToolDefinition {
+            name: "get_structure_forest".into(),
+            description: "Get the hierarchy tree of a Jira Structure. Returns nested tree with rowId, itemId (Jira issue key), itemType, and children. Supports pagination for large structures.".into(),
+            category: ToolCategory::JiraStructure,
+            input_schema: {
+                let mut s = ToolSchema::new();
+                s.add_property("structureId", PropertySchema::integer("Structure ID. Use get_structures to find it.", None, None));
+                s.add_property("offset", PropertySchema::integer("Offset for pagination (default: 0)", Some(0.0), None));
+                s.add_property("limit", PropertySchema::integer("Max rows to return (default: 200)", Some(1.0), Some(10000.0)));
+                s.set_required("structureId", true);
+                s
+            },
+        },
+        ToolDefinition {
+            name: "add_structure_rows".into(),
+            description: "Add items (Jira issues or folders) to a Structure. Specify position with under (parent row) and/or after (sibling row). Use forestVersion for optimistic concurrency.".into(),
+            category: ToolCategory::JiraStructure,
+            input_schema: {
+                let mut s = ToolSchema::new();
+                s.add_property("structureId", PropertySchema::integer("Structure ID", None, None));
+                s.add_property("items", PropertySchema::array(
+                    PropertySchema::string("Item: Jira issue key (e.g. 'PROJ-123') or JSON {\"itemId\":\"PROJ-123\",\"itemType\":\"issue\"}"),
+                    "Items to add",
+                ));
+                s.add_property("under", PropertySchema::integer("Parent row ID — items become children of this row", None, None));
+                s.add_property("after", PropertySchema::integer("Sibling row ID — items placed after this row", None, None));
+                s.add_property("forestVersion", PropertySchema::integer("Forest version for optimistic locking (from get_structure_forest)", None, None));
+                s.set_required("structureId", true);
+                s.set_required("items", true);
+                s
+            },
+        },
+        ToolDefinition {
+            name: "move_structure_rows".into(),
+            description: "Move rows within a Jira Structure hierarchy. Specify new position with under (new parent) and/or after (sibling).".into(),
+            category: ToolCategory::JiraStructure,
+            input_schema: {
+                let mut s = ToolSchema::new();
+                s.add_property("structureId", PropertySchema::integer("Structure ID", None, None));
+                s.add_property("rowIds", PropertySchema::array(
+                    PropertySchema::integer("Row ID", None, None),
+                    "Row IDs to move (from get_structure_forest)",
+                ));
+                s.add_property("under", PropertySchema::integer("New parent row ID", None, None));
+                s.add_property("after", PropertySchema::integer("Sibling row ID to place after", None, None));
+                s.add_property("forestVersion", PropertySchema::integer("Forest version for optimistic locking", None, None));
+                s.set_required("structureId", true);
+                s.set_required("rowIds", true);
+                s
+            },
+        },
+        ToolDefinition {
+            name: "remove_structure_row".into(),
+            description: "Remove a row from a Jira Structure. Only removes from the structure hierarchy — the underlying Jira issue is NOT deleted.".into(),
+            category: ToolCategory::JiraStructure,
+            input_schema: {
+                let mut s = ToolSchema::new();
+                s.add_property("structureId", PropertySchema::integer("Structure ID", None, None));
+                s.add_property("rowId", PropertySchema::integer("Row ID to remove (from get_structure_forest)", None, None));
+                s.set_required("structureId", true);
+                s.set_required("rowId", true);
+                s
+            },
+        },
+        ToolDefinition {
+            name: "get_structure_values".into(),
+            description: "Read column values (including Expr formulas like SUM, PROGRESS, COUNT) for specific rows in a Jira Structure. Values are computed server-side.".into(),
+            category: ToolCategory::JiraStructure,
+            input_schema: {
+                let mut s = ToolSchema::new();
+                s.add_property("structureId", PropertySchema::integer("Structure ID", None, None));
+                s.add_property("rows", PropertySchema::array(
+                    PropertySchema::integer("Row ID", None, None),
+                    "Row IDs to read values for",
+                ));
+                s.add_property("columns", PropertySchema::array(
+                    PropertySchema::string("Column spec: field name (e.g. 'summary'), or JSON {\"field\":\"status\"} or {\"formula\":\"SUM(\\\"Story Points\\\")\"})"),
+                    "Columns to read",
+                ));
+                s.set_required("structureId", true);
+                s.set_required("rows", true);
+                s.set_required("columns", true);
+                s
+            },
+        },
+        ToolDefinition {
+            name: "get_structure_views".into(),
+            description: "Get views for a Jira Structure. Without viewId: lists all views. With viewId: returns full view configuration (columns, grouping, sorting, filter).".into(),
+            category: ToolCategory::JiraStructure,
+            input_schema: {
+                let mut s = ToolSchema::new();
+                s.add_property("structureId", PropertySchema::integer("Structure ID", None, None));
+                s.add_property("viewId", PropertySchema::integer("View ID for full config (optional — omit to list all views)", None, None));
+                s.set_required("structureId", true);
+                s
+            },
+        },
+        ToolDefinition {
+            name: "save_structure_view".into(),
+            description: "Create or update a Jira Structure view. Views define column layout (fields and formulas), grouping, sorting, and filters. Omit id to create new.".into(),
+            category: ToolCategory::JiraStructure,
+            input_schema: {
+                let mut s = ToolSchema::new();
+                s.add_property("id", PropertySchema::integer("View ID to update (omit to create new)", None, None));
+                s.add_property("structureId", PropertySchema::integer("Structure ID this view belongs to", None, None));
+                s.add_property("name", PropertySchema::string("View name"));
+                s.add_property("columns", PropertySchema::array(
+                    PropertySchema::string("Column spec: JSON {\"field\":\"summary\"} or {\"formula\":\"SUM(\\\"Story Points\\\")\",\"width\":100}"),
+                    "Column definitions",
+                ));
+                s.add_property("groupBy", PropertySchema::string("Field name to group by"));
+                s.add_property("sortBy", PropertySchema::string("Field name to sort by"));
+                s.add_property("filter", PropertySchema::string("JQL filter expression"));
+                s.set_required("structureId", true);
+                s.set_required("name", true);
+                s
+            },
+        },
+        ToolDefinition {
+            name: "create_structure".into(),
+            description: "Create a new Jira Structure. After creation, use add_structure_rows to populate and save_structure_view to configure columns.".into(),
+            category: ToolCategory::JiraStructure,
+            input_schema: {
+                let mut s = ToolSchema::new();
+                s.add_property("name", PropertySchema::string("Structure name"));
+                s.add_property("description", PropertySchema::string("Structure description"));
+                s.set_required("name", true);
+                s
+            },
+        },
     ]
 }
 
@@ -532,7 +669,7 @@ mod tests {
     #[test]
     fn test_base_definitions_count() {
         let tools = base_tool_definitions();
-        assert_eq!(tools.len(), 34);
+        assert_eq!(tools.len(), 43);
     }
 
     #[test]
@@ -587,6 +724,17 @@ mod tests {
             "search_chat_messages",
             "send_message",
         ];
+        let jira_structure_tools = [
+            "get_structures",
+            "get_structure_forest",
+            "add_structure_rows",
+            "move_structure_rows",
+            "remove_structure_row",
+            "get_structure_values",
+            "get_structure_views",
+            "save_structure_view",
+            "create_structure",
+        ];
 
         for tool in &tools {
             if issue_tracker_tools.contains(&tool.name.as_str()) {
@@ -622,6 +770,13 @@ mod tests {
                     tool.category,
                     ToolCategory::Messenger,
                     "tool {} should be Messenger",
+                    tool.name
+                );
+            } else if jira_structure_tools.contains(&tool.name.as_str()) {
+                assert_eq!(
+                    tool.category,
+                    ToolCategory::JiraStructure,
+                    "tool {} should be JiraStructure",
                     tool.name
                 );
             } else {

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -48,6 +48,16 @@ pub const KNOWN_BUILTIN_TOOLS: &[&str] = &[
     "get_chat_messages",
     "search_chat_messages",
     "send_message",
+    // Jira Structure plugin tools
+    "get_structures",
+    "get_structure_forest",
+    "add_structure_rows",
+    "move_structure_rows",
+    "remove_structure_row",
+    "get_structure_values",
+    "get_structure_views",
+    "save_structure_view",
+    "create_structure",
     // Context management (handled by McpServer directly)
     "list_contexts",
     "use_context",

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -410,6 +410,7 @@ impl McpServer {
                     devboy_core::ToolCategory::MeetingNotes => has_meeting_providers,
                     devboy_core::ToolCategory::Messenger => has_messenger_providers,
                     devboy_core::ToolCategory::Releases => has_mr_providers,
+                    devboy_core::ToolCategory::JiraStructure => has_issue_providers,
                 })
                 .unwrap_or(true) // Tools without category are always available
         });

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -381,6 +381,12 @@ impl McpServer {
                 "github" | "gitlab"
             )
         });
+        // Jira Structure is a Jira-only add-on; don't expose the
+        // category under GitHub/GitLab/ClickUp — every call would
+        // return ProviderUnsupported and pollute the tool list.
+        let has_jira_provider = providers
+            .iter()
+            .any(|p| IssueProvider::provider_name(p.as_ref()) == "jira");
         let has_meeting_providers = !self.meeting_providers.is_empty();
         let has_messenger_providers = !self.active_messenger_providers().is_empty();
 
@@ -410,7 +416,7 @@ impl McpServer {
                     devboy_core::ToolCategory::MeetingNotes => has_meeting_providers,
                     devboy_core::ToolCategory::Messenger => has_messenger_providers,
                     devboy_core::ToolCategory::Releases => has_mr_providers,
-                    devboy_core::ToolCategory::JiraStructure => has_issue_providers,
+                    devboy_core::ToolCategory::JiraStructure => has_jira_provider,
                 })
                 .unwrap_or(true) // Tools without category are always available
         });

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -519,8 +519,15 @@ impl JiraClient {
     // =========================================================================
 
     /// Build a URL for the Structure REST API.
+    ///
+    /// Uses the same root as the regular REST API (`base_url` with the
+    /// `/rest/api/{2,3}` suffix stripped) so that Structure calls go
+    /// through the configured proxy — `instance_url` is intentionally
+    /// reserved for browse links and bypasses any proxy headers/auth
+    /// installed via [`JiraClient::with_proxy`].
     fn structure_url(&self, endpoint: &str) -> String {
-        format!("{}/rest/structure/2.0{}", self.instance_url, endpoint)
+        let root = instance_url_from_base(&self.base_url);
+        format!("{}/rest/structure/2.0{}", root, endpoint)
     }
 
     /// Make an authenticated GET request to the Structure API.
@@ -1113,13 +1120,27 @@ fn instance_url_from_base(base_url: &str) -> String {
 // Structure helpers
 // =============================================================================
 
-/// Transform compact `rows[] + depths[]` from Structure API into a nested tree.
-fn build_forest_tree(rows: &[crate::types::JiraForestRow], depths: &[u32]) -> Vec<StructureNode> {
+/// Transform compact `rows[] + depths[]` from Structure API into a
+/// nested tree. Returns `InvalidData` if the two vectors are not the
+/// same length — the Structure API contract guarantees alignment, and
+/// a mismatch here would otherwise silently nest rows at depth 0 and
+/// produce a subtly wrong tree.
+fn build_forest_tree(
+    rows: &[crate::types::JiraForestRow],
+    depths: &[u32],
+) -> Result<Vec<StructureNode>> {
+    if rows.len() != depths.len() {
+        return Err(Error::InvalidData(format!(
+            "Structure forest response has {} rows but {} depths",
+            rows.len(),
+            depths.len()
+        )));
+    }
     let mut roots: Vec<StructureNode> = Vec::new();
     let mut stack: Vec<StructureNode> = Vec::new();
 
-    for (i, row) in rows.iter().enumerate() {
-        let depth = depths.get(i).copied().unwrap_or(0) as usize;
+    for (row, depth) in rows.iter().zip(depths.iter()) {
+        let depth = *depth as usize;
         let node = StructureNode {
             row_id: row.id,
             item_id: row.item_id.clone(),
@@ -1129,7 +1150,7 @@ fn build_forest_tree(rows: &[crate::types::JiraForestRow], depths: &[u32]) -> Ve
 
         // Pop stack to find parent at depth - 1
         while stack.len() > depth {
-            let child = stack.pop().unwrap();
+            let child = stack.pop().expect("stack.len() > depth > 0");
             if let Some(parent) = stack.last_mut() {
                 parent.children.push(child);
             } else {
@@ -1149,7 +1170,7 @@ fn build_forest_tree(rows: &[crate::types::JiraForestRow], depths: &[u32]) -> Ve
         }
     }
 
-    roots
+    Ok(roots)
 }
 
 /// Map Jira Structure view to unified type.
@@ -1875,7 +1896,7 @@ impl IssueProvider for JiraClient {
             )
             .await?;
 
-        let tree = build_forest_tree(&resp.rows, &resp.depths);
+        let tree = build_forest_tree(&resp.rows, &resp.depths)?;
 
         Ok(StructureForest {
             version: resp.version,
@@ -2003,15 +2024,24 @@ impl IssueProvider for JiraClient {
 
         let resp: JiraStructureValuesResponse = self.structure_post("/value", &payload).await?;
 
-        // Group values by row_id
+        // Group values by row_id. A missing `columnId` is treated as
+        // an error rather than defaulted to `""` — silently bucketing
+        // unknown columns under the empty-string key would merge
+        // values from different columns and destroy user data.
         let mut row_map: std::collections::BTreeMap<u64, Vec<StructureColumnValue>> =
             std::collections::BTreeMap::new();
         for entry in resp.values {
+            let column = entry.column_id.ok_or_else(|| {
+                Error::InvalidData(format!(
+                    "Structure value for row {} is missing `columnId`",
+                    entry.row_id
+                ))
+            })?;
             row_map
                 .entry(entry.row_id)
                 .or_default()
                 .push(StructureColumnValue {
-                    column: entry.column_id.unwrap_or_default(),
+                    column,
                     value: entry.value,
                 });
         }
@@ -2034,6 +2064,17 @@ impl IssueProvider for JiraClient {
     ) -> Result<Vec<StructureView>> {
         if let Some(id) = view_id {
             let view: JiraStructureView = self.structure_get(&format!("/view/{}", id)).await?;
+            // Validate that the returned view actually belongs to the
+            // requested structure — the Structure API's `/view/{id}`
+            // endpoint ignores the structure id in the request, so a
+            // caller who mixes up ids would otherwise silently see a
+            // view from a different structure.
+            if view.structure_id != structure_id {
+                return Err(Error::InvalidData(format!(
+                    "view {id} belongs to structure {} but {structure_id} was requested",
+                    view.structure_id
+                )));
+            }
             Ok(vec![map_structure_view(view)])
         } else {
             let resp: JiraStructureViewListResponse = self
@@ -5086,7 +5127,7 @@ mod tests {
 
     #[test]
     fn test_build_forest_tree_empty() {
-        let tree = build_forest_tree(&[], &[]);
+        let tree = build_forest_tree(&[], &[]).unwrap();
         assert!(tree.is_empty());
     }
 
@@ -5105,12 +5146,27 @@ mod tests {
             },
         ];
         let depths = vec![0, 0];
-        let tree = build_forest_tree(&rows, &depths);
+        let tree = build_forest_tree(&rows, &depths).unwrap();
         assert_eq!(tree.len(), 2);
         assert_eq!(tree[0].row_id, 1);
         assert_eq!(tree[1].row_id, 2);
         assert!(tree[0].children.is_empty());
         assert!(tree[1].children.is_empty());
+    }
+
+    #[test]
+    fn test_build_forest_tree_rejects_mismatched_lengths() {
+        let rows = vec![JiraForestRow {
+            id: 1,
+            item_id: Some("PROJ-1".into()),
+            item_type: None,
+        }];
+        let depths = vec![0, 1];
+        let err = build_forest_tree(&rows, &depths).expect_err("mismatch must be rejected");
+        assert!(
+            matches!(err, Error::InvalidData(ref msg) if msg.contains("1 rows but 2 depths")),
+            "unexpected error: {err:?}"
+        );
     }
 
     #[test]
@@ -5142,7 +5198,7 @@ mod tests {
             },
         ];
         let depths = vec![0, 1, 2, 1];
-        let tree = build_forest_tree(&rows, &depths);
+        let tree = build_forest_tree(&rows, &depths).unwrap();
 
         assert_eq!(tree.len(), 1);
         assert_eq!(tree[0].row_id, 1);
@@ -5179,7 +5235,7 @@ mod tests {
             },
         ];
         let depths = vec![0, 1, 0, 1];
-        let tree = build_forest_tree(&rows, &depths);
+        let tree = build_forest_tree(&rows, &depths).unwrap();
 
         assert_eq!(tree.len(), 2);
         assert_eq!(tree[0].children.len(), 1);
@@ -5331,6 +5387,55 @@ mod tests {
             let views = client.get_structure_views(1, None).await.unwrap();
             assert_eq!(views.len(), 2);
             assert_eq!(views[1].columns.len(), 3);
+        }
+
+        #[tokio::test]
+        async fn test_get_structure_views_by_id_accepts_matching_structure() {
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method(GET).path("/rest/structure/2.0/view/10");
+                then.status(200).json_body(serde_json::json!({
+                    "id": 10,
+                    "name": "Default View",
+                    "structureId": 1,
+                    "columns": []
+                }));
+            });
+
+            let client = create_client(&server);
+            let views = client.get_structure_views(1, Some(10)).await.unwrap();
+            assert_eq!(views.len(), 1);
+            assert_eq!(views[0].id, 10);
+        }
+
+        #[tokio::test]
+        async fn test_get_structure_views_by_id_rejects_cross_structure_view() {
+            // View 99 actually lives in structure 7 — a caller who asked
+            // for `structureId=1` must see InvalidData, not a surprise
+            // view from a different structure.
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method(GET).path("/rest/structure/2.0/view/99");
+                then.status(200).json_body(serde_json::json!({
+                    "id": 99,
+                    "name": "Sibling view",
+                    "structureId": 7,
+                    "columns": []
+                }));
+            });
+
+            let client = create_client(&server);
+            let err = client
+                .get_structure_views(1, Some(99))
+                .await
+                .expect_err("mismatched structure must error");
+            match err {
+                Error::InvalidData(msg) => {
+                    assert!(msg.contains("belongs to structure 7"), "got: {msg}");
+                    assert!(msg.contains("but 1 was requested"), "got: {msg}");
+                }
+                other => panic!("expected InvalidData, got {other:?}"),
+            }
         }
     }
 }

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -5197,7 +5197,7 @@ mod tests {
         fn create_client(server: &MockServer) -> JiraClient {
             // with_base_url sets base_url WITHOUT /rest/api/N,
             // but Structure uses instance_url. Adjust:
-            
+
             // instance_url is set to base_url by with_base_url
             JiraClient::with_base_url(
                 server.base_url(),

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -17,18 +17,23 @@ fn safe_char_boundary(s: &str, max_bytes: usize) -> usize {
 
 use async_trait::async_trait;
 use devboy_core::{
-    AssetCapabilities, AssetMeta, Comment, ContextCapabilities, CreateIssueInput, Error,
-    GetUsersOptions, Issue, IssueFilter, IssueLink, IssueProvider, IssueRelations, IssueStatus,
-    MergeRequestProvider, PipelineProvider, Provider, ProviderResult, Result, UpdateIssueInput,
-    User,
+    AddStructureRowsInput, AssetCapabilities, AssetMeta, Comment, ContextCapabilities,
+    CreateIssueInput, CreateStructureInput, Error, ForestModifyResult, GetForestOptions,
+    GetStructureValuesInput, GetUsersOptions, Issue, IssueFilter, IssueLink, IssueProvider,
+    IssueRelations, IssueStatus, MergeRequestProvider, MoveStructureRowsInput, PipelineProvider,
+    Provider, ProviderResult, Result, SaveStructureViewInput, Structure, StructureColumnValue,
+    StructureForest, StructureNode, StructureRowValues, StructureValues, StructureView,
+    StructureViewColumn, UpdateIssueInput, User,
 };
 use tracing::{debug, warn};
 
 use crate::types::{
     AddCommentPayload, CreateIssueFields, CreateIssueLinkPayload, CreateIssuePayload,
     CreateIssueResponse, IssueKeyRef, IssueLinkTypeName, IssueType, JiraAttachment,
-    JiraCloudSearchResponse, JiraComment, JiraCommentsResponse, JiraIssue, JiraIssueTypeStatuses,
-    JiraPriority, JiraProjectStatus, JiraSearchResponse, JiraStatus, JiraTransition,
+    JiraCloudSearchResponse, JiraComment, JiraCommentsResponse, JiraForestModifyResponse,
+    JiraForestResponse, JiraIssue, JiraIssueTypeStatuses, JiraPriority, JiraProjectStatus,
+    JiraSearchResponse, JiraStatus, JiraStructure, JiraStructureListResponse,
+    JiraStructureValuesResponse, JiraStructureView, JiraStructureViewListResponse, JiraTransition,
     JiraTransitionsResponse, JiraUser, PriorityName, ProjectKey, TransitionId, TransitionPayload,
     UpdateIssueFields, UpdateIssuePayload,
 };
@@ -507,6 +512,78 @@ impl JiraClient {
         );
 
         Ok(statuses)
+    }
+
+    // =========================================================================
+    // Jira Structure Plugin API (/rest/structure/2.0/)
+    // =========================================================================
+
+    /// Build a URL for the Structure REST API.
+    fn structure_url(&self, endpoint: &str) -> String {
+        format!("{}/rest/structure/2.0{}", self.instance_url, endpoint)
+    }
+
+    /// Make an authenticated GET request to the Structure API.
+    async fn structure_get<T: serde::de::DeserializeOwned>(&self, endpoint: &str) -> Result<T> {
+        let url = self.structure_url(endpoint);
+        debug!(url = %url, "Jira Structure GET");
+        let response = self
+            .request(reqwest::Method::GET, &url)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+        self.handle_response(response).await
+    }
+
+    /// Make an authenticated POST request to the Structure API.
+    async fn structure_post<T: serde::de::DeserializeOwned, B: serde::Serialize>(
+        &self,
+        endpoint: &str,
+        body: &B,
+    ) -> Result<T> {
+        let url = self.structure_url(endpoint);
+        debug!(url = %url, "Jira Structure POST");
+        let response = self
+            .request(reqwest::Method::POST, &url)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+        self.handle_response(response).await
+    }
+
+    /// Make an authenticated PUT request to the Structure API (returns body).
+    async fn structure_put<T: serde::de::DeserializeOwned, B: serde::Serialize>(
+        &self,
+        endpoint: &str,
+        body: &B,
+    ) -> Result<T> {
+        let url = self.structure_url(endpoint);
+        debug!(url = %url, "Jira Structure PUT");
+        let response = self
+            .request(reqwest::Method::PUT, &url)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+        self.handle_response(response).await
+    }
+
+    /// Make an authenticated DELETE request to the Structure API.
+    async fn structure_delete_request(&self, endpoint: &str) -> Result<()> {
+        let url = self.structure_url(endpoint);
+        debug!(url = %url, "Jira Structure DELETE");
+        let response = self
+            .request(reqwest::Method::DELETE, &url)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            return Err(Error::from_status(status.as_u16(), message));
+        }
+        Ok(())
     }
 }
 
@@ -1030,6 +1107,71 @@ fn instance_url_from_base(base_url: &str) -> String {
         .trim_end_matches("/rest/api/3")
         .trim_end_matches("/rest/api/2")
         .to_string()
+}
+
+// =============================================================================
+// Structure helpers
+// =============================================================================
+
+/// Transform compact `rows[] + depths[]` from Structure API into a nested tree.
+fn build_forest_tree(rows: &[crate::types::JiraForestRow], depths: &[u32]) -> Vec<StructureNode> {
+    let mut roots: Vec<StructureNode> = Vec::new();
+    let mut stack: Vec<StructureNode> = Vec::new();
+
+    for (i, row) in rows.iter().enumerate() {
+        let depth = depths.get(i).copied().unwrap_or(0) as usize;
+        let node = StructureNode {
+            row_id: row.id,
+            item_id: row.item_id.clone(),
+            item_type: row.item_type.clone(),
+            children: Vec::new(),
+        };
+
+        // Pop stack to find parent at depth - 1
+        while stack.len() > depth {
+            let child = stack.pop().unwrap();
+            if let Some(parent) = stack.last_mut() {
+                parent.children.push(child);
+            } else {
+                roots.push(child);
+            }
+        }
+
+        stack.push(node);
+    }
+
+    // Flush remaining stack
+    while let Some(child) = stack.pop() {
+        if let Some(parent) = stack.last_mut() {
+            parent.children.push(child);
+        } else {
+            roots.push(child);
+        }
+    }
+
+    roots
+}
+
+/// Map Jira Structure view to unified type.
+fn map_structure_view(view: crate::types::JiraStructureView) -> StructureView {
+    StructureView {
+        id: view.id,
+        name: view.name,
+        structure_id: view.structure_id,
+        columns: view
+            .columns
+            .into_iter()
+            .map(|c| StructureViewColumn {
+                id: c.id,
+                field: c.field,
+                formula: c.formula,
+                width: c.width,
+            })
+            .collect(),
+        group_by: view.group_by,
+        sort_by: view.sort_by,
+        filter: view.filter,
+    }
 }
 
 // =============================================================================
@@ -1695,6 +1837,269 @@ impl IssueProvider for JiraClient {
             },
             ..Default::default()
         }
+    }
+
+    // --- Jira Structure plugin ---
+
+    async fn get_structures(&self) -> Result<ProviderResult<Structure>> {
+        let resp: JiraStructureListResponse = self.structure_get("/structure").await?;
+        let items: Vec<Structure> = resp
+            .structures
+            .into_iter()
+            .map(|s| Structure {
+                id: s.id,
+                name: s.name,
+                description: s.description,
+            })
+            .collect();
+        Ok(items.into())
+    }
+
+    async fn get_structure_forest(
+        &self,
+        structure_id: u64,
+        options: GetForestOptions,
+    ) -> Result<StructureForest> {
+        let mut spec = serde_json::Map::new();
+        if let Some(offset) = options.offset {
+            spec.insert("offset".into(), serde_json::json!(offset));
+        }
+        if let Some(limit) = options.limit {
+            spec.insert("limit".into(), serde_json::json!(limit));
+        }
+
+        let resp: JiraForestResponse = self
+            .structure_post(
+                &format!("/forest/{}/spec", structure_id),
+                &serde_json::Value::Object(spec),
+            )
+            .await?;
+
+        let tree = build_forest_tree(&resp.rows, &resp.depths);
+
+        Ok(StructureForest {
+            version: resp.version,
+            structure_id,
+            tree,
+            total_count: resp.total_count,
+        })
+    }
+
+    async fn add_structure_rows(
+        &self,
+        structure_id: u64,
+        input: AddStructureRowsInput,
+    ) -> Result<ForestModifyResult> {
+        let mut payload = serde_json::json!({
+            "rows": input.items.iter().map(|i| {
+                let mut row = serde_json::json!({"itemId": i.item_id});
+                if let Some(ref t) = i.item_type {
+                    row["itemType"] = serde_json::json!(t);
+                }
+                row
+            }).collect::<Vec<_>>()
+        });
+        if let Some(under) = input.under {
+            payload["under"] = serde_json::json!(under);
+        }
+        if let Some(after) = input.after {
+            payload["after"] = serde_json::json!(after);
+        }
+        if let Some(version) = input.forest_version {
+            payload["forestVersion"] = serde_json::json!(version);
+        }
+
+        let resp: JiraForestModifyResponse = self
+            .structure_put(&format!("/forest/{}/item", structure_id), &payload)
+            .await
+            .map_err(|e| {
+                if matches!(&e, Error::Api { status, .. } if *status == 409) {
+                    Error::Api {
+                        status: 409,
+                        message: "Forest version conflict. The structure was modified concurrently. Retry with the latest version.".to_string(),
+                    }
+                } else {
+                    e
+                }
+            })?;
+
+        Ok(ForestModifyResult {
+            version: resp.version,
+            affected_count: input.items.len(),
+        })
+    }
+
+    async fn move_structure_rows(
+        &self,
+        structure_id: u64,
+        input: MoveStructureRowsInput,
+    ) -> Result<ForestModifyResult> {
+        let mut payload = serde_json::json!({
+            "rowIds": input.row_ids
+        });
+        if let Some(under) = input.under {
+            payload["under"] = serde_json::json!(under);
+        }
+        if let Some(after) = input.after {
+            payload["after"] = serde_json::json!(after);
+        }
+        if let Some(version) = input.forest_version {
+            payload["forestVersion"] = serde_json::json!(version);
+        }
+
+        let resp: JiraForestModifyResponse = self
+            .structure_post(&format!("/forest/{}/move", structure_id), &payload)
+            .await
+            .map_err(|e| {
+                if matches!(&e, Error::Api { status, .. } if *status == 409) {
+                    Error::Api {
+                        status: 409,
+                        message: "Forest version conflict. Retry with the latest version."
+                            .to_string(),
+                    }
+                } else {
+                    e
+                }
+            })?;
+
+        Ok(ForestModifyResult {
+            version: resp.version,
+            affected_count: input.row_ids.len(),
+        })
+    }
+
+    async fn remove_structure_row(&self, structure_id: u64, row_id: u64) -> Result<()> {
+        self.structure_delete_request(&format!("/forest/{}/item/{}", structure_id, row_id))
+            .await
+    }
+
+    async fn get_structure_values(
+        &self,
+        input: GetStructureValuesInput,
+    ) -> Result<StructureValues> {
+        let columns: Vec<serde_json::Value> = input
+            .columns
+            .iter()
+            .map(|c| {
+                let mut col = serde_json::Map::new();
+                if let Some(ref id) = c.id {
+                    col.insert("id".into(), serde_json::json!(id));
+                }
+                if let Some(ref field) = c.field {
+                    col.insert("field".into(), serde_json::json!(field));
+                }
+                if let Some(ref formula) = c.formula {
+                    col.insert("formula".into(), serde_json::json!(formula));
+                }
+                serde_json::Value::Object(col)
+            })
+            .collect();
+
+        let payload = serde_json::json!({
+            "structureId": input.structure_id,
+            "rows": input.rows,
+            "columns": columns,
+        });
+
+        let resp: JiraStructureValuesResponse = self.structure_post("/value", &payload).await?;
+
+        // Group values by row_id
+        let mut row_map: std::collections::BTreeMap<u64, Vec<StructureColumnValue>> =
+            std::collections::BTreeMap::new();
+        for entry in resp.values {
+            row_map
+                .entry(entry.row_id)
+                .or_default()
+                .push(StructureColumnValue {
+                    column: entry.column_id.unwrap_or_default(),
+                    value: entry.value,
+                });
+        }
+
+        let values = row_map
+            .into_iter()
+            .map(|(row_id, columns)| StructureRowValues { row_id, columns })
+            .collect();
+
+        Ok(StructureValues {
+            structure_id: input.structure_id,
+            values,
+        })
+    }
+
+    async fn get_structure_views(
+        &self,
+        structure_id: u64,
+        view_id: Option<u64>,
+    ) -> Result<Vec<StructureView>> {
+        if let Some(id) = view_id {
+            let view: JiraStructureView = self.structure_get(&format!("/view/{}", id)).await?;
+            Ok(vec![map_structure_view(view)])
+        } else {
+            let resp: JiraStructureViewListResponse = self
+                .structure_get(&format!("/view?structureId={}", structure_id))
+                .await?;
+            Ok(resp.views.into_iter().map(map_structure_view).collect())
+        }
+    }
+
+    async fn save_structure_view(&self, input: SaveStructureViewInput) -> Result<StructureView> {
+        let columns: Option<Vec<serde_json::Value>> = input.columns.as_ref().map(|cols| {
+            cols.iter()
+                .map(|c| {
+                    let mut col = serde_json::Map::new();
+                    if let Some(ref field) = c.field {
+                        col.insert("field".into(), serde_json::json!(field));
+                    }
+                    if let Some(ref formula) = c.formula {
+                        col.insert("formula".into(), serde_json::json!(formula));
+                    }
+                    if let Some(width) = c.width {
+                        col.insert("width".into(), serde_json::json!(width));
+                    }
+                    serde_json::Value::Object(col)
+                })
+                .collect()
+        });
+
+        let mut payload = serde_json::json!({
+            "structureId": input.structure_id,
+            "name": input.name,
+        });
+        if let Some(cols) = columns {
+            payload["columns"] = serde_json::json!(cols);
+        }
+        if let Some(ref g) = input.group_by {
+            payload["groupBy"] = serde_json::json!(g);
+        }
+        if let Some(ref s) = input.sort_by {
+            payload["sortBy"] = serde_json::json!(s);
+        }
+        if let Some(ref f) = input.filter {
+            payload["filter"] = serde_json::json!(f);
+        }
+
+        let view: JiraStructureView = if let Some(id) = input.id {
+            self.structure_put(&format!("/view/{}", id), &payload)
+                .await?
+        } else {
+            self.structure_post("/view", &payload).await?
+        };
+
+        Ok(map_structure_view(view))
+    }
+
+    async fn create_structure(&self, input: CreateStructureInput) -> Result<Structure> {
+        let mut payload = serde_json::json!({"name": input.name});
+        if let Some(ref desc) = input.description {
+            payload["description"] = serde_json::json!(desc);
+        }
+        let s: JiraStructure = self.structure_post("/structure", &payload).await?;
+        Ok(Structure {
+            id: s.id,
+            name: s.name,
+            description: s.description,
+        })
     }
 
     fn provider_name(&self) -> &'static str {

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -5079,4 +5079,258 @@ mod tests {
         assert!(relations.related_to.is_empty());
         assert!(relations.duplicates.is_empty());
     }
+
+    // =========================================================================
+    // Structure: build_forest_tree tests
+    // =========================================================================
+
+    #[test]
+    fn test_build_forest_tree_empty() {
+        let tree = build_forest_tree(&[], &[]);
+        assert!(tree.is_empty());
+    }
+
+    #[test]
+    fn test_build_forest_tree_flat() {
+        let rows = vec![
+            JiraForestRow {
+                id: 1,
+                item_id: Some("PROJ-1".into()),
+                item_type: Some("issue".into()),
+            },
+            JiraForestRow {
+                id: 2,
+                item_id: Some("PROJ-2".into()),
+                item_type: Some("issue".into()),
+            },
+        ];
+        let depths = vec![0, 0];
+        let tree = build_forest_tree(&rows, &depths);
+        assert_eq!(tree.len(), 2);
+        assert_eq!(tree[0].row_id, 1);
+        assert_eq!(tree[1].row_id, 2);
+        assert!(tree[0].children.is_empty());
+        assert!(tree[1].children.is_empty());
+    }
+
+    #[test]
+    fn test_build_forest_tree_nested() {
+        // PROJ-1
+        //   PROJ-2
+        //     PROJ-3
+        //   PROJ-4
+        let rows = vec![
+            JiraForestRow {
+                id: 1,
+                item_id: Some("PROJ-1".into()),
+                item_type: None,
+            },
+            JiraForestRow {
+                id: 2,
+                item_id: Some("PROJ-2".into()),
+                item_type: None,
+            },
+            JiraForestRow {
+                id: 3,
+                item_id: Some("PROJ-3".into()),
+                item_type: None,
+            },
+            JiraForestRow {
+                id: 4,
+                item_id: Some("PROJ-4".into()),
+                item_type: None,
+            },
+        ];
+        let depths = vec![0, 1, 2, 1];
+        let tree = build_forest_tree(&rows, &depths);
+
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree[0].row_id, 1);
+        assert_eq!(tree[0].children.len(), 2);
+        assert_eq!(tree[0].children[0].row_id, 2);
+        assert_eq!(tree[0].children[0].children.len(), 1);
+        assert_eq!(tree[0].children[0].children[0].row_id, 3);
+        assert_eq!(tree[0].children[1].row_id, 4);
+        assert!(tree[0].children[1].children.is_empty());
+    }
+
+    #[test]
+    fn test_build_forest_tree_multiple_roots() {
+        let rows = vec![
+            JiraForestRow {
+                id: 1,
+                item_id: Some("PROJ-1".into()),
+                item_type: None,
+            },
+            JiraForestRow {
+                id: 2,
+                item_id: Some("PROJ-2".into()),
+                item_type: None,
+            },
+            JiraForestRow {
+                id: 3,
+                item_id: Some("PROJ-3".into()),
+                item_type: None,
+            },
+            JiraForestRow {
+                id: 4,
+                item_id: Some("PROJ-4".into()),
+                item_type: None,
+            },
+        ];
+        let depths = vec![0, 1, 0, 1];
+        let tree = build_forest_tree(&rows, &depths);
+
+        assert_eq!(tree.len(), 2);
+        assert_eq!(tree[0].children.len(), 1);
+        assert_eq!(tree[1].children.len(), 1);
+    }
+
+    // =========================================================================
+    // Structure: httpmock integration tests
+    // =========================================================================
+
+    mod structure_integration {
+        use super::*;
+        use httpmock::prelude::*;
+
+        fn create_client(server: &MockServer) -> JiraClient {
+            // with_base_url sets base_url WITHOUT /rest/api/N,
+            // but Structure uses instance_url. Adjust:
+            
+            // instance_url is set to base_url by with_base_url
+            JiraClient::with_base_url(
+                server.base_url(),
+                "PROJ",
+                "user@example.com",
+                "token",
+                false,
+            )
+        }
+
+        #[tokio::test]
+        async fn test_get_structures() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/rest/structure/2.0/structure");
+                then.status(200).json_body(serde_json::json!({
+                    "structures": [
+                        {"id": 1, "name": "Q1 Planning", "description": "Quarter 1"},
+                        {"id": 2, "name": "Sprint Board"}
+                    ]
+                }));
+            });
+
+            let client = create_client(&server);
+            let result = client.get_structures().await.unwrap();
+            assert_eq!(result.items.len(), 2);
+            assert_eq!(result.items[0].name, "Q1 Planning");
+            assert_eq!(result.items[1].id, 2);
+        }
+
+        #[tokio::test]
+        async fn test_get_structure_forest() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(POST).path("/rest/structure/2.0/forest/1/spec");
+                then.status(200).json_body(serde_json::json!({
+                    "version": 42,
+                    "rows": [
+                        {"id": 100, "itemId": "PROJ-1", "itemType": "issue"},
+                        {"id": 101, "itemId": "PROJ-2", "itemType": "issue"},
+                        {"id": 102, "itemId": "PROJ-3", "itemType": "issue"}
+                    ],
+                    "depths": [0, 1, 1],
+                    "totalCount": 3
+                }));
+            });
+
+            let client = create_client(&server);
+            let forest = client
+                .get_structure_forest(
+                    1,
+                    GetForestOptions {
+                        offset: None,
+                        limit: Some(200),
+                    },
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(forest.version, 42);
+            assert_eq!(forest.structure_id, 1);
+            assert_eq!(forest.total_count, Some(3));
+            assert_eq!(forest.tree.len(), 1); // one root
+            assert_eq!(forest.tree[0].item_id, Some("PROJ-1".into()));
+            assert_eq!(forest.tree[0].children.len(), 2);
+        }
+
+        #[tokio::test]
+        async fn test_create_structure() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(POST).path("/rest/structure/2.0/structure");
+                then.status(200).json_body(serde_json::json!({
+                    "id": 99,
+                    "name": "New Structure",
+                    "description": "Test"
+                }));
+            });
+
+            let client = create_client(&server);
+            let result = client
+                .create_structure(CreateStructureInput {
+                    name: "New Structure".into(),
+                    description: Some("Test".into()),
+                })
+                .await
+                .unwrap();
+
+            assert_eq!(result.id, 99);
+            assert_eq!(result.name, "New Structure");
+        }
+
+        #[tokio::test]
+        async fn test_remove_structure_row() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(DELETE)
+                    .path("/rest/structure/2.0/forest/1/item/100");
+                then.status(204);
+            });
+
+            let client = create_client(&server);
+            client.remove_structure_row(1, 100).await.unwrap();
+        }
+
+        #[tokio::test]
+        async fn test_get_structure_views() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/rest/structure/2.0/view")
+                    .query_param("structureId", "1");
+                then.status(200).json_body(serde_json::json!({
+                    "views": [
+                        {"id": 10, "name": "Default View", "structureId": 1, "columns": []},
+                        {"id": 11, "name": "Sprint View", "structureId": 1, "columns": [
+                            {"field": "summary"},
+                            {"field": "status"},
+                            {"formula": "SUM(\"Story Points\")"}
+                        ]}
+                    ]
+                }));
+            });
+
+            let client = create_client(&server);
+            let views = client.get_structure_views(1, None).await.unwrap();
+            assert_eq!(views.len(), 2);
+            assert_eq!(views[1].columns.len(), 3);
+        }
+    }
 }

--- a/crates/plugins/api/jira/src/types.rs
+++ b/crates/plugins/api/jira/src/types.rs
@@ -482,7 +482,10 @@ pub struct JiraForestModifyResponse {
 pub struct JiraStructureView {
     pub id: u64,
     pub name: String,
-    #[serde(default)]
+    /// Owning structure id. Left non-optional and **without**
+    /// `#[serde(default)]` so a missing / renamed field from the API
+    /// fails loudly rather than silently deserialising to `0` — the
+    /// caller uses this id for cross-structure scope checks.
     pub structure_id: u64,
     #[serde(default)]
     pub columns: Vec<JiraStructureViewColumn>,

--- a/crates/plugins/api/jira/src/types.rs
+++ b/crates/plugins/api/jira/src/types.rs
@@ -424,3 +424,108 @@ pub struct IssueKeyRef {
     /// Issue key (e.g., "PROJ-123")
     pub key: String,
 }
+
+// =============================================================================
+// Jira Structure Plugin API types (/rest/structure/2.0/)
+// =============================================================================
+
+/// Structure info from GET /rest/structure/2.0/structure
+#[derive(Debug, Clone, Deserialize)]
+pub struct JiraStructure {
+    pub id: u64,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Response from GET /rest/structure/2.0/structure
+#[derive(Debug, Clone, Deserialize)]
+pub struct JiraStructureListResponse {
+    pub structures: Vec<JiraStructure>,
+}
+
+/// A single row in the forest (compact format from API)
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraForestRow {
+    pub id: u64,
+    #[serde(default)]
+    pub item_id: Option<String>,
+    #[serde(default)]
+    pub item_type: Option<String>,
+}
+
+/// Forest response from POST /rest/structure/2.0/forest/{id}/spec
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraForestResponse {
+    pub version: u64,
+    #[serde(default)]
+    pub rows: Vec<JiraForestRow>,
+    #[serde(default)]
+    pub depths: Vec<u32>,
+    #[serde(default)]
+    pub total_count: Option<u64>,
+}
+
+/// Response from forest modification operations (add/move)
+#[derive(Debug, Clone, Deserialize)]
+pub struct JiraForestModifyResponse {
+    pub version: u64,
+    #[serde(default)]
+    pub rows: Vec<JiraForestRow>,
+}
+
+/// Structure view from /rest/structure/2.0/view
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraStructureView {
+    pub id: u64,
+    pub name: String,
+    #[serde(default)]
+    pub structure_id: u64,
+    #[serde(default)]
+    pub columns: Vec<JiraStructureViewColumn>,
+    #[serde(default)]
+    pub group_by: Option<String>,
+    #[serde(default)]
+    pub sort_by: Option<String>,
+    #[serde(default)]
+    pub filter: Option<String>,
+}
+
+/// Column definition in a structure view
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct JiraStructureViewColumn {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub field: Option<String>,
+    #[serde(default)]
+    pub formula: Option<String>,
+    #[serde(default)]
+    pub width: Option<u32>,
+}
+
+/// Response from GET /rest/structure/2.0/view?structureId={id}
+#[derive(Debug, Clone, Deserialize)]
+pub struct JiraStructureViewListResponse {
+    pub views: Vec<JiraStructureView>,
+}
+
+/// Batch value response from POST /rest/structure/2.0/value
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JiraStructureValueEntry {
+    pub row_id: u64,
+    #[serde(default)]
+    pub column_id: Option<String>,
+    #[serde(default)]
+    pub value: serde_json::Value,
+}
+
+/// Response from POST /rest/structure/2.0/value
+#[derive(Debug, Clone, Deserialize)]
+pub struct JiraStructureValuesResponse {
+    pub values: Vec<JiraStructureValueEntry>,
+}


### PR DESCRIPTION
## Summary

Add 9 MCP tools for Jira Structure plugin REST API (`/rest/structure/2.0/`), enabling AI agents to manage Structure hierarchies, views, and formulas.

Closes #178

## Tools

### P1 — Must Have
| Tool | Description |
|------|-------------|
| `get_structures` | List all available structures |
| `get_structure_forest` | Get hierarchy tree (rows+depths → nested tree) |
| `add_structure_rows` | Add issues/folders with position control |
| `move_structure_rows` | Move rows within hierarchy |
| `remove_structure_row` | Remove row from structure |

### P2 — Should Have
| Tool | Description |
|------|-------------|
| `get_structure_values` | Batch-read column values (including formulas) |
| `get_structure_views` | List views or get single view config |
| `save_structure_view` | Create/update view |
| `create_structure` | Create new structure |

## Changes (12 files, +1333 lines)

- **devboy-core**: `ToolCategory::JiraStructure`, unified types, 9 new `IssueProvider` methods (default `ProviderUnsupported`)
- **devboy-jira**: Structure HTTP client (`structure_get/post/put/delete`), forest→tree transformation, trait implementation
- **devboy-executor**: 9 tool definitions, dispatch handlers, 5 new `ToolOutput` variants
- **devboy-mcp**: `JiraStructure` category filtering, `KNOWN_BUILTIN_TOOLS` update

## Key design decisions

1. **Provider trait extension** — follows `link_issues`/`get_issue_relations` pattern: methods on `IssueProvider` with default `ProviderUnsupported`
2. **Forest → Tree** — `build_forest_tree()` converts compact `rows[]+depths[]` to nested `StructureNode` with `children[]`
3. **Version stamps** — `forestVersion` param for optimistic concurrency, 409 Conflict handling
4. **Format output** — Structure outputs serialize as JSON (TOON pipeline integration deferred)

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets --all-features` — zero warnings
- [x] `cargo test` — all 152+ tests pass
- [ ] Manual test: `get_structures` against Jira Self-Hosted with Structure plugin