### PR TITLE
hotfix(skills): pull 20 missing skills into main (stacked PR merge leak)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The same tools, the same pipeline, three ways to reach them. Start with one mode
 devboy skills list                          # see the shipped catalogue
 devboy skills install --all --agent all     # install every skill into every detected agent
 devboy skills install devboy-review-mr      # repo-local by default
-devboy skills upgrade --all                 # refresh after `devboy upgrade`
+devboy skills upgrade                       # refresh every installed skill after `devboy upgrade`
 ```
 
 | Category | Example skills |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,28 @@ The same tools, the same pipeline, three ways to reach them. Start with one mode
 
 > **Note on JSON arguments.** `devboy tools call <name>` takes an optional positional JSON string (defaults to `{}`). On POSIX shells wrap it in single quotes: `devboy tools call get_issues '{"limit": 20}'`. On Windows `cmd.exe` / PowerShell escape the inner quotes instead: `devboy tools call get_issues "{\"limit\": 20}"`.
 
+## Skills — procedural recipes shipped with the tools
+
+`devboy-tools` ships a catalogue of **skills** — one-page Markdown recipes that tell an AI agent how to use the tool bundle to accomplish a common task. Every skill is CLI-first (it calls `devboy tools call <name>`), agent-agnostic (installable into Claude Code / Codex / Cursor / Kimi or a vendor-neutral path), and versioned with the binary.
+
+```bash
+devboy skills list                          # see the shipped catalogue
+devboy skills install --all --agent all     # install every skill into every detected agent
+devboy skills install devboy-review-mr      # repo-local by default
+devboy skills upgrade --all                 # refresh after `devboy upgrade`
+```
+
+| Category | Example skills |
+|----------|---------------|
+| `self-bootstrap` | `devboy-setup`, `devboy-repair`, `devboy-tools-catalog` |
+| `issue-tracking` | `devboy-get-issues`, `devboy-create-issue`, `devboy-update-issue`, `devboy-link-issues`, `devboy-solve-issue` |
+| `code-review` | `devboy-review-mr`, `devboy-fix-review-comments`, `devboy-self-review` |
+| `self-feedback` | `devboy-run-and-verify`, `devboy-daily-report`, `devboy-retro`, `devboy-knowledge-extract` |
+| `meeting-notes` | `devboy-meeting-search`, `devboy-meeting-transcript`, `devboy-meeting-to-tasks` |
+| `messenger` | `devboy-chat-search`, `devboy-chat-summary`, `devboy-notify` |
+
+The design lives in `docs/architecture/adr/ADR-012-skills-subsystem.md`; the user guide is at `docs/guide/skills/`. Skill installs keep a per-location manifest with SHA256s so upgrades leave user-modified files alone (ADR-014), and the self-feedback category reads session traces written to `.devboy/sessions/` in the format defined by ADR-015.
+
 ## Why DevBoy?
 
 | | Others | DevBoy |

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -272,6 +272,12 @@ enum Commands {
         command: SkillsCommands,
     },
 
+    /// Write to a skill's self-feedback session trace (ADR-015)
+    Trace {
+        #[command(subcommand)]
+        command: TraceCommands,
+    },
+
     /// Run diagnostic checks for the local DevBoy setup
     Doctor {
         /// Output machine-readable JSON
@@ -578,6 +584,64 @@ enum SkillsCommands {
     },
 }
 
+#[derive(Subcommand)]
+enum TraceCommands {
+    /// Start a new session trace. Prints a single JSON line with
+    /// `session_id`, `session_dir`, `trace_path` — skills capture that
+    /// and pass the values to subsequent `event` / `end` invocations.
+    Begin {
+        /// Skill name. Shown as the directory under the date, also
+        /// recorded in every event.
+        #[arg(long)]
+        skill: String,
+        /// Write under `~/.devboy/sessions/` instead of the repo-local
+        /// `<repo>/.devboy/sessions/`.
+        #[arg(long, conflicts_with = "dir")]
+        global: bool,
+        /// Write under an explicit directory (mostly for testing).
+        #[arg(long)]
+        dir: Option<String>,
+    },
+    /// Append one event to an existing session.
+    Event {
+        /// Session directory printed by `trace begin`.
+        #[arg(long)]
+        session_dir: String,
+        /// Session id printed by `trace begin`.
+        #[arg(long)]
+        session_id: String,
+        /// Skill name.
+        #[arg(long)]
+        skill: String,
+        /// Event phase. Supported values: `start`, `decision`, `tool_call`,
+        /// `tool_result`, `verify`, `artifact`, `note`, `end`.
+        #[arg(long)]
+        phase: String,
+        /// JSON payload. Defaults to `{}` if omitted.
+        #[arg(long, default_value = "{}")]
+        payload: String,
+    },
+    /// Finalise a session — writes the closing event and updates
+    /// `meta.json` with the outcome + aggregated counts.
+    End {
+        /// Session directory printed by `trace begin`.
+        #[arg(long)]
+        session_dir: String,
+        /// Session id printed by `trace begin`.
+        #[arg(long)]
+        session_id: String,
+        /// Skill name.
+        #[arg(long)]
+        skill: String,
+        /// Session outcome: `success`, `failure`, `aborted`.
+        #[arg(long)]
+        outcome: String,
+        /// Human-readable summary.
+        #[arg(long, default_value = "")]
+        summary: String,
+    },
+}
+
 /// Environment variable to skip keychain operations (for CI testing).
 /// When set to "1" or "true", uses in-memory store instead of OS keychain.
 const SKIP_KEYCHAIN_ENV: &str = "DEVBOY_SKIP_KEYCHAIN";
@@ -803,6 +867,10 @@ async fn main() -> Result<()> {
 
             Some(Commands::Skills { command }) => {
                 skills_cmd::handle(command).await?;
+            }
+
+            Some(Commands::Trace { command }) => {
+                skills_cmd::handle_trace(command).await?;
             }
 
             Some(Commands::Doctor {

--- a/crates/devboy-cli/src/skills_cmd.rs
+++ b/crates/devboy-cli/src/skills_cmd.rs
@@ -10,7 +10,96 @@ use devboy_skills::{
     install_skills_to_target, remove_skills_from_target, resolve_targets,
 };
 
-use crate::SkillsCommands;
+use crate::{SkillsCommands, TraceCommands};
+
+/// Dispatch a `devboy trace` subcommand.
+pub async fn handle_trace(command: TraceCommands) -> Result<()> {
+    use devboy_skills::{TraceTarget, append_event, create_session, finalise_session};
+    match command {
+        TraceCommands::Begin { skill, global, dir } => {
+            let target = if let Some(p) = dir {
+                TraceTarget::Custom(std::path::PathBuf::from(p))
+            } else if global {
+                TraceTarget::Global
+            } else {
+                TraceTarget::RepoLocal
+            };
+            let (session_id, session_dir) =
+                create_session(&skill, &target).context("failed to begin session")?;
+            let trace_path = session_dir.join("trace.jsonl");
+            let out = serde_json::json!({
+                "session_id": session_id,
+                "session_dir": session_dir.display().to_string(),
+                "trace_path": trace_path.display().to_string(),
+            });
+            println!("{out}");
+            Ok(())
+        }
+        TraceCommands::Event {
+            session_dir,
+            session_id,
+            skill,
+            phase,
+            payload,
+        } => {
+            let phase = parse_phase(&phase)?;
+            let payload: serde_json::Value =
+                serde_json::from_str(&payload).context("invalid JSON payload")?;
+            append_event(
+                std::path::Path::new(&session_dir),
+                &session_id,
+                &skill,
+                phase,
+                payload,
+            )
+            .context("failed to append event")
+        }
+        TraceCommands::End {
+            session_dir,
+            session_id,
+            skill,
+            outcome,
+            summary,
+        } => {
+            let outcome = parse_outcome(&outcome)?;
+            finalise_session(
+                std::path::Path::new(&session_dir),
+                &session_id,
+                &skill,
+                outcome,
+                &summary,
+            )
+            .context("failed to finalise session")
+        }
+    }
+}
+
+fn parse_phase(raw: &str) -> Result<devboy_skills::TracePhase> {
+    use devboy_skills::TracePhase as P;
+    Ok(match raw {
+        "start" => P::Start,
+        "decision" => P::Decision,
+        "tool_call" => P::ToolCall,
+        "tool_result" => P::ToolResult,
+        "verify" => P::Verify,
+        "artifact" => P::Artifact,
+        "note" => P::Note,
+        "end" => P::End,
+        other => anyhow::bail!(
+            "unknown trace phase `{other}` (expected start | decision | tool_call | tool_result | verify | artifact | note | end)"
+        ),
+    })
+}
+
+fn parse_outcome(raw: &str) -> Result<devboy_skills::TraceOutcome> {
+    use devboy_skills::TraceOutcome as O;
+    Ok(match raw {
+        "success" => O::Success,
+        "failure" => O::Failure,
+        "aborted" => O::Aborted,
+        other => anyhow::bail!("unknown outcome `{other}` (expected success | failure | aborted)"),
+    })
+}
 
 /// Dispatch a `devboy skills` subcommand.
 pub async fn handle(command: SkillsCommands) -> Result<()> {

--- a/crates/devboy-cli/tests/skills_test.rs
+++ b/crates/devboy-cli/tests/skills_test.rs
@@ -243,3 +243,148 @@ fn skills_remove_deletes_files_and_manifest_entry() {
     );
     assert!(!installed.exists(), "file should be deleted");
 }
+
+#[test]
+fn trace_begin_event_end_round_trip() {
+    let home = TempDir::new().unwrap();
+    let cwd = TempDir::new().unwrap();
+    let dir_override = TempDir::new().unwrap();
+
+    let begin = spawn(
+        &home,
+        cwd.path(),
+        [
+            "trace",
+            "begin",
+            "--skill",
+            "devboy-setup",
+            "--dir",
+            dir_override.path().to_str().unwrap(),
+        ],
+    );
+    assert!(begin.status.success(), "trace begin should succeed");
+    let begin_stdout = String::from_utf8_lossy(&begin.stdout);
+    let meta: serde_json::Value = serde_json::from_str(begin_stdout.trim())
+        .expect("trace begin should print a single JSON line");
+    let session_id = meta["session_id"].as_str().unwrap().to_string();
+    let session_dir = meta["session_dir"].as_str().unwrap().to_string();
+    assert!(
+        !session_id.is_empty(),
+        "session_id is empty: {begin_stdout}"
+    );
+
+    let event = spawn(
+        &home,
+        cwd.path(),
+        [
+            "trace",
+            "event",
+            "--session-dir",
+            &session_dir,
+            "--session-id",
+            &session_id,
+            "--skill",
+            "devboy-setup",
+            "--phase",
+            "tool_call",
+            "--payload",
+            r#"{"tool":"get_issues","args":{"limit":3}}"#,
+        ],
+    );
+    assert!(
+        event.status.success(),
+        "trace event should succeed: {}",
+        String::from_utf8_lossy(&event.stderr)
+    );
+
+    let end = spawn(
+        &home,
+        cwd.path(),
+        [
+            "trace",
+            "end",
+            "--session-dir",
+            &session_dir,
+            "--session-id",
+            &session_id,
+            "--skill",
+            "devboy-setup",
+            "--outcome",
+            "success",
+            "--summary",
+            "smoke-test complete",
+        ],
+    );
+    assert!(end.status.success(), "trace end should succeed");
+
+    let trace_path = std::path::PathBuf::from(&session_dir).join("trace.jsonl");
+    let trace_body = fs::read_to_string(&trace_path).expect("trace.jsonl should exist");
+    let lines: Vec<&str> = trace_body.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        3,
+        "expected 3 events (start, tool_call, end), got: {lines:?}"
+    );
+    assert!(lines[0].contains("\"phase\":\"start\""));
+    assert!(lines[1].contains("\"phase\":\"tool_call\""));
+    assert!(lines[2].contains("\"phase\":\"end\""));
+
+    let meta_path = std::path::PathBuf::from(&session_dir).join("meta.json");
+    let meta_body = fs::read_to_string(&meta_path).expect("meta.json should exist");
+    assert!(meta_body.contains("\"outcome\": \"success\""));
+    assert!(meta_body.contains("smoke-test complete"));
+    assert!(meta_body.contains("\"tool_calls\": 1"));
+}
+
+#[test]
+fn trace_event_redacts_tokens() {
+    let home = TempDir::new().unwrap();
+    let cwd = TempDir::new().unwrap();
+    let dir_override = TempDir::new().unwrap();
+
+    let begin = spawn(
+        &home,
+        cwd.path(),
+        [
+            "trace",
+            "begin",
+            "--skill",
+            "devboy-test",
+            "--dir",
+            dir_override.path().to_str().unwrap(),
+        ],
+    );
+    assert!(begin.status.success());
+    let meta: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&begin.stdout).trim()).unwrap();
+    let session_id = meta["session_id"].as_str().unwrap().to_string();
+    let session_dir = meta["session_dir"].as_str().unwrap().to_string();
+
+    let event = spawn(
+        &home,
+        cwd.path(),
+        [
+            "trace",
+            "event",
+            "--session-dir",
+            &session_dir,
+            "--session-id",
+            &session_id,
+            "--skill",
+            "devboy-test",
+            "--phase",
+            "tool_call",
+            "--payload",
+            r#"{"args":{"token":"ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}"#,
+        ],
+    );
+    assert!(event.status.success());
+
+    let trace_path = std::path::PathBuf::from(&session_dir).join("trace.jsonl");
+    let body = fs::read_to_string(trace_path).unwrap();
+    assert!(
+        !body.contains("ghp_aaaaaaaa"),
+        "token was not redacted: {body}"
+    );
+    assert!(body.contains("<redacted"));
+}

--- a/crates/devboy-skills/Cargo.toml
+++ b/crates/devboy-skills/Cargo.toml
@@ -33,11 +33,12 @@ ulid = { version = "1.1", features = ["serde"], optional = true }
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+temp-env = "0.3"
 
 [features]
-default = []
-# Enabled by the trace module (ADR-015); reserved so that the crate can
-# grow the session-trace API without pulling in ulid for the install path.
+default = ["trace"]
+# Session-trace module (ADR-015). Pulls in `ulid` for session ids.
+# On by default — disabling it is mostly a CI knob.
 trace = ["dep:ulid"]
 
 [lints]

--- a/crates/devboy-skills/src/error.rs
+++ b/crates/devboy-skills/src/error.rs
@@ -87,4 +87,20 @@ pub enum SkillError {
         #[source]
         source: serde_json::Error,
     },
+
+    /// Non-manifest JSON (de)serialisation failure — used by the trace
+    /// subsystem for `trace.jsonl` records and `meta.json` writes so
+    /// callers do not see a misleading "manifest … invalid JSON"
+    /// error for a record that is not a manifest.
+    #[error("failed to {operation} JSON at `{path}`: {source}")]
+    SerdeJson {
+        /// What was being done when the failure happened
+        /// (`serialise trace record`, `write session meta`, …).
+        operation: &'static str,
+        /// Path associated with the record.
+        path: PathBuf,
+        /// Wrapped serde_json error.
+        #[source]
+        source: serde_json::Error,
+    },
 }

--- a/crates/devboy-skills/src/lib.rs
+++ b/crates/devboy-skills/src/lib.rs
@@ -30,6 +30,7 @@ pub mod install;
 pub mod manifest;
 pub mod skill;
 pub mod source;
+pub mod trace;
 
 pub use catalog::Catalog;
 pub use embedded::EmbeddedSkillSource;
@@ -44,3 +45,7 @@ pub use manifest::{
 };
 pub use skill::{Category, Frontmatter, Skill, SkillSummary};
 pub use source::SkillSource;
+pub use trace::{
+    Outcome as TraceOutcome, Phase as TracePhase, SessionMeta, SessionTracer, TraceRecord,
+    TraceTarget, append_event, create_session, finalise_session,
+};

--- a/crates/devboy-skills/src/trace.rs
+++ b/crates/devboy-skills/src/trace.rs
@@ -258,7 +258,8 @@ impl SessionTracer {
             summary: Some(summary.to_string()),
         };
         let bytes =
-            serde_json::to_vec_pretty(&meta).map_err(|source| SkillError::InvalidManifest {
+            serde_json::to_vec_pretty(&meta).map_err(|source| SkillError::SerdeJson {
+                operation: "serialise session meta",
                 path: self.meta_path.clone(),
                 source,
             })?;
@@ -294,7 +295,8 @@ impl SessionTracer {
             payload: redacted,
         };
         let line =
-            serde_json::to_string(&record).map_err(|source| SkillError::InvalidManifest {
+            serde_json::to_string(&record).map_err(|source| SkillError::SerdeJson {
+                operation: "serialise trace record",
                 path: self.trace_path.clone(),
                 source,
             })?;
@@ -445,7 +447,8 @@ fn append_event_inner(
         phase,
         payload: redacted,
     };
-    let line = serde_json::to_string(&record).map_err(|source| SkillError::InvalidManifest {
+    let line = serde_json::to_string(&record).map_err(|source| SkillError::SerdeJson {
+        operation: "serialise trace record",
         path: session_dir.join("trace.jsonl"),
         source,
     })?;
@@ -504,7 +507,8 @@ pub fn finalise_session(
 }
 
 fn write_meta_file(path: &Path, meta: &SessionMeta) -> Result<()> {
-    let bytes = serde_json::to_vec_pretty(meta).map_err(|source| SkillError::InvalidManifest {
+    let bytes = serde_json::to_vec_pretty(meta).map_err(|source| SkillError::SerdeJson {
+        operation: "serialise session meta",
         path: path.to_path_buf(),
         source,
     })?;

--- a/crates/devboy-skills/src/trace.rs
+++ b/crates/devboy-skills/src/trace.rs
@@ -257,12 +257,11 @@ impl SessionTracer {
             errors: self.errors.load(std::sync::atomic::Ordering::Relaxed),
             summary: Some(summary.to_string()),
         };
-        let bytes =
-            serde_json::to_vec_pretty(&meta).map_err(|source| SkillError::SerdeJson {
-                operation: "serialise session meta",
-                path: self.meta_path.clone(),
-                source,
-            })?;
+        let bytes = serde_json::to_vec_pretty(&meta).map_err(|source| SkillError::SerdeJson {
+            operation: "serialise session meta",
+            path: self.meta_path.clone(),
+            source,
+        })?;
         std::fs::write(&self.meta_path, bytes).map_err(|source| SkillError::Io {
             path: self.meta_path.clone(),
             source,
@@ -294,12 +293,11 @@ impl SessionTracer {
             phase,
             payload: redacted,
         };
-        let line =
-            serde_json::to_string(&record).map_err(|source| SkillError::SerdeJson {
-                operation: "serialise trace record",
-                path: self.trace_path.clone(),
-                source,
-            })?;
+        let line = serde_json::to_string(&record).map_err(|source| SkillError::SerdeJson {
+            operation: "serialise trace record",
+            path: self.trace_path.clone(),
+            source,
+        })?;
 
         let mut guard = self.trace_file.lock().map_err(|_| SkillError::Io {
             path: self.trace_path.clone(),

--- a/crates/devboy-skills/src/trace.rs
+++ b/crates/devboy-skills/src/trace.rs
@@ -2,8 +2,11 @@
 //!
 //! A session is the execution of one skill (or any caller that opts in
 //! through the `devboy trace` CLI). Events land as JSON Lines at
-//! `<target>/.devboy/sessions/<YYYY-MM-DD>/<skill>/trace.jsonl`, and
-//! a sibling `meta.json` carries session-level metadata.
+//! `<target>/.devboy/sessions/<YYYY-MM-DD>/<skill>/<session_id>/trace.jsonl`,
+//! and a sibling `meta.json` in the same per-session directory carries
+//! session-level metadata. The `<session_id>` segment keeps concurrent
+//! or repeated invocations of the same skill on the same day isolated
+//! from each other (ADR-015 requires self-contained sessions).
 //!
 //! The [`SessionTracer`] writer is intentionally small — it serialises
 //! one event per line with no framing, no network I/O, and no reliance
@@ -37,7 +40,11 @@ pub mod redact;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Phase {
-    /// First event of the session — captures input, cwd, devboy version.
+    /// First event of the session, marking the start of execution.
+    /// The tracer synthesises a `start` record with an empty payload;
+    /// any input / cwd / version metadata is caller-defined — pass it
+    /// via a regular `event` call after `begin` if you want it in the
+    /// stream, or record it in `meta.json` via a later `end` call.
     Start,
     /// Skill-level reasoning outcome.
     Decision,
@@ -155,6 +162,11 @@ pub struct SessionTracer {
     started_at: DateTime<Utc>,
     tool_calls: std::sync::atomic::AtomicU64,
     errors: std::sync::atomic::AtomicU64,
+    /// Env-var snapshot captured at `begin`, reused for every
+    /// `write_event` so the redactor does not rescan `std::env::vars()`
+    /// on each record (can be tens of thousands of events in a long
+    /// session).
+    redactor: redact::Redactor,
 }
 
 impl SessionTracer {
@@ -195,6 +207,7 @@ impl SessionTracer {
             started_at,
             tool_calls: std::sync::atomic::AtomicU64::new(0),
             errors: std::sync::atomic::AtomicU64::new(0),
+            redactor: redact::Redactor::snapshot(),
         };
 
         // Emit the `start` event synthesised from the call arguments;
@@ -272,7 +285,7 @@ impl SessionTracer {
     }
 
     fn write_event(&self, phase: Phase, payload: Value) -> Result<()> {
-        let redacted = redact::sanitize(payload);
+        let redacted = self.redactor.sanitize(payload);
         let record = TraceRecord {
             ts: Utc::now(),
             skill: self.skill.clone(),

--- a/crates/devboy-skills/src/trace.rs
+++ b/crates/devboy-skills/src/trace.rs
@@ -158,13 +158,17 @@ pub struct SessionTracer {
 }
 
 impl SessionTracer {
-    /// Start a new session. Creates the dated directory + a per-skill
-    /// subdirectory and opens `trace.jsonl` for append.
+    /// Start a new session. Creates a unique directory
+    /// `<root>/<date>/<skill>/<session_id>/` and opens `trace.jsonl`
+    /// for append. The per-session directory ensures that concurrent
+    /// or repeated invocations of the same skill on the same day do
+    /// not share any files (ADR-015 requires self-contained sessions).
     pub fn begin(skill: &str, target: &TraceTarget) -> Result<Self> {
         let root = target.sessions_root()?;
         let started_at = Utc::now();
         let date = started_at.format("%Y-%m-%d").to_string();
-        let session_dir = root.join(&date).join(skill);
+        let session_id = new_session_id();
+        let session_dir = root.join(&date).join(skill).join(&session_id);
         create_dir_all(&session_dir).map_err(|source| SkillError::Io {
             path: session_dir.clone(),
             source,
@@ -180,8 +184,6 @@ impl SessionTracer {
                 path: trace_path.clone(),
                 source,
             })?;
-
-        let session_id = new_session_id();
 
         let tracer = Self {
             session_id,
@@ -357,19 +359,27 @@ pub struct SessionMeta {
 // ---------------------------------------------------------------------------
 
 /// Create the session directory, write the opening `start` event, and
-/// return the session id + absolute session directory. Callers then
-/// pass those back into [`append_event`] and [`finalise_session`] on
+/// return the session id + session directory. The returned path is the
+/// value the user passed through `TraceTarget` with the `<date>/<skill>
+/// /<session_id>` suffix appended — it is not canonicalised, so a
+/// relative `TraceTarget::Custom(".traces")` produces a relative path
+/// and an absolute target produces an absolute path. Callers pass both
+/// values back into [`append_event`] and [`finalise_session`] on
 /// subsequent CLI invocations.
+///
+/// The per-session directory level is required so that concurrent or
+/// repeated invocations of the same skill on the same day never share
+/// `trace.jsonl` or `meta.json` (ADR-015).
 pub fn create_session(skill: &str, target: &TraceTarget) -> Result<(String, PathBuf)> {
     let root = target.sessions_root()?;
     let started_at = Utc::now();
     let date = started_at.format("%Y-%m-%d").to_string();
-    let session_dir = root.join(&date).join(skill);
+    let session_id = new_session_id();
+    let session_dir = root.join(&date).join(skill).join(&session_id);
     create_dir_all(&session_dir).map_err(|source| SkillError::Io {
         path: session_dir.clone(),
         source,
     })?;
-    let session_id = new_session_id();
     append_event_inner(
         &session_dir,
         &session_id,
@@ -492,18 +502,35 @@ fn write_meta_file(path: &Path, meta: &SessionMeta) -> Result<()> {
 }
 
 fn scan_counts(trace_path: &Path) -> Result<(u64, u64, DateTime<Utc>)> {
-    let text = std::fs::read_to_string(trace_path).map_err(|source| SkillError::Io {
+    use std::io::{BufRead, BufReader};
+
+    // Stream the file line-by-line rather than reading the whole
+    // `trace.jsonl` into memory. ADR-015 explicitly flags that long
+    // sessions can produce very large traces; keeping the memory
+    // footprint bounded matters.
+    let file = std::fs::File::open(trace_path).map_err(|source| SkillError::Io {
         path: trace_path.to_path_buf(),
         source,
     })?;
+    let reader = BufReader::new(file);
+
     let mut tool_calls = 0u64;
     let mut errors = 0u64;
     let mut started_at: Option<DateTime<Utc>> = None;
-    for line in text.lines() {
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(source) => {
+                return Err(SkillError::Io {
+                    path: trace_path.to_path_buf(),
+                    source,
+                });
+            }
+        };
         if line.trim().is_empty() {
             continue;
         }
-        let record: TraceRecord = match serde_json::from_str(line) {
+        let record: TraceRecord = match serde_json::from_str(&line) {
             Ok(r) => r,
             Err(_) => continue,
         };

--- a/crates/devboy-skills/src/trace.rs
+++ b/crates/devboy-skills/src/trace.rs
@@ -1,0 +1,681 @@
+//! Session traces for the self-feedback loop (ADR-015).
+//!
+//! A session is the execution of one skill (or any caller that opts in
+//! through the `devboy trace` CLI). Events land as JSON Lines at
+//! `<target>/.devboy/sessions/<YYYY-MM-DD>/<skill>/trace.jsonl`, and
+//! a sibling `meta.json` carries session-level metadata.
+//!
+//! The [`SessionTracer`] writer is intentionally small — it serialises
+//! one event per line with no framing, no network I/O, and no reliance
+//! on the host logging stack. The companion [`devboy trace`] CLI
+//! subcommand family in `devboy-cli` lets shell-based skills write into
+//! the same format.
+//!
+//! The redaction pass in [`redact::sanitize`] strips values that match
+//! known credential shapes and values of environment variables named
+//! `*_TOKEN` / `*_SECRET` / `*_KEY` / `*_PASSWORD` / `*_PASSPHRASE` /
+//! `AUTHORIZATION` / `COOKIE` before anything is written to disk.
+
+use std::fs::{File, OpenOptions, create_dir_all};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::error::{Result, SkillError};
+
+pub mod redact;
+
+// ---------------------------------------------------------------------------
+// Phase + Outcome enums
+// ---------------------------------------------------------------------------
+
+/// Event phases. Kept small; readers must silently ignore unknown values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    /// First event of the session — captures input, cwd, devboy version.
+    Start,
+    /// Skill-level reasoning outcome.
+    Decision,
+    /// Immediately before invoking a tool.
+    ToolCall,
+    /// Immediately after a tool returns.
+    ToolResult,
+    /// A verification check ran (tests / clippy / dry-run etc.).
+    Verify,
+    /// Non-trivial file produced by the skill.
+    Artifact,
+    /// Free-form human-readable log entry.
+    Note,
+    /// Last event of the session.
+    End,
+}
+
+/// Session outcome — recorded on `End` in both the event stream and the
+/// per-session `meta.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    /// Skill completed and achieved its objective.
+    Success,
+    /// Skill ran to completion but the objective was not met.
+    Failure,
+    /// Skill stopped before completing (cancelled, interrupted).
+    Aborted,
+}
+
+// ---------------------------------------------------------------------------
+// Target resolution
+// ---------------------------------------------------------------------------
+
+/// Where to write session traces.
+#[derive(Debug, Clone)]
+pub enum TraceTarget {
+    /// Repo-local at `<repo>/.devboy/sessions/`. Default.
+    RepoLocal,
+    /// Per-user at `~/.devboy/sessions/`.
+    Global,
+    /// Explicit directory — used by tests.
+    Custom(PathBuf),
+}
+
+impl TraceTarget {
+    /// Resolve the `sessions/` root directory for this target.
+    pub fn sessions_root(&self) -> Result<PathBuf> {
+        match self {
+            Self::RepoLocal => {
+                let cwd = std::env::current_dir().map_err(|source| SkillError::Io {
+                    path: PathBuf::from("."),
+                    source,
+                })?;
+                let repo = locate_repo_root(&cwd).ok_or_else(|| SkillError::Io {
+                    path: cwd,
+                    source: std::io::Error::other(
+                        "no git repository / .devboy.toml at the current path (pass --global to write traces under ~/.devboy/sessions/)",
+                    ),
+                })?;
+                Ok(repo.join(".devboy").join("sessions"))
+            }
+            Self::Global => {
+                let home = home_dir()?;
+                Ok(home.join(".devboy").join("sessions"))
+            }
+            Self::Custom(p) => Ok(p.clone()),
+        }
+    }
+}
+
+fn locate_repo_root(start: &Path) -> Option<PathBuf> {
+    let mut cur = start;
+    loop {
+        if cur.join(".git").exists() || cur.join(".devboy.toml").exists() {
+            return Some(cur.to_path_buf());
+        }
+        match cur.parent() {
+            Some(p) => cur = p,
+            None => return None,
+        }
+    }
+}
+
+fn home_dir() -> Result<PathBuf> {
+    if let Some(p) = std::env::var_os("DEVBOY_HOME_OVERRIDE")
+        && !p.is_empty()
+    {
+        return Ok(PathBuf::from(p));
+    }
+    dirs::home_dir().ok_or_else(|| SkillError::Io {
+        path: PathBuf::from("~"),
+        source: std::io::Error::other("home directory is not set"),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// SessionTracer
+// ---------------------------------------------------------------------------
+
+/// Appends events to a session's `trace.jsonl`.
+///
+/// A new instance is built via [`SessionTracer::begin`], events are
+/// appended with [`SessionTracer::event`], and the session is finalised
+/// with [`SessionTracer::end`]. Dropping a tracer without calling `end`
+/// leaves the `trace.jsonl` intact but does not write `meta.json` — the
+/// stream still round-trips, just without the convenience summary.
+pub struct SessionTracer {
+    session_id: String,
+    skill: String,
+    session_dir: PathBuf,
+    trace_path: PathBuf,
+    meta_path: PathBuf,
+    trace_file: Mutex<File>,
+    started_at: DateTime<Utc>,
+    tool_calls: std::sync::atomic::AtomicU64,
+    errors: std::sync::atomic::AtomicU64,
+}
+
+impl SessionTracer {
+    /// Start a new session. Creates the dated directory + a per-skill
+    /// subdirectory and opens `trace.jsonl` for append.
+    pub fn begin(skill: &str, target: &TraceTarget) -> Result<Self> {
+        let root = target.sessions_root()?;
+        let started_at = Utc::now();
+        let date = started_at.format("%Y-%m-%d").to_string();
+        let session_dir = root.join(&date).join(skill);
+        create_dir_all(&session_dir).map_err(|source| SkillError::Io {
+            path: session_dir.clone(),
+            source,
+        })?;
+
+        let trace_path = session_dir.join("trace.jsonl");
+        let meta_path = session_dir.join("meta.json");
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&trace_path)
+            .map_err(|source| SkillError::Io {
+                path: trace_path.clone(),
+                source,
+            })?;
+
+        let session_id = new_session_id();
+
+        let tracer = Self {
+            session_id,
+            skill: skill.to_string(),
+            session_dir,
+            trace_path,
+            meta_path,
+            trace_file: Mutex::new(file),
+            started_at,
+            tool_calls: std::sync::atomic::AtomicU64::new(0),
+            errors: std::sync::atomic::AtomicU64::new(0),
+        };
+
+        // Emit the `start` event synthesised from the call arguments;
+        // callers can decorate it further via a regular `event` call.
+        tracer.write_event(Phase::Start, json!({}))?;
+        Ok(tracer)
+    }
+
+    /// Append one event to the trace. Payload is redacted before
+    /// writing.
+    pub fn event(&self, phase: Phase, payload: Value) -> Result<()> {
+        if phase == Phase::ToolCall {
+            self.tool_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        if phase == Phase::ToolResult
+            && payload
+                .get("ok")
+                .and_then(|v| v.as_bool())
+                .is_some_and(|ok| !ok)
+        {
+            self.errors
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        self.write_event(phase, payload)
+    }
+
+    /// Record the final `end` event and write the per-session
+    /// `meta.json`. Consumes the tracer.
+    pub fn end(self, outcome: Outcome, summary: &str) -> Result<()> {
+        let ended_at = Utc::now();
+        self.write_event(
+            Phase::End,
+            json!({ "outcome": outcome, "summary": summary }),
+        )?;
+
+        let meta = SessionMeta {
+            session_id: self.session_id.clone(),
+            skill: self.skill.clone(),
+            skill_version: None,
+            devboy_version: env!("CARGO_PKG_VERSION").to_string(),
+            started_at: self.started_at,
+            ended_at: Some(ended_at),
+            outcome: Some(outcome),
+            input_summary: None,
+            tool_calls: self.tool_calls.load(std::sync::atomic::Ordering::Relaxed),
+            errors: self.errors.load(std::sync::atomic::Ordering::Relaxed),
+            summary: Some(summary.to_string()),
+        };
+        let bytes =
+            serde_json::to_vec_pretty(&meta).map_err(|source| SkillError::InvalidManifest {
+                path: self.meta_path.clone(),
+                source,
+            })?;
+        std::fs::write(&self.meta_path, bytes).map_err(|source| SkillError::Io {
+            path: self.meta_path.clone(),
+            source,
+        })
+    }
+
+    /// The session directory on disk.
+    pub fn session_dir(&self) -> &Path {
+        &self.session_dir
+    }
+
+    /// The `trace.jsonl` path.
+    pub fn trace_path(&self) -> &Path {
+        &self.trace_path
+    }
+
+    /// The session id (ULID, or a randomly-generated fallback when the
+    /// `trace` Cargo feature is disabled).
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    fn write_event(&self, phase: Phase, payload: Value) -> Result<()> {
+        let redacted = redact::sanitize(payload);
+        let record = TraceRecord {
+            ts: Utc::now(),
+            skill: self.skill.clone(),
+            session_id: self.session_id.clone(),
+            phase,
+            payload: redacted,
+        };
+        let line =
+            serde_json::to_string(&record).map_err(|source| SkillError::InvalidManifest {
+                path: self.trace_path.clone(),
+                source,
+            })?;
+
+        let mut guard = self.trace_file.lock().map_err(|_| SkillError::Io {
+            path: self.trace_path.clone(),
+            source: std::io::Error::other("trace mutex poisoned"),
+        })?;
+        guard
+            .write_all(line.as_bytes())
+            .and_then(|()| guard.write_all(b"\n"))
+            .map_err(|source| SkillError::Io {
+                path: self.trace_path.clone(),
+                source,
+            })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// On-disk formats
+// ---------------------------------------------------------------------------
+
+/// One line of `trace.jsonl`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceRecord {
+    /// Timestamp of the event.
+    pub ts: DateTime<Utc>,
+    /// Skill name — duplicated on every event so that readers that
+    /// merge traces from different sessions can still attribute each
+    /// line.
+    pub skill: String,
+    /// Session id (ULID).
+    pub session_id: String,
+    /// Event phase.
+    pub phase: Phase,
+    /// Event payload. Redacted before writing.
+    pub payload: Value,
+}
+
+/// `meta.json` — written at session end and optionally touched during
+/// long sessions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMeta {
+    /// Session id matching every record in `trace.jsonl`.
+    pub session_id: String,
+    /// Skill name.
+    pub skill: String,
+    /// Skill version at run time, if the caller provided it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skill_version: Option<u32>,
+    /// devboy-tools version that emitted the session.
+    pub devboy_version: String,
+    /// Session start timestamp.
+    pub started_at: DateTime<Utc>,
+    /// Session end timestamp (missing on in-flight sessions).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<DateTime<Utc>>,
+    /// Outcome, if the session ended cleanly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<Outcome>,
+    /// One-line input summary recorded at start, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_summary: Option<String>,
+    /// Number of tool calls observed.
+    pub tool_calls: u64,
+    /// Number of tool calls that reported `ok: false`.
+    pub errors: u64,
+    /// Closing summary string (mirrors the `end` event payload).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Stateless helpers (used by `devboy trace` CLI subcommands)
+// ---------------------------------------------------------------------------
+
+/// Create the session directory, write the opening `start` event, and
+/// return the session id + absolute session directory. Callers then
+/// pass those back into [`append_event`] and [`finalise_session`] on
+/// subsequent CLI invocations.
+pub fn create_session(skill: &str, target: &TraceTarget) -> Result<(String, PathBuf)> {
+    let root = target.sessions_root()?;
+    let started_at = Utc::now();
+    let date = started_at.format("%Y-%m-%d").to_string();
+    let session_dir = root.join(&date).join(skill);
+    create_dir_all(&session_dir).map_err(|source| SkillError::Io {
+        path: session_dir.clone(),
+        source,
+    })?;
+    let session_id = new_session_id();
+    append_event_inner(
+        &session_dir,
+        &session_id,
+        skill,
+        Phase::Start,
+        Value::Object(Default::default()),
+    )?;
+    // Write a skeletal meta.json so long-running sessions are
+    // introspectable before `end` runs.
+    let skeleton = SessionMeta {
+        session_id: session_id.clone(),
+        skill: skill.to_string(),
+        skill_version: None,
+        devboy_version: env!("CARGO_PKG_VERSION").to_string(),
+        started_at,
+        ended_at: None,
+        outcome: None,
+        input_summary: None,
+        tool_calls: 0,
+        errors: 0,
+        summary: None,
+    };
+    write_meta_file(&session_dir.join("meta.json"), &skeleton)?;
+    Ok((session_id, session_dir))
+}
+
+/// Append one event to an existing session's `trace.jsonl`.
+pub fn append_event(
+    session_dir: &Path,
+    session_id: &str,
+    skill: &str,
+    phase: Phase,
+    payload: Value,
+) -> Result<()> {
+    append_event_inner(session_dir, session_id, skill, phase, payload)
+}
+
+fn append_event_inner(
+    session_dir: &Path,
+    session_id: &str,
+    skill: &str,
+    phase: Phase,
+    payload: Value,
+) -> Result<()> {
+    let redacted = redact::sanitize(payload);
+    let record = TraceRecord {
+        ts: Utc::now(),
+        skill: skill.to_string(),
+        session_id: session_id.to_string(),
+        phase,
+        payload: redacted,
+    };
+    let line = serde_json::to_string(&record).map_err(|source| SkillError::InvalidManifest {
+        path: session_dir.join("trace.jsonl"),
+        source,
+    })?;
+
+    let trace_path = session_dir.join("trace.jsonl");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&trace_path)
+        .map_err(|source| SkillError::Io {
+            path: trace_path.clone(),
+            source,
+        })?;
+    file.write_all(line.as_bytes())
+        .and_then(|()| file.write_all(b"\n"))
+        .map_err(|source| SkillError::Io {
+            path: trace_path.clone(),
+            source,
+        })
+}
+
+/// Write the final `end` event and refresh `meta.json` with the
+/// outcome + aggregated counts derived from the existing trace.
+pub fn finalise_session(
+    session_dir: &Path,
+    session_id: &str,
+    skill: &str,
+    outcome: Outcome,
+    summary: &str,
+) -> Result<()> {
+    append_event_inner(
+        session_dir,
+        session_id,
+        skill,
+        Phase::End,
+        json!({ "outcome": outcome, "summary": summary }),
+    )?;
+
+    let trace_path = session_dir.join("trace.jsonl");
+    let (tool_calls, errors, started_at) = scan_counts(&trace_path)?;
+
+    let meta = SessionMeta {
+        session_id: session_id.to_string(),
+        skill: skill.to_string(),
+        skill_version: None,
+        devboy_version: env!("CARGO_PKG_VERSION").to_string(),
+        started_at,
+        ended_at: Some(Utc::now()),
+        outcome: Some(outcome),
+        input_summary: None,
+        tool_calls,
+        errors,
+        summary: Some(summary.to_string()),
+    };
+    write_meta_file(&session_dir.join("meta.json"), &meta)
+}
+
+fn write_meta_file(path: &Path, meta: &SessionMeta) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(meta).map_err(|source| SkillError::InvalidManifest {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    std::fs::write(path, bytes).map_err(|source| SkillError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn scan_counts(trace_path: &Path) -> Result<(u64, u64, DateTime<Utc>)> {
+    let text = std::fs::read_to_string(trace_path).map_err(|source| SkillError::Io {
+        path: trace_path.to_path_buf(),
+        source,
+    })?;
+    let mut tool_calls = 0u64;
+    let mut errors = 0u64;
+    let mut started_at: Option<DateTime<Utc>> = None;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: TraceRecord = match serde_json::from_str(line) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        if started_at.is_none() && record.phase == Phase::Start {
+            started_at = Some(record.ts);
+        }
+        if record.phase == Phase::ToolCall {
+            tool_calls += 1;
+        }
+        if record.phase == Phase::ToolResult
+            && record
+                .payload
+                .get("ok")
+                .and_then(|v| v.as_bool())
+                .is_some_and(|ok| !ok)
+        {
+            errors += 1;
+        }
+    }
+    Ok((tool_calls, errors, started_at.unwrap_or_else(Utc::now)))
+}
+
+// ---------------------------------------------------------------------------
+// Session id
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "trace")]
+fn new_session_id() -> String {
+    ulid::Ulid::new().to_string()
+}
+
+#[cfg(not(feature = "trace"))]
+fn new_session_id() -> String {
+    // Deterministic-enough fallback when the `trace` feature is off —
+    // time-prefixed so logs stay sortable.
+    format!(
+        "{}-{:x}",
+        Utc::now().format("%Y%m%d%H%M%S%f"),
+        std::process::id()
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn events_in(path: &Path) -> Vec<TraceRecord> {
+        let text = std::fs::read_to_string(path).unwrap();
+        text.lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn session_round_trip() {
+        let dir = tempdir().unwrap();
+        let target = TraceTarget::Custom(dir.path().to_path_buf());
+
+        let tracer = SessionTracer::begin("devboy-setup", &target).unwrap();
+        let trace_path = tracer.trace_path().to_path_buf();
+        let meta_path = tracer.session_dir().join("meta.json");
+
+        tracer
+            .event(
+                Phase::Decision,
+                json!({ "question": "provider?", "decision": "github" }),
+            )
+            .unwrap();
+        tracer
+            .event(
+                Phase::ToolCall,
+                json!({ "tool": "get_issues", "args": { "limit": 3 } }),
+            )
+            .unwrap();
+        tracer
+            .event(
+                Phase::ToolResult,
+                json!({ "tool": "get_issues", "ok": true, "duration_ms": 42 }),
+            )
+            .unwrap();
+        tracer.end(Outcome::Success, "configured github").unwrap();
+
+        let events = events_in(&trace_path);
+        // start + decision + tool_call + tool_result + end = 5
+        assert_eq!(events.len(), 5);
+        assert_eq!(events[0].phase, Phase::Start);
+        assert_eq!(events.last().unwrap().phase, Phase::End);
+        assert!(events.iter().all(|e| e.skill == "devboy-setup"));
+        assert!(events.iter().all(|e| e.session_id == events[0].session_id));
+
+        let meta_bytes = std::fs::read(&meta_path).unwrap();
+        let meta: SessionMeta = serde_json::from_slice(&meta_bytes).unwrap();
+        assert_eq!(meta.skill, "devboy-setup");
+        assert_eq!(meta.outcome, Some(Outcome::Success));
+        assert_eq!(meta.tool_calls, 1);
+        assert_eq!(meta.errors, 0);
+    }
+
+    #[test]
+    fn failed_tool_result_is_counted_as_error() {
+        let dir = tempdir().unwrap();
+        let target = TraceTarget::Custom(dir.path().to_path_buf());
+        let tracer = SessionTracer::begin("devboy-test", &target).unwrap();
+        tracer
+            .event(Phase::ToolCall, json!({ "tool": "get_issues" }))
+            .unwrap();
+        tracer
+            .event(
+                Phase::ToolResult,
+                json!({ "tool": "get_issues", "ok": false, "error": "401 Unauthorized" }),
+            )
+            .unwrap();
+        let meta_path = tracer.session_dir().join("meta.json");
+        tracer.end(Outcome::Failure, "401").unwrap();
+
+        let meta: SessionMeta = serde_json::from_slice(&std::fs::read(meta_path).unwrap()).unwrap();
+        assert_eq!(meta.tool_calls, 1);
+        assert_eq!(meta.errors, 1);
+        assert_eq!(meta.outcome, Some(Outcome::Failure));
+    }
+
+    #[test]
+    fn events_are_redacted_before_writing() {
+        let dir = tempdir().unwrap();
+        let target = TraceTarget::Custom(dir.path().to_path_buf());
+        let tracer = SessionTracer::begin("devboy-test", &target).unwrap();
+        let trace_path = tracer.trace_path().to_path_buf();
+        tracer
+            .event(
+                Phase::ToolCall,
+                json!({
+                    "tool": "create_issue",
+                    "args": { "token": "ghp_012345678901234567890123456789012345" }
+                }),
+            )
+            .unwrap();
+        tracer.end(Outcome::Success, "").unwrap();
+
+        let text = std::fs::read_to_string(&trace_path).unwrap();
+        assert!(
+            !text.contains("ghp_0123456789"),
+            "trace contained raw GitHub token: {text}"
+        );
+        assert!(
+            text.contains("<redacted"),
+            "trace did not include redaction marker: {text}"
+        );
+    }
+
+    #[test]
+    fn global_target_respects_home_override() {
+        let home = tempdir().unwrap();
+        let home_path = home.path().to_path_buf();
+        temp_env::with_var("DEVBOY_HOME_OVERRIDE", Some(home.path()), || {
+            let root = TraceTarget::Global.sessions_root().unwrap();
+            assert!(root.starts_with(&home_path));
+        });
+    }
+
+    #[test]
+    fn custom_target_writes_exactly_where_asked() {
+        let dir = tempdir().unwrap();
+        let target = TraceTarget::Custom(dir.path().to_path_buf());
+        let tracer = SessionTracer::begin("x", &target).unwrap();
+        let trace_path = tracer.trace_path().to_path_buf();
+        assert!(trace_path.starts_with(dir.path()));
+        tracer.end(Outcome::Success, "").unwrap();
+    }
+}

--- a/crates/devboy-skills/src/trace/redact.rs
+++ b/crates/devboy-skills/src/trace/redact.rs
@@ -1,0 +1,254 @@
+//! Redaction of sensitive values before traces hit disk.
+//!
+//! Two mechanisms are layered:
+//!
+//! 1. Known credential shapes are masked regardless of where they
+//!    appear in the tree. Currently: `ghp_`, `glpat-`, `pk_live_`,
+//!    `pk_test_`, `sk-`, `xoxb-`/`xoxa-`/`xapp-`, `Bearer `, plus a
+//!    few other common prefixes. These all survive without knowing
+//!    the configured credential set — useful when a token leaks into
+//!    an error message, a git URL, or a user-supplied prompt.
+//! 2. Values of any string-valued environment variable whose name
+//!    matches a sensitive suffix (`*_TOKEN` / `*_SECRET` / `*_KEY` /
+//!    `*_PASSWORD` / `*_PASSPHRASE` / `AUTHORIZATION` / `COOKIE`) are
+//!    masked — the redactor snapshots those at call time.
+//!
+//! Setting the `DEVBOY_TRACE_REDACTION=off` environment variable
+//! disables both passes for local debugging. Never default to off.
+
+use std::collections::HashSet;
+
+use serde_json::Value;
+
+/// Redact sensitive data in `value`. Recursively walks maps and
+/// arrays. Strings are rewritten; numbers / bools / null pass through
+/// unchanged.
+pub fn sanitize(value: Value) -> Value {
+    if redaction_disabled() {
+        return value;
+    }
+    let secrets = known_env_secrets();
+    sanitize_with(&secrets, value)
+}
+
+fn redaction_disabled() -> bool {
+    match std::env::var("DEVBOY_TRACE_REDACTION") {
+        Ok(v) => matches!(v.to_lowercase().as_str(), "off" | "0" | "false" | "no"),
+        Err(_) => false,
+    }
+}
+
+fn sanitize_with(secrets: &HashSet<String>, value: Value) -> Value {
+    match value {
+        Value::String(s) => Value::String(redact_string(secrets, &s)),
+        Value::Array(xs) => {
+            Value::Array(xs.into_iter().map(|x| sanitize_with(secrets, x)).collect())
+        }
+        Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                // If the key itself hints at a secret, redact the whole
+                // value to prevent `{"auth": "Bearer abc"}` style leaks
+                // when the string does not match a known prefix.
+                let key_is_secret_name = key_looks_secret(&k);
+                let new_val = if key_is_secret_name && v.is_string() {
+                    Value::String("<redacted:secret-field>".to_string())
+                } else {
+                    sanitize_with(secrets, v)
+                };
+                out.insert(k, new_val);
+            }
+            Value::Object(out)
+        }
+        other => other,
+    }
+}
+
+fn redact_string(secrets: &HashSet<String>, s: &str) -> String {
+    // 1. Exact env-var match.
+    if !s.is_empty() && secrets.contains(s) {
+        return "<redacted:credential>".to_string();
+    }
+    // 2. Known token prefixes. We search case-sensitively because every
+    //    supported prefix is case-sensitive in practice.
+    if has_known_prefix(s) {
+        return "<redacted:token-pattern>".to_string();
+    }
+    // 3. Bearer / Basic schemes embedded inside a larger string. Don't
+    //    rewrite the whole string — replace only the credential segment.
+    if let Some(rewritten) = mask_auth_header_segment(s) {
+        return rewritten;
+    }
+    s.to_string()
+}
+
+fn has_known_prefix(s: &str) -> bool {
+    const PREFIXES: &[&str] = &[
+        // GitHub PATs
+        "ghp_",
+        "github_pat_",
+        "gho_",
+        "ghu_",
+        "ghs_",
+        "ghr_",
+        // GitLab PATs
+        "glpat-",
+        // Stripe-ish shapes, also matches ClickUp `pk_`
+        "pk_live_",
+        "pk_test_",
+        "sk_live_",
+        "sk_test_",
+        // OpenAI-ish
+        "sk-",
+        // Slack
+        "xoxb-",
+        "xoxa-",
+        "xoxp-",
+        "xapp-",
+        // Anthropic
+        "sk-ant-",
+        // Generic bearer markers users sometimes paste as a raw value.
+        "Bearer ",
+        "Basic ",
+    ];
+    PREFIXES
+        .iter()
+        .any(|p| s.starts_with(p) && s.len() > p.len() + 8)
+}
+
+fn mask_auth_header_segment(s: &str) -> Option<String> {
+    // e.g. "Authorization: Bearer ghp_…" embedded inside a log line.
+    let needles = ["Bearer ", "Basic "];
+    for needle in needles {
+        if let Some(idx) = s.find(needle) {
+            let head = &s[..idx];
+            // Credential runs until whitespace, comma, or semicolon.
+            let rest = &s[idx + needle.len()..];
+            let end = rest
+                .find(|c: char| c.is_whitespace() || c == ',' || c == ';')
+                .unwrap_or(rest.len());
+            if end >= 8 {
+                let tail = &rest[end..];
+                return Some(format!("{head}{needle}<redacted:auth>{tail}"));
+            }
+        }
+    }
+    None
+}
+
+fn key_looks_secret(key: &str) -> bool {
+    let upper = key.to_ascii_uppercase();
+    const SUFFIXES: &[&str] = &[
+        "_TOKEN",
+        "_SECRET",
+        "_KEY",
+        "_PASSWORD",
+        "_PASSPHRASE",
+        "_AUTH",
+    ];
+    const EXACT: &[&str] = &["AUTHORIZATION", "COOKIE", "TOKEN", "SECRET", "PASSWORD"];
+    if EXACT.contains(&upper.as_str()) {
+        return true;
+    }
+    if SUFFIXES.iter().any(|suf| upper.ends_with(suf)) {
+        return true;
+    }
+    // Common devboy conventions.
+    if key.contains("password") || key.contains("secret") || key.contains("token") {
+        return true;
+    }
+    false
+}
+
+fn known_env_secrets() -> HashSet<String> {
+    let mut out = HashSet::new();
+    for (name, value) in std::env::vars() {
+        if value.is_empty() {
+            continue;
+        }
+        if key_looks_secret(&name) {
+            out.insert(value);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn masks_github_pat() {
+        let v = json!({ "args": { "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } });
+        let out = sanitize(v);
+        let s = serde_json::to_string(&out).unwrap();
+        assert!(!s.contains("ghp_aaaaaaaa"));
+        assert!(s.contains("<redacted"));
+    }
+
+    #[test]
+    fn masks_bearer_scheme_in_header_string() {
+        let v = json!("Authorization: Bearer xxxxxxxxxxxxyyyyyyyyyyyy");
+        let out = sanitize(v);
+        let s = out.as_str().unwrap();
+        assert!(!s.contains("xxxxxxxxxxxxyyyyyyyyyyyy"), "got: {s}");
+        assert!(s.contains("<redacted"), "got: {s}");
+    }
+
+    #[test]
+    fn masks_by_key_name_even_when_value_looks_harmless() {
+        // A value that does not match any known prefix but lives under
+        // a key called `password` must still be redacted.
+        let v = json!({ "password": "not-a-prefix" });
+        let out = sanitize(v);
+        assert_eq!(
+            out.get("password").and_then(|v| v.as_str()),
+            Some("<redacted:secret-field>")
+        );
+    }
+
+    #[test]
+    fn env_var_values_are_redacted_when_they_match_exactly() {
+        temp_env::with_var(
+            "DEVBOY_TEST_TOKEN",
+            Some("super-secret-value-nothing-matches"),
+            || {
+                let v = json!({ "note": "leaked: super-secret-value-nothing-matches" });
+                let out = sanitize(v);
+                // The exact-match secret replacement only fires when the
+                // value IS the secret — not when it's embedded in a
+                // larger string. Embedded leakage is the DLP case we do
+                // not attempt to solve (see the doc comment). Assert the
+                // exact-value case instead.
+                let note = out.get("note").and_then(|v| v.as_str()).unwrap();
+                assert_eq!(note, "leaked: super-secret-value-nothing-matches");
+
+                let v = json!({ "raw": "super-secret-value-nothing-matches" });
+                let out = sanitize(v);
+                assert_eq!(
+                    out.get("raw").and_then(|v| v.as_str()),
+                    Some("<redacted:credential>")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn short_strings_are_not_redacted_by_prefix_check() {
+        // `ghp_` alone must not be redacted — only long PAT-shaped
+        // strings are. This matters for documentation and for the
+        // redaction marker itself.
+        let v = json!("ghp_");
+        assert_eq!(sanitize(v).as_str(), Some("ghp_"));
+    }
+
+    #[test]
+    fn redaction_can_be_disabled_via_env() {
+        temp_env::with_var("DEVBOY_TRACE_REDACTION", Some("off"), || {
+            let v = json!({ "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
+            let out = sanitize(v.clone());
+            assert_eq!(out, v);
+        });
+    }
+}

--- a/crates/devboy-skills/src/trace/redact.rs
+++ b/crates/devboy-skills/src/trace/redact.rs
@@ -3,11 +3,12 @@
 //! Two mechanisms are layered:
 //!
 //! 1. Known credential shapes are masked regardless of where they
-//!    appear in the tree. Currently: `ghp_`, `glpat-`, `pk_live_`,
-//!    `pk_test_`, `sk-`, `xoxb-`/`xoxa-`/`xapp-`, `Bearer `, plus a
-//!    few other common prefixes. These all survive without knowing
-//!    the configured credential set — useful when a token leaks into
-//!    an error message, a git URL, or a user-supplied prompt.
+//!    appear in the tree. Currently: `ghp_`, `glpat-`, `pk_`, `sk-`,
+//!    `xoxb-` / `xoxa-` / `xapp-`, `Bearer ` / `Basic ` (case-
+//!    insensitive), plus a few other common prefixes. These all
+//!    survive without knowing the configured credential set — useful
+//!    when a token leaks into an error message, a git URL, or a
+//!    user-supplied prompt.
 //! 2. Values of any string-valued environment variable whose name
 //!    matches a sensitive suffix (`*_TOKEN` / `*_SECRET` / `*_KEY` /
 //!    `*_PASSWORD` / `*_PASSPHRASE` / `AUTHORIZATION` / `COOKIE`) are
@@ -15,6 +16,15 @@
 //!
 //! Setting the `DEVBOY_TRACE_REDACTION=off` environment variable
 //! disables both passes for local debugging. Never default to off.
+//!
+//! ## Amortizing the env snapshot
+//!
+//! The top-level [`sanitize`] helper walks `std::env::vars()` on every
+//! call — fine for one-shot CLI invocations but wasteful inside a
+//! long-running producer like [`super::SessionTracer`] that writes
+//! many events. Build a [`Redactor`] once with
+//! [`Redactor::snapshot`] and reuse it for every event in the same
+//! session to pay the env scan just once.
 
 use std::collections::HashSet;
 
@@ -23,12 +33,49 @@ use serde_json::Value;
 /// Redact sensitive data in `value`. Recursively walks maps and
 /// arrays. Strings are rewritten; numbers / bools / null pass through
 /// unchanged.
+///
+/// Each call snapshots `*_TOKEN` / `*_SECRET` / … env vars afresh so
+/// that tests using `temp_env::with_var` (and production callers that
+/// legitimately mutate the environment) see up-to-date state. Inside
+/// a long session, prefer [`Redactor::snapshot`] + [`Redactor::sanitize`].
 pub fn sanitize(value: Value) -> Value {
-    if redaction_disabled() {
-        return value;
+    Redactor::snapshot().sanitize(value)
+}
+
+/// A reusable redactor that holds one env-var snapshot. Created via
+/// [`Redactor::snapshot`]; use once per long-running producer (e.g.
+/// one per `SessionTracer`) to avoid rescanning the environment on
+/// every event.
+#[derive(Debug, Clone)]
+pub struct Redactor {
+    enabled: bool,
+    secrets: HashSet<String>,
+}
+
+impl Redactor {
+    /// Capture the current set of sensitive env-var values and the
+    /// `DEVBOY_TRACE_REDACTION=off` opt-out state. Cheap to clone.
+    pub fn snapshot() -> Self {
+        if redaction_disabled() {
+            Self {
+                enabled: false,
+                secrets: HashSet::new(),
+            }
+        } else {
+            Self {
+                enabled: true,
+                secrets: known_env_secrets(),
+            }
+        }
     }
-    let secrets = known_env_secrets();
-    sanitize_with(&secrets, value)
+
+    /// Sanitize a single value using the captured env-var snapshot.
+    pub fn sanitize(&self, value: Value) -> Value {
+        if !self.enabled {
+            return value;
+        }
+        sanitize_with(&self.secrets, value)
+    }
 }
 
 fn redaction_disabled() -> bool {
@@ -84,7 +131,11 @@ fn redact_string(secrets: &HashSet<String>, s: &str) -> String {
 }
 
 fn has_known_prefix(s: &str) -> bool {
-    const PREFIXES: &[&str] = &[
+    // Case-sensitive prefixes. The publisher-defined provider tokens
+    // are all case-sensitive in the wild, so matching them strictly
+    // avoids redacting words that merely share the letters (e.g. an
+    // English sentence starting with "Ghp").
+    const CASE_SENSITIVE: &[&str] = &[
         // GitHub PATs
         "ghp_",
         "github_pat_",
@@ -94,35 +145,46 @@ fn has_known_prefix(s: &str) -> bool {
         "ghr_",
         // GitLab PATs
         "glpat-",
-        // Stripe-ish shapes, also matches ClickUp `pk_`
-        "pk_live_",
-        "pk_test_",
-        "sk_live_",
-        "sk_test_",
-        // OpenAI-ish
+        // Publishable / secret key families shared across a few
+        // providers (Stripe, ClickUp, etc.). ADR-015 spec calls these
+        // out as a single `pk_` / `sk_` group — keep them generic.
+        "pk_",
+        "sk_",
+        // OpenAI-ish (also covers sk-ant-… via the `sk-` prefix).
         "sk-",
         // Slack
         "xoxb-",
         "xoxa-",
         "xoxp-",
         "xapp-",
-        // Anthropic
-        "sk-ant-",
-        // Generic bearer markers users sometimes paste as a raw value.
-        "Bearer ",
-        "Basic ",
     ];
-    PREFIXES
+    if CASE_SENSITIVE
         .iter()
         .any(|p| s.starts_with(p) && s.len() > p.len() + 8)
+    {
+        return true;
+    }
+    // Case-insensitive auth-scheme prefixes: HTTP scheme tokens are
+    // case-insensitive per RFC 7235, so `Bearer <tok>`, `bearer <tok>`
+    // and `BEARER <tok>` should all redact.
+    const SCHEME_CI: &[&str] = &["bearer ", "basic "];
+    let lower = s.to_ascii_lowercase();
+    SCHEME_CI
+        .iter()
+        .any(|p| lower.starts_with(p) && s.len() > p.len() + 8)
 }
 
 fn mask_auth_header_segment(s: &str) -> Option<String> {
     // e.g. "Authorization: Bearer ghp_…" embedded inside a log line.
-    let needles = ["Bearer ", "Basic "];
+    // HTTP auth schemes are case-insensitive (RFC 7235), so locate the
+    // needle in the lowercased copy but preserve the original casing
+    // of the scheme token in the rewritten output.
+    let lower = s.to_ascii_lowercase();
+    let needles = ["bearer ", "basic "];
     for needle in needles {
-        if let Some(idx) = s.find(needle) {
+        if let Some(idx) = lower.find(needle) {
             let head = &s[..idx];
+            let scheme = &s[idx..idx + needle.len()]; // original case preserved
             // Credential runs until whitespace, comma, or semicolon.
             let rest = &s[idx + needle.len()..];
             let end = rest
@@ -130,7 +192,7 @@ fn mask_auth_header_segment(s: &str) -> Option<String> {
                 .unwrap_or(rest.len());
             if end >= 8 {
                 let tail = &rest[end..];
-                return Some(format!("{head}{needle}<redacted:auth>{tail}"));
+                return Some(format!("{head}{scheme}<redacted:auth>{tail}"));
             }
         }
     }
@@ -253,6 +315,92 @@ mod tests {
             let v = json!({ "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
             let out = sanitize(v.clone());
             assert_eq!(out, v);
+        });
+    }
+
+    #[test]
+    fn masks_bearer_scheme_case_insensitive() {
+        // HTTP schemes are case-insensitive per RFC 7235, so all of
+        // these variants must redact.
+        for header in [
+            "Authorization: Bearer xxxxxxxxxxxxyyyyyyyyyyyy",
+            "authorization: bearer xxxxxxxxxxxxyyyyyyyyyyyy",
+            "AUTHORIZATION: BEARER xxxxxxxxxxxxyyyyyyyyyyyy",
+            "authorization: BeArEr xxxxxxxxxxxxyyyyyyyyyyyy",
+        ] {
+            let out = sanitize(json!(header));
+            let s = out.as_str().unwrap();
+            assert!(
+                !s.contains("xxxxxxxxxxxxyyyyyyyyyyyy"),
+                "token leaked for header `{header}` → `{s}`"
+            );
+            assert!(
+                s.contains("<redacted"),
+                "no redaction marker for header `{header}` → `{s}`"
+            );
+        }
+    }
+
+    #[test]
+    fn masks_bare_bearer_value_case_insensitive() {
+        // When the caller pasted just the `Bearer <token>` segment as
+        // a standalone value, the prefix check (not the header scanner)
+        // fires — must also be case-insensitive.
+        for raw in [
+            "Bearer abcdefghijklmnopqrstuvwx",
+            "bearer abcdefghijklmnopqrstuvwx",
+            "BEARER abcdefghijklmnopqrstuvwx",
+            "Basic YWxpY2U6aHVudGVyMjpkcmFnb24=",
+        ] {
+            let out = sanitize(json!(raw));
+            let s = out.as_str().unwrap();
+            assert!(s.contains("<redacted"), "not redacted: `{raw}` → `{s}`");
+        }
+    }
+
+    #[test]
+    fn masks_generic_pk_prefix() {
+        // ADR-015 calls out a generic `pk_` prefix (not just
+        // `pk_live_` / `pk_test_`). Enough bytes after the prefix to
+        // clear the length guard so a bare `pk_` literal is left alone.
+        let v = json!({ "clickup_pk": "pk_abcdefghijklmnop" });
+        let out = sanitize(v);
+        assert_eq!(
+            out.get("clickup_pk").and_then(|v| v.as_str()),
+            Some("<redacted:token-pattern>"),
+            "generic pk_ prefix should redact"
+        );
+
+        // Short `pk_` literal stays untouched (e.g. in docs).
+        let doc = json!("pk_");
+        assert_eq!(sanitize(doc).as_str(), Some("pk_"));
+    }
+
+    #[test]
+    fn redactor_snapshot_amortizes_env_scan() {
+        // The Redactor captures the env-var set at snapshot time and
+        // keeps redacting the snapshotted value even after the source
+        // env var has been unset — this is what makes reuse inside a
+        // long session cheap and consistent.
+        let redactor = temp_env::with_var(
+            "DEVBOY_REDACTOR_CACHE_TOKEN",
+            Some("cached-token-zzzzzzzz"),
+            Redactor::snapshot,
+        );
+        // The env var is gone at this point, but the snapshot remembers.
+        let out = redactor.sanitize(json!({ "raw": "cached-token-zzzzzzzz" }));
+        assert_eq!(
+            out.get("raw").and_then(|v| v.as_str()),
+            Some("<redacted:credential>")
+        );
+    }
+
+    #[test]
+    fn redactor_snapshot_respects_disable_env() {
+        temp_env::with_var("DEVBOY_TRACE_REDACTION", Some("off"), || {
+            let redactor = Redactor::snapshot();
+            let v = json!({ "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
+            assert_eq!(redactor.sanitize(v.clone()), v);
         });
     }
 }

--- a/crates/devboy-skills/src/trace/redact.rs
+++ b/crates/devboy-skills/src/trace/redact.rs
@@ -48,10 +48,11 @@ fn sanitize_with(secrets: &HashSet<String>, value: Value) -> Value {
             let mut out = serde_json::Map::with_capacity(map.len());
             for (k, v) in map {
                 // If the key itself hints at a secret, redact the whole
-                // value to prevent `{"auth": "Bearer abc"}` style leaks
-                // when the string does not match a known prefix.
-                let key_is_secret_name = key_looks_secret(&k);
-                let new_val = if key_is_secret_name && v.is_string() {
+                // value regardless of its type. This prevents structured
+                // leaks like `{"authorization": {"scheme": "Bearer",
+                // "value": "…"}}` where nested field names may not
+                // themselves trip the secret-key heuristic.
+                let new_val = if key_looks_secret(&k) {
                     Value::String("<redacted:secret-field>".to_string())
                 } else {
                     sanitize_with(secrets, v)
@@ -154,7 +155,10 @@ fn key_looks_secret(key: &str) -> bool {
         return true;
     }
     // Common devboy conventions.
-    if key.contains("password") || key.contains("secret") || key.contains("token") {
+    // Use the upper-cased copy for the substring heuristic too, so
+    // mixed-case keys like `Password` / `Token` / `Secret` are caught
+    // consistently with the EXACT / SUFFIX branches above.
+    if upper.contains("PASSWORD") || upper.contains("SECRET") || upper.contains("TOKEN") {
         return true;
     }
     false

--- a/crates/devboy-skills/src/trace/redact.rs
+++ b/crates/devboy-skills/src/trace/redact.rs
@@ -243,50 +243,86 @@ fn known_env_secrets() -> HashSet<String> {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::sync::Mutex;
+
+    /// Serialise every test in this module around the process-wide
+    /// environment. Two tests legitimately toggle
+    /// `DEVBOY_TRACE_REDACTION=off` via `temp_env::with_var`, and
+    /// `cargo test` runs the others concurrently — without this mutex
+    /// a sibling test's `off` setting can leak into an unrelated test
+    /// for the window it holds the var, making
+    /// `masks_bare_bearer_value_case_insensitive` and friends flake
+    /// on CI. The mutex is cheap (only contended during tests) and
+    /// keeps the production code path zero-overhead. Combined with
+    /// `temp_env::with_var`'s own save/restore logic this gives the
+    /// whole module deterministic env state.
+    static ENV_TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    /// Helper: acquire the module-wide env-serialisation lock and run
+    /// `f` inside a `temp_env` guard that explicitly UNsets
+    /// `DEVBOY_TRACE_REDACTION`. Used by every test that expects the
+    /// default (enabled) redactor. Without this wrapper a sibling
+    /// test's `DEVBOY_TRACE_REDACTION=off` setting could race in and
+    /// silently disable redaction mid-assertion.
+    fn with_clean_env<R>(f: impl FnOnce() -> R) -> R {
+        let _guard = ENV_TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+        temp_env::with_var("DEVBOY_TRACE_REDACTION", None::<&str>, f)
+    }
 
     #[test]
     fn masks_github_pat() {
-        let v = json!({ "args": { "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } });
-        let out = sanitize(v);
-        let s = serde_json::to_string(&out).unwrap();
-        assert!(!s.contains("ghp_aaaaaaaa"));
-        assert!(s.contains("<redacted"));
+        with_clean_env(|| {
+            let v = json!({ "args": { "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } });
+            let out = sanitize(v);
+            let s = serde_json::to_string(&out).unwrap();
+            assert!(!s.contains("ghp_aaaaaaaa"));
+            assert!(s.contains("<redacted"));
+        });
     }
 
     #[test]
     fn masks_bearer_scheme_in_header_string() {
-        let v = json!("Authorization: Bearer xxxxxxxxxxxxyyyyyyyyyyyy");
-        let out = sanitize(v);
-        let s = out.as_str().unwrap();
-        assert!(!s.contains("xxxxxxxxxxxxyyyyyyyyyyyy"), "got: {s}");
-        assert!(s.contains("<redacted"), "got: {s}");
+        with_clean_env(|| {
+            let v = json!("Authorization: Bearer xxxxxxxxxxxxyyyyyyyyyyyy");
+            let out = sanitize(v);
+            let s = out.as_str().unwrap();
+            assert!(!s.contains("xxxxxxxxxxxxyyyyyyyyyyyy"), "got: {s}");
+            assert!(s.contains("<redacted"), "got: {s}");
+        });
     }
 
     #[test]
     fn masks_by_key_name_even_when_value_looks_harmless() {
-        // A value that does not match any known prefix but lives under
-        // a key called `password` must still be redacted.
-        let v = json!({ "password": "not-a-prefix" });
-        let out = sanitize(v);
-        assert_eq!(
-            out.get("password").and_then(|v| v.as_str()),
-            Some("<redacted:secret-field>")
-        );
+        with_clean_env(|| {
+            // A value that does not match any known prefix but lives under
+            // a key called `password` must still be redacted.
+            let v = json!({ "password": "not-a-prefix" });
+            let out = sanitize(v);
+            assert_eq!(
+                out.get("password").and_then(|v| v.as_str()),
+                Some("<redacted:secret-field>")
+            );
+        });
     }
 
     #[test]
     fn env_var_values_are_redacted_when_they_match_exactly() {
-        temp_env::with_var(
-            "DEVBOY_TEST_TOKEN",
-            Some("super-secret-value-nothing-matches"),
+        let _guard = ENV_TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+        temp_env::with_vars(
+            [
+                ("DEVBOY_TRACE_REDACTION", None::<&str>),
+                (
+                    "DEVBOY_TEST_TOKEN",
+                    Some("super-secret-value-nothing-matches"),
+                ),
+            ],
             || {
                 let v = json!({ "note": "leaked: super-secret-value-nothing-matches" });
                 let out = sanitize(v);
-                // The exact-match secret replacement only fires when the
-                // value IS the secret — not when it's embedded in a
-                // larger string. Embedded leakage is the DLP case we do
-                // not attempt to solve (see the doc comment). Assert the
-                // exact-value case instead.
+                // The exact-match secret replacement only fires when
+                // the value IS the secret — not when it's embedded in
+                // a larger string. Embedded leakage is the DLP case we
+                // don't attempt to solve (see the doc comment).
                 let note = out.get("note").and_then(|v| v.as_str()).unwrap();
                 assert_eq!(note, "leaked: super-secret-value-nothing-matches");
 
@@ -302,15 +338,18 @@ mod tests {
 
     #[test]
     fn short_strings_are_not_redacted_by_prefix_check() {
-        // `ghp_` alone must not be redacted — only long PAT-shaped
-        // strings are. This matters for documentation and for the
-        // redaction marker itself.
-        let v = json!("ghp_");
-        assert_eq!(sanitize(v).as_str(), Some("ghp_"));
+        with_clean_env(|| {
+            // `ghp_` alone must not be redacted — only long PAT-shaped
+            // strings are. This matters for documentation and for the
+            // redaction marker itself.
+            let v = json!("ghp_");
+            assert_eq!(sanitize(v).as_str(), Some("ghp_"));
+        });
     }
 
     #[test]
     fn redaction_can_be_disabled_via_env() {
+        let _guard = ENV_TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
         temp_env::with_var("DEVBOY_TRACE_REDACTION", Some("off"), || {
             let v = json!({ "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
             let out = sanitize(v.clone());
@@ -320,71 +359,76 @@ mod tests {
 
     #[test]
     fn masks_bearer_scheme_case_insensitive() {
-        // HTTP schemes are case-insensitive per RFC 7235, so all of
-        // these variants must redact.
-        for header in [
-            "Authorization: Bearer xxxxxxxxxxxxyyyyyyyyyyyy",
-            "authorization: bearer xxxxxxxxxxxxyyyyyyyyyyyy",
-            "AUTHORIZATION: BEARER xxxxxxxxxxxxyyyyyyyyyyyy",
-            "authorization: BeArEr xxxxxxxxxxxxyyyyyyyyyyyy",
-        ] {
-            let out = sanitize(json!(header));
-            let s = out.as_str().unwrap();
-            assert!(
-                !s.contains("xxxxxxxxxxxxyyyyyyyyyyyy"),
-                "token leaked for header `{header}` → `{s}`"
-            );
-            assert!(
-                s.contains("<redacted"),
-                "no redaction marker for header `{header}` → `{s}`"
-            );
-        }
+        with_clean_env(|| {
+            // HTTP schemes are case-insensitive per RFC 7235, so all of
+            // these variants must redact.
+            for header in [
+                "Authorization: Bearer xxxxxxxxxxxxyyyyyyyyyyyy",
+                "authorization: bearer xxxxxxxxxxxxyyyyyyyyyyyy",
+                "AUTHORIZATION: BEARER xxxxxxxxxxxxyyyyyyyyyyyy",
+                "authorization: BeArEr xxxxxxxxxxxxyyyyyyyyyyyy",
+            ] {
+                let out = sanitize(json!(header));
+                let s = out.as_str().unwrap();
+                assert!(
+                    !s.contains("xxxxxxxxxxxxyyyyyyyyyyyy"),
+                    "token leaked for header `{header}` → `{s}`"
+                );
+                assert!(
+                    s.contains("<redacted"),
+                    "no redaction marker for header `{header}` → `{s}`"
+                );
+            }
+        });
     }
 
     #[test]
     fn masks_bare_bearer_value_case_insensitive() {
-        // When the caller pasted just the `Bearer <token>` segment as
-        // a standalone value, the prefix check (not the header scanner)
-        // fires — must also be case-insensitive.
-        for raw in [
-            "Bearer abcdefghijklmnopqrstuvwx",
-            "bearer abcdefghijklmnopqrstuvwx",
-            "BEARER abcdefghijklmnopqrstuvwx",
-            "Basic YWxpY2U6aHVudGVyMjpkcmFnb24=",
-        ] {
-            let out = sanitize(json!(raw));
-            let s = out.as_str().unwrap();
-            assert!(s.contains("<redacted"), "not redacted: `{raw}` → `{s}`");
-        }
+        with_clean_env(|| {
+            // When the caller pasted just the `Bearer <token>` segment as
+            // a standalone value, the prefix check (not the header scanner)
+            // fires — must also be case-insensitive.
+            for raw in [
+                "Bearer abcdefghijklmnopqrstuvwx",
+                "bearer abcdefghijklmnopqrstuvwx",
+                "BEARER abcdefghijklmnopqrstuvwx",
+                "Basic YWxpY2U6aHVudGVyMjpkcmFnb24=",
+            ] {
+                let out = sanitize(json!(raw));
+                let s = out.as_str().unwrap();
+                assert!(s.contains("<redacted"), "not redacted: `{raw}` → `{s}`");
+            }
+        });
     }
 
     #[test]
     fn masks_generic_pk_prefix() {
-        // ADR-015 calls out a generic `pk_` prefix (not just
-        // `pk_live_` / `pk_test_`). Enough bytes after the prefix to
-        // clear the length guard so a bare `pk_` literal is left alone.
-        let v = json!({ "clickup_pk": "pk_abcdefghijklmnop" });
-        let out = sanitize(v);
-        assert_eq!(
-            out.get("clickup_pk").and_then(|v| v.as_str()),
-            Some("<redacted:token-pattern>"),
-            "generic pk_ prefix should redact"
-        );
+        with_clean_env(|| {
+            // ADR-015 calls out a generic `pk_` prefix (not just
+            // `pk_live_` / `pk_test_`). Enough bytes after the prefix to
+            // clear the length guard so a bare `pk_` literal is left alone.
+            let v = json!({ "clickup_pk": "pk_abcdefghijklmnop" });
+            let out = sanitize(v);
+            assert_eq!(
+                out.get("clickup_pk").and_then(|v| v.as_str()),
+                Some("<redacted:token-pattern>"),
+                "generic pk_ prefix should redact"
+            );
 
-        // Short `pk_` literal stays untouched (e.g. in docs).
-        let doc = json!("pk_");
-        assert_eq!(sanitize(doc).as_str(), Some("pk_"));
+            // Short `pk_` literal stays untouched (e.g. in docs).
+            let doc = json!("pk_");
+            assert_eq!(sanitize(doc).as_str(), Some("pk_"));
+        });
     }
 
     #[test]
     fn redactor_snapshot_amortizes_env_scan() {
-        // The Redactor captures the env-var set at snapshot time and
-        // keeps redacting the snapshotted value even after the source
-        // env var has been unset — this is what makes reuse inside a
-        // long session cheap and consistent.
-        let redactor = temp_env::with_var(
-            "DEVBOY_REDACTOR_CACHE_TOKEN",
-            Some("cached-token-zzzzzzzz"),
+        let _guard = ENV_TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+        let redactor = temp_env::with_vars(
+            [
+                ("DEVBOY_TRACE_REDACTION", None::<&str>),
+                ("DEVBOY_REDACTOR_CACHE_TOKEN", Some("cached-token-zzzzzzzz")),
+            ],
             Redactor::snapshot,
         );
         // The env var is gone at this point, but the snapshot remembers.
@@ -397,6 +441,7 @@ mod tests {
 
     #[test]
     fn redactor_snapshot_respects_disable_env() {
+        let _guard = ENV_TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
         temp_env::with_var("DEVBOY_TRACE_REDACTION", Some("off"), || {
             let redactor = Redactor::snapshot();
             let v = json!({ "token": "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });

--- a/docs/guide/_nav.json
+++ b/docs/guide/_nav.json
@@ -15,6 +15,11 @@
     "activeMatch": "/configuration/proxy"
   },
   {
+    "text": "Skills",
+    "link": "/skills/",
+    "activeMatch": "/skills/"
+  },
+  {
     "text": "Architecture",
     "link": "/architecture/",
     "activeMatch": "/architecture/"

--- a/docs/guide/skills/_meta.json
+++ b/docs/guide/skills/_meta.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "file",
+    "name": "index",
+    "label": "Overview"
+  }
+]

--- a/docs/guide/skills/index.md
+++ b/docs/guide/skills/index.md
@@ -49,10 +49,11 @@ Preview a change without touching disk:
 devboy skills install devboy-review-mr --agent claude --dry-run
 ```
 
-Upgrade previously-installed skills after a `devboy upgrade`:
+Upgrade previously-installed skills after a `devboy upgrade` — with no arguments the subcommand upgrades every skill recorded in the local manifest; pass explicit names to scope it to a subset:
 
 ```bash
-devboy skills upgrade --all
+devboy skills upgrade                       # every installed skill
+devboy skills upgrade devboy-review-mr      # just one
 ```
 
 ## Where skills go

--- a/docs/guide/skills/index.md
+++ b/docs/guide/skills/index.md
@@ -80,7 +80,7 @@ This means you can edit installed skills to taste and later upgrade the rest of 
 
 ## Session traces
 
-Skills in the `self-feedback` category read **session traces** — append-only JSONL files at `<target>/.devboy/sessions/<YYYY-MM-DD>/<skill>/trace.jsonl` that record what another skill did. Any caller can write into that format via the `devboy trace` CLI:
+Skills in the `self-feedback` category read **session traces** — append-only JSONL files at `<target>/.devboy/sessions/<YYYY-MM-DD>/<skill>/<session_id>/trace.jsonl` that record what another skill did. Each `trace begin` gets its own `<session_id>` subdirectory with a sibling `meta.json`, so concurrent runs of the same skill on the same day never overwrite one another. Any caller can write into that format via the `devboy trace` CLI:
 
 ```bash
 result=$(devboy trace begin --skill my-skill)

--- a/docs/guide/skills/index.md
+++ b/docs/guide/skills/index.md
@@ -1,0 +1,124 @@
+# Skills
+
+`devboy-tools` is not only a tool bundle — it also ships a catalogue of **skills**: small Markdown recipes that tell an AI agent how to use those tools to accomplish common tasks. Skills are the second half of the "configurable tool bundle" story (see [ADR-012](https://github.com/meteora-pro/devboy-tools/blob/main/docs/architecture/adr/ADR-012-skills-subsystem.md)).
+
+A skill is a single `SKILL.md` file with a short YAML frontmatter and a Markdown body. Agents that honour the Agent Skills Standard pick them up from a well-known directory; the CLI puts them there for you.
+
+## Why skills
+
+Tools are verbs — `get_issues`, `create_merge_request`, `send_message`. Skills are short recipes that chain verbs into procedures: "to review a merge request, first fetch the diff, then look up open discussions, then post inline comments with this checklist". Without skills, every agent learns those patterns from scratch on every new project. With skills, the pattern ships next to the tools it calls and every agent picks it up for free.
+
+Skills in `devboy-tools` follow a few conventions:
+
+- **English only** — no locale-specific copy in the baseline catalogue.
+- **CLI-first tool invocation** — skills call `devboy tools call <name>` rather than referring to a specific MCP server. That keeps recipes portable across agents and transports.
+- **Short bodies** — roughly one page each. A skill is a recipe, not a framework.
+- **Minimal frontmatter** — `name`, `description`, `category`, `version` are required; `compatibility`, `activation`, `tools` are recommended; unknown fields are preserved.
+
+## The shipped catalogue
+
+The baseline catalogue is compiled into the binary and falls into six categories. Every skill is listed with `devboy skills list`; every skill's full body is printed with `devboy skills show <name>`.
+
+| Category | What the skills cover |
+|----------|-----------------------|
+| `self-bootstrap` | Configure and repair `devboy-tools` itself. |
+| `issue-tracking` | Fetch, create, update, link, and solve issues across GitHub / GitLab / ClickUp / Jira. |
+| `code-review` | Review a merge request, apply reviewer feedback, dry-run a review pass of your own MR. |
+| `self-feedback` | Run and verify a command, produce a daily report, do a retrospective over the last N days, extract the lesson from a fix. |
+| `meeting-notes` | Search meeting notes, fetch a transcript, turn action items into issues. |
+| `messenger` | Search chat history, summarise a channel over a time window, send a structured notification. |
+
+## Quick start
+
+Install the self-bootstrap skills into the current project:
+
+```bash
+devboy skills list --category self-bootstrap
+devboy skills install --category self-bootstrap
+```
+
+Install every shipped skill globally so Claude Code / Codex / Cursor / Kimi pick them up regardless of which repository you're in:
+
+```bash
+devboy skills install --all --agent all
+```
+
+Preview a change without touching disk:
+
+```bash
+devboy skills install devboy-review-mr --agent claude --dry-run
+```
+
+Upgrade previously-installed skills after a `devboy upgrade`:
+
+```bash
+devboy skills upgrade --all
+```
+
+## Where skills go
+
+Install targets follow the rules in [ADR-013](https://github.com/meteora-pro/devboy-tools/blob/main/docs/architecture/adr/ADR-013-skills-install-targets.md):
+
+- **Default** — repo-local at `<repo>/.agents/skills/<skill>/`. Mirrors the `.devboy.toml` convention.
+- `--global` — `~/.agents/skills/<skill>/`.
+- `--agent claude|codex|cursor|kimi` — that agent's conventional path (e.g. `~/.claude/skills/`).
+- `--agent all` — every detected agent, plus the vendor-neutral `~/.agents/skills/`.
+- `--local` in combination with `--agent X` puts the install inside the repo instead of the home directory.
+
+If you run `devboy skills install` outside a git repository and without `--global` or `--agent`, the command fails with a clear error listing the flags you might have meant — no silent fallbacks.
+
+## Upgrade safety
+
+Every install target keeps a `.manifest.json` recording the SHA256 of each installed file. When you `upgrade`:
+
+- **Unchanged** files (same hash as the current shipped version) are skipped silently.
+- **Historical-safe** files (hash matches a version we previously shipped) are auto-upgraded to the current version.
+- **User-modified** files (hash matches nothing we ever shipped) are left alone with a warning. Pass `--force` to overwrite.
+
+This means you can edit installed skills to taste and later upgrade the rest of the catalogue without losing your edits. See [ADR-014](https://github.com/meteora-pro/devboy-tools/blob/main/docs/architecture/adr/ADR-014-skills-lifecycle.md) for the full lifecycle.
+
+## Session traces
+
+Skills in the `self-feedback` category read **session traces** — append-only JSONL files at `<target>/.devboy/sessions/<YYYY-MM-DD>/<skill>/trace.jsonl` that record what another skill did. Any caller can write into that format via the `devboy trace` CLI:
+
+```bash
+result=$(devboy trace begin --skill my-skill)
+SESSION_DIR=$(echo "$result" | jq -r .session_dir)
+SESSION_ID=$(echo "$result" | jq -r .session_id)
+
+devboy trace event --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill my-skill --phase tool_call \
+  --payload '{"tool":"get_issues","args":{"limit":20}}'
+
+devboy trace end --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill my-skill --outcome success --summary "pulled 20 issues"
+```
+
+A central redaction pass strips known credential shapes and env-var-valued secrets before anything lands on disk. Set `DEVBOY_TRACE_REDACTION=off` to disable it for local debugging only. The format is described in [ADR-015](https://github.com/meteora-pro/devboy-tools/blob/main/docs/architecture/adr/ADR-015-skills-session-traces.md).
+
+## Adding your own skill
+
+Skills are plain Markdown. To add one to a project, drop a `SKILL.md` under `<repo>/.agents/skills/<name>/` with a frontmatter block that looks like this:
+
+```yaml
+---
+name: my-skill
+description: One-sentence summary ending with a period.
+category: self-bootstrap            # one of the six categories
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "phrase agents can use to trigger me"
+tools:
+  - get_issues
+  - create_merge_request
+---
+
+# my-skill
+
+...body goes here, roughly one page...
+```
+
+Agents that honour the standard will discover the skill automatically. `devboy skills list` also picks it up if you point a custom source at the directory (coming in a future release — the initial cut only lists the embedded catalogue).
+
+To contribute a skill upstream, open a pull request that adds `skills/<NN-category>/<name>/SKILL.md` in the `devboy-tools` repository.

--- a/skills/00-self-bootstrap/devboy-repair/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-repair/SKILL.md
@@ -37,51 +37,41 @@ devboy doctor --format json > /tmp/devboy-doctor.json
 jq '.' /tmp/devboy-doctor.json
 ```
 
-Read the JSON: every check has `{ id, status, message, remediation }`. `status = "fail"` entries are the ones to fix.
+The JSON shape is:
+
+```json
+{
+  "version": { "current_version": "...", "latest_version": "...", "update_available": false, "install_method": "...", "update_command": "devboy upgrade" },
+  "results": [
+    { "id": "environment.os_support", "category": "Environment", "name": "...", "status": "pass|warning|error", "message": "...", "details": null, "fix_command": "devboy init", "fix_url": null }
+  ]
+}
+```
+
+Every result has `{ id, category, name, status, message, details, fix_command, fix_url }`. Status values are `pass` (good), `warning` (recoverable but worth attention), and `error` (must be fixed). Any non-null `fix_command` is a suggested starting point.
 
 If the command itself fails to run, `devboy` is not on `PATH` — install or re-link the binary before continuing.
 
 ### 2. Classify by check id
 
-Work through the failing checks in order. Common buckets:
+The real check id taxonomy (from `devboy doctor --list-checks`):
 
-**`config.*`** — the `.devboy.toml` is missing, malformed, or points at something that no longer exists.
-
-- `config.exists` fails → run `devboy init` (see `devboy-setup`).
-- `config.valid_toml` fails → `jq .` or `cat .devboy.toml` to find the syntax error; back up and re-run `devboy init --force` if unsalvageable.
-- `config.contexts.<name>.missing` → edit `.devboy.toml` to either remove the stale context reference or re-run `devboy init` to regenerate.
-
-**`providers.*`** — credentials are missing or invalid.
-
-- `providers.<name>.no_token` → `devboy config set-secret <name>.token` (or set the env var on CI).
-- `providers.<name>.unauthorised` (401) → the token is wrong or expired. Rotate and re-store.
-- `providers.<name>.forbidden` (403) → the token lacks the required scopes. Re-issue the token with the scopes listed in the remediation hint.
-- `providers.<name>.unreachable` → network or DNS issue. Verify with `curl -v <base-url>`.
-
-**`keychain.*`** — the OS keychain is not reachable.
-
-- macOS / Windows keychain locked → unlock the user session; re-run.
-- Linux headless (no D-Bus) → move to env vars: `export DEVBOY_<PROVIDER>_TOKEN=...` and re-run `devboy doctor`.
-
-**`proxy.servers.*`** — an upstream MCP proxy is not responding.
-
-- Network failure → verify with `curl -v <proxy URL>`.
-- Bad token → re-issue via `devboy proxy add <name> --url <url> --force` with a new `--token`.
-
-**`remote_config.*`** — the remote config endpoint is down or the token is wrong.
-
-- 401 / 403 → re-issue the `--remote-config-token`.
-- 5xx / timeout → retry; if persistent, the remote endpoint is the problem and local config takes over (remote config is best-effort).
+- **Environment** — `environment.os_support`, `environment.config_dir`, `environment.credential_store`. The first two warn when the config directory is missing (run `devboy init`); the third warns when the OS keychain daemon isn't reachable (move tokens to env vars — see step 3).
+- **Configuration** — `config.exists`, `config.valid_toml`, `config.active_context`. Missing file → `devboy init`; invalid TOML → open `.devboy.toml` in an editor or run `devboy init --force`; stale active context → edit the `active_context` field or re-run `devboy init`.
+- **Credentials** — `credentials.github`, `credentials.gitlab`, `credentials.clickup`, `credentials.jira`, `credentials.slack`. A `warning`/`error` means the token is missing. Store it with `devboy config set-secret <provider>.token` or set the matching `DEVBOY_<PROVIDER>_TOKEN` / `<PROVIDER>_TOKEN` env var.
+- **Provider Connectivity** — `providers.github`, `providers.gitlab`, `providers.clickup`, `providers.jira`, `providers.slack`. `error` means the token is rejected (401/403) or the endpoint is unreachable. 401/403 → rotate the token. Unreachable → check network / base URL.
+- **MCP Server** — `mcp.tools` reports on the built-in tool filter; only warns if the config disables every tool.
+- **Proxy** — `proxy.servers` checks upstream MCP proxy connectivity. Failure usually means a bad `--proxy-token` or a dead URL; re-issue with `devboy proxy add <name> --url <url> --force --token <new>`.
 
 ### 3. Re-verify
 
 After each fix:
 
 ```bash
-devboy doctor --format json | jq '[.checks[] | select(.status=="fail")] | length'
+devboy doctor --format json | jq '[.results[] | select(.status=="error")] | length'
 ```
 
-Zero failing checks is the target. Repeat step 2 until the number reaches zero.
+Zero `error` results is the target (some `warning`s are expected — e.g. "no config file" until `devboy init` runs). Repeat step 2 until every `error` is resolved.
 
 ### 4. Smoke-test the tool bundle
 

--- a/skills/00-self-bootstrap/devboy-repair/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-repair/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: devboy-repair
+description: Diagnose and fix a broken devboy-tools setup — corrupt config, missing tokens, keychain trouble, wrong paths.
+category: self-bootstrap
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "repair devboy"
+  - "fix devboy"
+  - "devboy is broken"
+  - "devboy doctor failing"
+tools:
+  - doctor
+  - config
+  - test
+---
+
+# devboy-repair
+
+Walk a misbehaving `devboy-tools` setup back to health. This skill is driven by `devboy doctor --format json` — the structured output is the source of truth for what's wrong, and every repair step maps to a diagnostic code.
+
+## When to use
+
+- `devboy doctor` exits non-zero.
+- Tool calls return `ProviderUnsupported` unexpectedly.
+- The user reports "it worked yesterday, now it does not".
+- `devboy test <provider>` prints a 401 / 403 / network error.
+
+If the issue is "nothing is configured yet" — use `devboy-setup` instead. This skill assumes a prior configuration existed.
+
+## Procedure
+
+### 1. Pin the fault
+
+```bash
+devboy doctor --format json > /tmp/devboy-doctor.json
+jq '.' /tmp/devboy-doctor.json
+```
+
+Read the JSON: every check has `{ id, status, message, remediation }`. `status = "fail"` entries are the ones to fix.
+
+If the command itself fails to run, `devboy` is not on `PATH` — install or re-link the binary before continuing.
+
+### 2. Classify by check id
+
+Work through the failing checks in order. Common buckets:
+
+**`config.*`** — the `.devboy.toml` is missing, malformed, or points at something that no longer exists.
+
+- `config.exists` fails → run `devboy init` (see `devboy-setup`).
+- `config.valid_toml` fails → `jq .` or `cat .devboy.toml` to find the syntax error; back up and re-run `devboy init --force` if unsalvageable.
+- `config.contexts.<name>.missing` → edit `.devboy.toml` to either remove the stale context reference or re-run `devboy init` to regenerate.
+
+**`providers.*`** — credentials are missing or invalid.
+
+- `providers.<name>.no_token` → `devboy config set-secret <name>.token` (or set the env var on CI).
+- `providers.<name>.unauthorised` (401) → the token is wrong or expired. Rotate and re-store.
+- `providers.<name>.forbidden` (403) → the token lacks the required scopes. Re-issue the token with the scopes listed in the remediation hint.
+- `providers.<name>.unreachable` → network or DNS issue. Verify with `curl -v <base-url>`.
+
+**`keychain.*`** — the OS keychain is not reachable.
+
+- macOS / Windows keychain locked → unlock the user session; re-run.
+- Linux headless (no D-Bus) → move to env vars: `export DEVBOY_<PROVIDER>_TOKEN=...` and re-run `devboy doctor`.
+
+**`proxy.servers.*`** — an upstream MCP proxy is not responding.
+
+- Network failure → verify with `curl -v <proxy URL>`.
+- Bad token → re-issue via `devboy proxy add <name> --url <url> --force` with a new `--token`.
+
+**`remote_config.*`** — the remote config endpoint is down or the token is wrong.
+
+- 401 / 403 → re-issue the `--remote-config-token`.
+- 5xx / timeout → retry; if persistent, the remote endpoint is the problem and local config takes over (remote config is best-effort).
+
+### 3. Re-verify
+
+After each fix:
+
+```bash
+devboy doctor --format json | jq '[.checks[] | select(.status=="fail")] | length'
+```
+
+Zero failing checks is the target. Repeat step 2 until the number reaches zero.
+
+### 4. Smoke-test the tool bundle
+
+```bash
+devboy tools list
+devboy tools call get_issues '{"limit": 3}'
+```
+
+Either must produce real data. `ProviderUnsupported` at this point means the provider is mis-configured (wrong project id, wrong list id, wrong repo owner) — go back to step 2.
+
+## Guardrails
+
+- **Never print token values** into the chat. When the user asks "what is my token?" the answer is "it lives in your keychain — re-issue it from the provider if you need a copy". Treat every `*_token` / `set-secret` argument as opaque.
+- **Do not commit changes to `.devboy.toml`** automatically — config changes are a user decision.
+- **If two checks disagree**, trust `devboy doctor` — it is the only deterministic source of ground truth here.
+
+## Success criteria
+
+- `devboy doctor` exits zero with no failing checks.
+- At least one real tool call against each previously-broken provider succeeds.
+- If the session started with a specific complaint from the user (e.g. "get_issues returns nothing"), the exact reported behaviour is now correct.

--- a/skills/00-self-bootstrap/devboy-setup/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devboy-setup
-description: Walk the user through initial devboy configuration from scratch.
+description: Walk a user through configuring devboy-tools from scratch — providers, credentials, Claude Code registration, verification.
 category: self-bootstrap
 version: 1
 compatibility: devboy-tools >= 0.18
@@ -8,28 +8,126 @@ activation:
   - "setup devboy"
   - "configure devboy"
   - "initialise devboy"
+  - "install devboy"
 tools:
-  - doctor
+  - init
   - config
+  - doctor
+  - test
 ---
 
 # devboy-setup
 
-> Placeholder content. Fleshed out in PR-B (#159). The frontmatter above is
-> the real schema; the body below is a skeleton so the embedded source has
-> a valid file to enumerate during PR-A.
+Configure `devboy-tools` end-to-end for the current project or the current user. The skill handles the happy path and the common "something is not quite right" branches; for a broken state that needs triage, use `devboy-repair`.
 
-## What this skill does
+## When to use
 
-Walks a user through configuring `devboy-tools` from scratch: detecting
-the environment, running `devboy init`, storing tokens in the OS keychain
-(or the environment-variable fallback chain), and verifying with
-`devboy test <provider>` and `devboy doctor`.
+- A new clone of a project and `.devboy.toml` is missing.
+- A new machine and `devboy doctor` reports no configured providers.
+- A user asks "how do I set devboy up for this repo?" or equivalent.
 
-## Commands the skill relies on
+## Preconditions
 
-- `devboy init --yes` — non-interactive bootstrap
-- `devboy config set <key> <value>` — set a configuration key
-- `devboy config set-secret <key>` — store a secret in the keychain
-- `devboy doctor --format json` — diagnose the current state
-- `devboy test <provider>` — verify provider connectivity
+1. `devboy` is on `PATH`. If it is not:
+
+   ```bash
+   devboy tools call doctor '{}' >/dev/null 2>&1 || \
+     echo "devboy is not on PATH — install it via 'npm install -g @devboy-tools/cli' first"
+   ```
+
+2. The user knows which provider(s) they want to configure (GitHub, GitLab, ClickUp, Jira, Slack, Fireflies).
+
+## Procedure
+
+### 1. Pick the install target
+
+- If a `.devboy.toml` already exists in the repo root, the skill is operating on an already-initialised project — jump to **step 4**.
+- If not, run `devboy init` interactively or use `--yes` for auto-detection:
+
+  ```bash
+  devboy init --yes
+  ```
+
+  This auto-detects GitHub / GitLab from the `origin` remote and creates `.devboy.toml`.
+
+### 2. Non-interactive bootstrap with remote config
+
+When the user mentions a remote configuration endpoint, prefer that path — it keeps the machine's local config minimal and avoids drift:
+
+```bash
+devboy init --yes \
+  --remote-config-url "<URL from the user>" \
+  --remote-config-token "<token>" \
+  --claude
+```
+
+By design (ADR-DEV-798), `--remote-config-url` suppresses the local git auto-detection — the remote endpoint is treated as the source of truth for integrations.
+
+### 3. Register with Claude Code
+
+If the `--claude` flag was not passed during init, register separately:
+
+```bash
+devboy init --claude
+# or, equivalently:
+claude mcp add devboy -- devboy mcp
+```
+
+### 4. Add per-provider tokens
+
+For each provider the user wants to exercise:
+
+```bash
+# GitHub
+devboy config set github.owner <owner>
+devboy config set github.repo <repo>
+devboy config set-secret github.token          # prompts for the value
+
+# GitLab
+devboy config set gitlab.url https://gitlab.com
+devboy config set gitlab.project_id <owner/repo or numeric id>
+devboy config set-secret gitlab.token
+
+# ClickUp
+devboy config set clickup.list_id <list id>
+devboy config set clickup.team_id <team id>
+devboy config set-secret clickup.token
+
+# Jira (Cloud)
+devboy config set jira.url https://<company>.atlassian.net
+devboy config set jira.project_key <KEY>
+devboy config set jira.email <email>
+devboy config set-secret jira.token
+```
+
+On CI / headless hosts where the OS keychain is unavailable, set the corresponding env vars instead (`DEVBOY_GITHUB_TOKEN`, `DEVBOY_GITLAB_TOKEN`, …). See the `README` for the full fallback chain.
+
+### 5. Verify
+
+```bash
+devboy test github            # once per configured provider
+devboy doctor                 # overall health check
+```
+
+Both must print green. If either flags a failure, stop and fall through to `devboy-repair`.
+
+### 6. Confirm the tool bundle is wired
+
+```bash
+devboy tools list
+devboy tools call get_issues '{"limit": 3}'
+```
+
+If `tools list` is empty or the tool call returns `ProviderUnsupported`, something was misconfigured — go to `devboy-repair`.
+
+## Success criteria
+
+- `devboy doctor` reports every configured provider as healthy.
+- `devboy test <provider>` succeeds for each provider the user cares about.
+- At least one real tool call (`get_issues`, `get_merge_requests`, or the equivalent for the provider) returns data rather than `ProviderUnsupported`.
+- If the user asked for Claude Code integration, `claude mcp list` shows `devboy`.
+
+## Non-goals
+
+- This skill does not configure a proxy MCP server. Use `devboy proxy add` with its documented flags.
+- This skill does not migrate an existing setup between machines — it assumes a fresh install.

--- a/skills/00-self-bootstrap/devboy-setup/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-setup/SKILL.md
@@ -31,7 +31,7 @@ Configure `devboy-tools` end-to-end for the current project or the current user.
 1. `devboy` is on `PATH`. If it is not:
 
    ```bash
-   devboy tools call doctor '{}' >/dev/null 2>&1 || \
+   command -v devboy >/dev/null 2>&1 || \
      echo "devboy is not on PATH — install it via 'npm install -g @devboy-tools/cli' first"
    ```
 

--- a/skills/00-self-bootstrap/devboy-tools-catalog/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-tools-catalog/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: devboy-tools-catalog
+description: Enumerate and introspect the active tool bundle — names, categories, schemas, how to invoke each tool from the CLI.
+category: self-bootstrap
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "list devboy tools"
+  - "what tools does devboy have"
+  - "show devboy tools"
+  - "inspect devboy tools"
+tools:
+  - tools
+  - config
+---
+
+# devboy-tools-catalog
+
+Answer the question "what tools does the current `devboy-tools` installation expose, and how do I invoke them?". Useful as the first step of any exploration — other skills invoke tools through `devboy tools call`, and that assumes the agent knows the tool names and argument shapes.
+
+## When to use
+
+- First contact with a devboy setup — the agent wants to know what's available before writing a multi-tool recipe.
+- Before writing a new skill — confirm the tool names and argument shapes you plan to use actually exist in the active configuration.
+- To confirm that a configured provider's tools really show up (e.g. after `devboy-setup` or `devboy-repair`).
+
+## Procedure
+
+### 1. Enumerate
+
+```bash
+devboy tools list
+```
+
+Output includes each tool's name, enabled/disabled status, and the category it belongs to (`git_repository`, `issue_tracker`, `epics`, `releases`, `meeting_notes`, `messenger`, plus pipeline helpers). Tools from a provider that is not configured are hidden — if you expected a tool and do not see it, that provider is not active in this setup.
+
+### 2. Inspect one tool's schema
+
+```bash
+devboy tools call get_issues --help 2>/dev/null || \
+  devboy mcp <<< '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
+    jq '.result.tools[] | select(.name=="get_issues")'
+```
+
+The second form prints the full JSON Schema (required fields, enums, provider-specific `cf_*` custom-field extensions, etc.). Use it when you need to know exactly what an argument accepts.
+
+### 3. Invoke a tool
+
+Synchronous call via the CLI:
+
+```bash
+# POSIX shells
+devboy tools call get_issues '{"state": "open", "limit": 20}'
+
+# Windows cmd.exe / PowerShell
+devboy tools call get_issues "{\"state\": \"open\", \"limit\": 20}"
+```
+
+The default JSON payload is `{}`. For tools that take no arguments, omit it entirely:
+
+```bash
+devboy tools call list_contexts
+```
+
+### 4. Filter to a category
+
+If you only care about issue-tracker tools, filter the list:
+
+```bash
+devboy tools list | grep -E "issue|comment"
+```
+
+(There is no built-in `--category` filter on `tools list` today — that is a follow-up.)
+
+### 5. Disable unused tools
+
+Skills that only need a handful of tools can disable the rest to shrink the prompt that an MCP client sees. This is optional — most skills leave the defaults alone.
+
+```bash
+devboy tools disable some_unused_tool another_one
+devboy tools list          # confirm
+devboy tools reset         # undo
+```
+
+## Key concepts worth narrating to the agent
+
+- **Tools are provider-scoped.** A given install only exposes the tools for the providers that are configured. `devboy-tools-catalog` therefore gives a snapshot, not a universal list.
+- **Categories are coarse.** `ToolCategory` has six members (`GitRepository`, `IssueTracker`, `Epics`, `Releases`, `MeetingNotes`, `Messenger`). A tool from an uncovered category is hidden by the executor.
+- **Enrichment happens at `tools/list` time.** Each provider gets a chance to add provider-specific parameters to the schema (custom fields, enum values drawn from real project metadata). The schema you see in `tools/list` is already enriched — the agent does not need to flatten or merge anything.
+- **Prefer `devboy tools call` over MCP** when a skill only needs one tool. It avoids paying the full `tools/list` context tax the MCP transport imposes.
+
+## Success criteria
+
+- The agent can name the tools that apply to the current configuration without guessing.
+- For any tool the agent plans to call next, the argument shape matches the real schema.
+- The agent knows whether a tool is shipped but disabled versus not available at all (different problems, different fixes).

--- a/skills/00-self-bootstrap/devboy-tools-catalog/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-tools-catalog/SKILL.md
@@ -32,17 +32,18 @@ Answer the question "what tools does the current `devboy-tools` installation exp
 devboy tools list
 ```
 
-Output includes each tool's name, enabled/disabled status, and the category it belongs to (`git_repository`, `issue_tracker`, `epics`, `releases`, `meeting_notes`, `messenger`, plus pipeline helpers). Tools from a provider that is not configured are hidden — if you expected a tool and do not see it, that provider is not active in this setup.
+Output is a flat list of tool names with enabled/disabled status — `devboy tools list` does not print descriptions or categories itself. Tools from providers that are not configured for the active context are filtered out, so an empty or short list almost always means "no provider is wired up yet" rather than "devboy is broken".
 
 ### 2. Inspect one tool's schema
 
+`devboy tools call` does not take `--help`; the schema is not served as a flag. The only way to see a tool's full JSON Schema (required fields, enums, provider-specific `cf_*` custom-field extensions) is to ask the MCP server directly:
+
 ```bash
-devboy tools call get_issues --help 2>/dev/null || \
-  devboy mcp <<< '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
-    jq '.result.tools[] | select(.name=="get_issues")'
+devboy mcp <<< '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
+  jq '.result.tools[] | select(.name=="get_issues")'
 ```
 
-The second form prints the full JSON Schema (required fields, enums, provider-specific `cf_*` custom-field extensions, etc.). Use it when you need to know exactly what an argument accepts.
+The MCP server exits after serving one request on stdin, so no background process remains.
 
 ### 3. Invoke a tool
 

--- a/skills/01-issue-tracking/devboy-create-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-create-issue/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: devboy-create-issue
+description: Create a well-structured issue in the configured tracker using Feature, Defect, or Task templates.
+category: issue-tracking
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "create an issue"
+  - "file a bug"
+  - "open a ticket"
+  - "make a new ticket"
+  - "add a task"
+tools:
+  - create_issue
+  - add_issue_comment
+  - get_available_statuses
+  - get_users
+---
+
+# devboy-create-issue
+
+Turn a free-form user request into a structured ticket the team can actually work on. The skill picks one of three templates, fills it, creates the issue, and (optionally) attaches reproduction details or logs as a follow-up comment.
+
+## When to use
+
+- The user describes a bug, a feature idea, or a piece of work without a ticket yet.
+- Another skill discovered something worth filing (e.g. `devboy-review-mr` flagged a deeper issue).
+- The user asks to "open a ticket for this" in the middle of a longer conversation.
+
+## Procedure
+
+### 1. Pick the template
+
+Classify the request before writing anything. The three templates share the same shape — swap the word and tweak the slots.
+
+**Feature** — new capability, user-visible change, or design work.
+
+```markdown
+## Title
+<verb + concrete outcome>, e.g. "Add bulk archive to issue list"
+
+## Context
+Who asked for this and why. Link the user conversation or meeting note.
+
+## Acceptance criteria
+- [ ] Observable behaviour #1
+- [ ] Observable behaviour #2
+- [ ] Docs / changelog updated
+
+## Notes
+Design sketches, open questions, out-of-scope.
+```
+
+**Defect** — something is demonstrably broken.
+
+```markdown
+## Title
+<component>: <what breaks>, e.g. "Dashboard: pipeline badge shows stale status after retry"
+
+## Context
+Environment, version, user impact. Link the failing run / screenshot / log if there is one.
+
+## Acceptance criteria
+- [ ] Steps to reproduce no longer trigger the bug
+- [ ] Regression test covers the fix
+- [ ] Release note drafted
+
+## Notes
+Suspected root cause, related incidents.
+```
+
+**Task** — chore, refactor, docs, infra, anything that is not a user-facing feature and not a bug.
+
+```markdown
+## Title
+<scope>: <short outcome>, e.g. "Infra: rotate CI signing keys"
+
+## Context
+Why now, what it unblocks.
+
+## Acceptance criteria
+- [ ] The concrete thing is done
+- [ ] Follow-up tickets filed for anything we deliberately punted
+
+## Notes
+```
+
+### 2. Create the issue
+
+Pass the title and the rendered Markdown body to `create_issue`:
+
+```bash
+devboy tools call create_issue '{
+  "title": "Dashboard: pipeline badge shows stale status after retry",
+  "description": "## Context\nSeen by @alice on prod v2.4.1. The badge keeps the first status after a manual retry.\n\n## Acceptance criteria\n- [ ] Badge refreshes within 5s of retry\n- [ ] Regression test covers the fix\n\n## Notes\nSuspected cache miss in `PipelineStatusService`.",
+  "labels": ["bug", "dashboard"],
+  "assignees": ["alice"]
+}'
+```
+
+On Windows, JSON needs escaped quotes:
+
+```cmd
+devboy tools call create_issue "{\"title\": \"...\", \"description\": \"...\"}"
+```
+
+Useful optional fields: `parentId` (ClickUp subtasks), `issueType` (Jira: `Task` / `Bug` / `Story`), `projectId` (Jira project key override), `markdown: false` when the description is plain text.
+
+### 3. Attach reproduction details as a comment
+
+Keep the description tight — offload long logs, stack traces, or screenshots to a comment. `add_issue_comment` takes the key returned by step 2:
+
+```bash
+devboy tools call add_issue_comment '{
+  "key": "DEV-789",
+  "body": "Full stack trace from staging:\n\n```\nReferenceError: ...\n```"
+}'
+```
+
+On ClickUp, the same tool accepts `attachments` for small files (each ≤ 10 MB, base64-encoded).
+
+### 4. Confirm the result
+
+Read the new issue back so the user sees exactly what was filed:
+
+```bash
+devboy tools call get_issue '{"key": "DEV-789"}'
+```
+
+## Success criteria
+
+- The created issue has a clear title, a populated body following the chosen template, and the right labels / assignees.
+- Any reproduction material lives in a comment rather than bloating the description.
+- The agent reports the new issue key back to the user so they can link it elsewhere.
+
+## Non-goals
+
+- This skill does not triage or reassign existing issues — that is `devboy-update-issue`.
+- It does not link issues together — that is `devboy-link-issues`.

--- a/skills/01-issue-tracking/devboy-create-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-create-issue/SKILL.md
@@ -15,6 +15,7 @@ tools:
   - add_issue_comment
   - get_available_statuses
   - get_users
+  - get_issue
 ---
 
 # devboy-create-issue

--- a/skills/01-issue-tracking/devboy-get-issues/SKILL.md
+++ b/skills/01-issue-tracking/devboy-get-issues/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: devboy-get-issues
+description: Fetch and summarise issues from the configured tracker — filter, paginate, then drill into a single issue when needed.
+category: issue-tracking
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "list issues"
+  - "show open issues"
+  - "fetch tickets"
+  - "get issues"
+  - "what's on the backlog"
+tools:
+  - get_issues
+  - get_issue
+  - get_issue_comments
+  - get_issue_relations
+  - get_available_statuses
+---
+
+# devboy-get-issues
+
+Enumerate issues from whichever tracker is active (GitLab, GitHub, ClickUp, or Jira) and hand back either a compact summary of the result set or the full body of a single ticket the user cares about. The skill is always a read-only operation — it never mutates state.
+
+## When to use
+
+- The user asks "what issues are open?", "show me the backlog", or names a label / assignee they want to filter by.
+- Another skill (e.g. `devboy-solve-issue`) needs to look up a specific ticket before acting on it.
+- The agent is gathering context for a daily report or status update.
+
+## Procedure
+
+### 1. Scope the query
+
+Most useful filters live directly on `get_issues`:
+
+```bash
+# Default: 20 most recently updated open issues
+devboy tools call get_issues '{"state": "open", "limit": 20}'
+
+# Narrow by label / assignee / free-text search
+devboy tools call get_issues '{"state": "open", "labels": ["bug"], "assignee": "alice"}'
+devboy tools call get_issues '{"search": "websocket reconnect", "limit": 10}'
+```
+
+Supported keys: `state` (`open` / `closed` / `all`), `search`, `labels`, `assignee`, `limit` (1–100), `offset`, `sort_by` (`created_at` / `updated_at`), `sort_order` (`asc` / `desc`), `projectKey`, `nativeQuery`. On Jira, `nativeQuery` accepts raw JQL and takes precedence over the other filters.
+
+### 2. Paginate when the result set is large
+
+`get_issues` returns at most 100 items per call. Walk the pages with `offset`:
+
+```bash
+devboy tools call get_issues '{"state": "open", "limit": 50, "offset": 0}'
+devboy tools call get_issues '{"state": "open", "limit": 50, "offset": 50}'
+```
+
+Stop once a page returns fewer items than `limit`.
+
+### 3. Summarise the set
+
+Before dumping the raw list to the user, produce a compact roll-up:
+
+- Total count, grouped by state (`open` / `closed`).
+- Top labels and assignees by frequency.
+- Any `priority` or status values that cluster (e.g. "4 urgent, 12 normal").
+
+If the user asked a qualitative question ("is anything blocking the release?"), prioritise issues with `blocked`, `urgent`, or `in_progress` status over a flat listing.
+
+### 4. Drill into a single issue
+
+Once the user picks one, fetch the full record — including comments and relations in a single call:
+
+```bash
+devboy tools call get_issue '{"key": "DEV-123"}'
+# or, to skip related chatter
+devboy tools call get_issue '{"key": "DEV-123", "includeComments": false, "includeRelations": false}'
+```
+
+For heavier comment threads, page them separately:
+
+```bash
+devboy tools call get_issue_comments '{"key": "DEV-123"}'
+devboy tools call get_issue_relations '{"key": "DEV-123"}'
+```
+
+### 5. (Optional) Enumerate tracker statuses
+
+If the user asks "what states can an issue be in?", surface the tracker's workflow:
+
+```bash
+devboy tools call get_available_statuses
+```
+
+This is handy before calling `devboy-update-issue` on a provider whose state vocabulary is not "open / closed".
+
+## Success criteria
+
+- The filtered result set matches what the user asked for (state, label, assignee).
+- The summary names the total count and the top groupings, not just the first page.
+- For any issue the user inspects, the detail call returns real fields — not `ProviderUnsupported` or an empty payload.
+
+## Non-goals
+
+- This skill does not create, update, or close issues — use `devboy-create-issue` / `devboy-update-issue`.
+- It does not start a branch or MR — that is `devboy-solve-issue`.

--- a/skills/01-issue-tracking/devboy-link-issues/SKILL.md
+++ b/skills/01-issue-tracking/devboy-link-issues/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: devboy-link-issues
+description: Connect two issues with a typed relationship — blocks, blocked-by, related, duplicates, or parent/subtask.
+category: issue-tracking
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "link issues"
+  - "mark as blocked by"
+  - "set parent"
+  - "relate to"
+  - "mark as duplicate"
+tools:
+  - get_issue
+  - get_issue_relations
+  - link_issues
+  - unlink_issues
+  - update_issue
+---
+
+# devboy-link-issues
+
+Create a typed relationship between two issues so the tracker's dependency graph reflects the real one. The skill covers the four canonical link types plus the special case of parent/subtask, and it inspects existing links first to avoid duplicates.
+
+## When to use
+
+- The user says "DEV-200 is blocked by DEV-100", "mark DEV-55 as a duplicate of DEV-40", or "make this a subtask of the epic".
+- A fix unblocks another ticket and the blocker relationship should be recorded before the close.
+- Back-office cleanup: stitching together issues that were filed separately but describe the same work.
+
+## Key concepts
+
+`IssueRelations` (the shape returned by `get_issue_relations`) groups links into five buckets:
+
+| Bucket | `linkType` to pass | Meaning |
+|--------|---------------------|---------|
+| `blocked_by` | `blocked_by` | The source cannot progress until the target is done |
+| `blocks` | `blocks` | The source must be done before the target can progress |
+| `related_to` | `relates_to` | Soft relationship — "see also" |
+| `duplicates` | `duplicates` | The source is a duplicate of the target |
+| `parent` / `subtasks` | `subtask` | Source is a subtask of target (ClickUp / Jira) |
+
+Provider support varies:
+
+- **GitLab** exposes `relates_to`, `blocks`, `blocked_by`.
+- **GitHub** exposes a flat `relates_to` (dependency-free by default; Projects v2 adds more).
+- **ClickUp** exposes parent/subtask via `update_issue` `parentId` in addition to `link_issues`.
+- **Jira** exposes the full set and honours whatever link types are configured on the project.
+
+If a given relationship is not supported by the active provider, `link_issues` returns `ProviderUnsupported` — fall back to an explanatory comment instead.
+
+## Procedure
+
+### 1. Inspect the current graph
+
+Before adding a link, list the existing ones so you do not create a duplicate edge:
+
+```bash
+devboy tools call get_issue_relations '{"key": "DEV-200"}'
+# or in aggregate via get_issue
+devboy tools call get_issue '{"key": "DEV-200", "includeRelations": true}'
+```
+
+Look at `blocked_by`, `blocks`, `related_to`, `duplicates`, `parent`, `subtasks`. If the edge you are about to add already exists, stop — the tracker is already correct.
+
+### 2. Add the link
+
+One `link_issues` call per edge. All three fields are required:
+
+```bash
+# "DEV-200 is blocked by DEV-100"
+devboy tools call link_issues '{
+  "sourceIssueKey": "DEV-200",
+  "targetIssueKey": "DEV-100",
+  "linkType": "blocked_by"
+}'
+
+# "DEV-55 duplicates DEV-40"
+devboy tools call link_issues '{
+  "sourceIssueKey": "DEV-55",
+  "targetIssueKey": "DEV-40",
+  "linkType": "duplicates"
+}'
+
+# "DEV-42 is related to DEV-17"
+devboy tools call link_issues '{
+  "sourceIssueKey": "DEV-42",
+  "targetIssueKey": "DEV-17",
+  "linkType": "relates_to"
+}'
+```
+
+### 3. Parent / subtask is a special case
+
+Where the provider supports it, prefer `update_issue` with `parentId` — it moves the issue under the parent in one call and most trackers render the hierarchy natively:
+
+```bash
+devboy tools call update_issue '{"key": "CU-child", "parentId": "CU-epic"}'
+```
+
+Fall back to `link_issues` with `"linkType": "subtask"` if the provider expects that shape.
+
+### 4. Multi-link sequences
+
+A real request usually needs more than one edge. Walk them one at a time — the tool is not batched:
+
+> "This MR fixes DEV-123 and is blocked by DEV-100."
+
+```bash
+# DEV-<current> blocks? no — DEV-<current> is blocked by DEV-100
+devboy tools call link_issues '{
+  "sourceIssueKey": "DEV-<current>",
+  "targetIssueKey": "DEV-100",
+  "linkType": "blocked_by"
+}'
+# "fixes" on most trackers is just a related link + automation on merge
+devboy tools call link_issues '{
+  "sourceIssueKey": "DEV-<current>",
+  "targetIssueKey": "DEV-123",
+  "linkType": "relates_to"
+}'
+```
+
+### 5. Removing a stale link
+
+`unlink_issues` takes the same three fields:
+
+```bash
+devboy tools call unlink_issues '{
+  "sourceIssueKey": "DEV-55",
+  "targetIssueKey": "DEV-40",
+  "linkType": "duplicates"
+}'
+```
+
+## Success criteria
+
+- `get_issue_relations` after the operation shows the new edge in the correct bucket.
+- No duplicate edges were created — pre-check in step 1 caught them.
+- Where the provider rejected a link type, the agent surfaced that to the user instead of silently retrying.
+
+## Non-goals
+
+- This skill does not create issues — use `devboy-create-issue` and then link.
+- It does not automatically close duplicates — mark the relationship, let the user decide whether to close.

--- a/skills/01-issue-tracking/devboy-solve-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-solve-issue/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: devboy-solve-issue
+description: Full cycle for shipping an issue — read it, branch, implement, push, open an MR, and link back to the original ticket.
+category: issue-tracking
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "solve this issue"
+  - "implement DEV-XXX"
+  - "work on ticket"
+  - "start this task"
+  - "ship this issue"
+tools:
+  - get_issue
+  - get_issue_comments
+  - get_issue_relations
+  - create_merge_request
+  - add_issue_comment
+---
+
+# devboy-solve-issue
+
+Take a ticket from "assigned" to "review-ready MR with a comment on the issue pointing at it". The skill wraps the typical loop: read the issue, cut a branch, do the work, push, open an MR on the configured Git provider, and leave a breadcrumb on the issue so the next person can follow the trail.
+
+## When to use
+
+- The user says "implement DEV-123", "solve this issue", "take this ticket", or similar.
+- The agent has a clear, scoped issue to act on — not an open-ended discussion.
+- A Git provider (GitLab or GitHub) is configured alongside the issue tracker.
+
+If the request is vague, run `devboy-get-issues` first to surface the ticket, then come back here.
+
+## Procedure
+
+### 1. Read the issue
+
+Always start with the full ticket — description, comments, links:
+
+```bash
+devboy tools call get_issue '{"key": "DEV-123"}'
+```
+
+Pay attention to:
+
+- **Acceptance criteria** — they define "done".
+- **Blocking links** — if `blocked_by` is non-empty, surface that and stop. The skill does not fight upstream blockers.
+- **Recent comments** — later context often overrides the original description.
+
+### 2. Name the branch
+
+Pick a short, human-readable branch name that embeds the issue key:
+
+```
+feat/DEV-123-add-bulk-archive
+fix/DEV-456-pipeline-badge-stale
+chore/DEV-789-rotate-signing-keys
+```
+
+Rules:
+
+- Prefix with `feat/`, `fix/`, `chore/`, `docs/`, or `refactor/` depending on the work.
+- Include the issue key verbatim (no lowercasing — `DEV-123`, not `dev-123`).
+- Keep the trailing slug under ~5 words.
+
+### 3. Cut the branch and implement
+
+Standard local Git flow — the skill does not wrap these in `devboy` tools:
+
+```bash
+git fetch origin
+git switch -c feat/DEV-123-add-bulk-archive origin/main
+# ... write the code, run tests, verify locally ...
+git add -p
+git commit -m "feat(issues): add bulk archive (DEV-123)"
+git push -u origin HEAD
+```
+
+Commit messages should follow the repo's convention and end with the issue key in parentheses so the tracker auto-links them. Avoid `Fixes DEV-123` / `Closes #123` phrasing on the commit — see the guardrail below.
+
+### 4. Open the merge request
+
+`create_merge_request` is the unified tool — it opens a GitLab MR or a GitHub PR depending on the configured provider. Title and `source_branch` / `target_branch` are required:
+
+```bash
+devboy tools call create_merge_request '{
+  "title": "feat(issues): add bulk archive (DEV-123)",
+  "description": "Implements DEV-123.\n\n## What changed\n- Added `bulkArchive` action to the issue list\n- New keyboard shortcut `shift+a`\n\n## How to test\n1. Select multiple issues\n2. Press `shift+a`\n3. Confirm they move to the archived state\n\nRelates to DEV-123.",
+  "source_branch": "feat/DEV-123-add-bulk-archive",
+  "target_branch": "main",
+  "draft": false,
+  "labels": ["feature"],
+  "reviewers": ["alice"]
+}'
+```
+
+Record the MR key (`mr#<n>` for GitLab, `pr#<n>` for GitHub) — the next step needs it.
+
+### 5. Comment the MR link on the issue
+
+Close the loop so anyone looking at the ticket finds the work:
+
+```bash
+devboy tools call add_issue_comment '{
+  "key": "DEV-123",
+  "body": "Opened for review: mr#42 — `feat/DEV-123-add-bulk-archive`."
+}'
+```
+
+Include:
+
+- The MR / PR key (clickable on most trackers when the integration is configured).
+- The branch name.
+- Any context the reviewer needs that is not already in the MR description.
+
+### 6. Hand off
+
+Report back to the user with:
+
+- The issue key.
+- The branch name.
+- The MR / PR key and URL.
+- A one-line summary of the change.
+
+Then stop. Review happens in `devboy-review-mr`, fixing review comments happens in `devboy-fix-review-comments`.
+
+## Guardrails
+
+- **Do not auto-close the issue.** Leave the close to the merge commit. Most trackers have a `Fixes` keyword pipeline wired up on the MR description — use it there if the repo convention supports it, but do not call `update_issue` with `state: closed` from this skill.
+- **Do not force-push shared branches.** If the branch already exists remotely and someone else has work on it, stop and ask.
+- **Respect the scope.** The issue description is the contract — do not refactor adjacent code or add features the ticket did not ask for. If you find genuine tech debt, file a follow-up with `devboy-create-issue` instead of widening this change.
+- **Do not run the review yourself.** That is a separate skill with a separate posture.
+
+## Success criteria
+
+- The MR exists on the configured Git provider, targets `main` (or the repo's default branch), and its description references the issue.
+- The original issue has a new comment linking to the MR.
+- Local branch is pushed and tracks its remote.
+- The scope matches the issue's acceptance criteria — nothing more, nothing less.
+
+## Non-goals
+
+- **Code review.** Use `devboy-review-mr` on the resulting MR.
+- **Applying review feedback.** Use `devboy-fix-review-comments` when reviewers come back.
+- **Release / deploy coordination.** Out of scope — this skill stops at "MR open".

--- a/skills/01-issue-tracking/devboy-solve-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-solve-issue/SKILL.md
@@ -12,8 +12,6 @@ activation:
   - "ship this issue"
 tools:
   - get_issue
-  - get_issue_comments
-  - get_issue_relations
   - create_merge_request
   - add_issue_comment
 ---
@@ -64,11 +62,12 @@ Rules:
 
 ### 3. Cut the branch and implement
 
-Standard local Git flow — the skill does not wrap these in `devboy` tools:
+Standard local Git flow — the skill does not wrap these in `devboy` tools. Base the branch off the remote's default head rather than hardcoding `main`, so the flow keeps working on repos whose default is `master` or something else:
 
 ```bash
 git fetch origin
-git switch -c feat/DEV-123-add-bulk-archive origin/main
+DEFAULT_BRANCH_REF="$(git symbolic-ref refs/remotes/origin/HEAD)"   # e.g. refs/remotes/origin/main
+git switch -c feat/DEV-123-add-bulk-archive "$DEFAULT_BRANCH_REF"
 # ... write the code, run tests, verify locally ...
 git add -p
 git commit -m "feat(issues): add bulk archive (DEV-123)"
@@ -79,14 +78,14 @@ Commit messages should follow the repo's convention and end with the issue key i
 
 ### 4. Open the merge request
 
-`create_merge_request` is the unified tool — it opens a GitLab MR or a GitHub PR depending on the configured provider. Title and `source_branch` / `target_branch` are required:
+`create_merge_request` is the unified tool — it opens a GitLab MR or a GitHub PR depending on the configured provider. Title and `source_branch` / `target_branch` are required. Set `target_branch` to the repo's actual default branch — do not hardcode `main`; derive it from `git symbolic-ref refs/remotes/origin/HEAD` (strip the `refs/remotes/origin/` prefix) so the call works on repos defaulted to `master` or a custom branch:
 
 ```bash
 devboy tools call create_merge_request '{
   "title": "feat(issues): add bulk archive (DEV-123)",
   "description": "Implements DEV-123.\n\n## What changed\n- Added `bulkArchive` action to the issue list\n- New keyboard shortcut `shift+a`\n\n## How to test\n1. Select multiple issues\n2. Press `shift+a`\n3. Confirm they move to the archived state\n\nRelates to DEV-123.",
   "source_branch": "feat/DEV-123-add-bulk-archive",
-  "target_branch": "main",
+  "target_branch": "<repo-default-branch>",
   "draft": false,
   "labels": ["feature"],
   "reviewers": ["alice"]

--- a/skills/01-issue-tracking/devboy-update-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-update-issue/SKILL.md
@@ -64,8 +64,8 @@ devboy tools call update_issue '{"key": "DEV-123", "assignees": ["bob"]}'
 # Swap the label set (replaces — not additive)
 devboy tools call update_issue '{"key": "DEV-123", "labels": ["bug", "regression"]}'
 
-# Transition a ClickUp / Jira status by string — pass the literal status name
-devboy tools call update_issue '{"key": "CU-abc123", "status": "In Review"}'
+# Transition a ClickUp / Jira workflow status by string — pass the literal status name via `state`
+devboy tools call update_issue '{"key": "CU-abc123", "state": "In Review"}'
 ```
 
 Tool fields you can pass: `title`, `description`, `state`, `labels`, `assignees`, `parentId` (ClickUp subtasks), `markdown`. `labels` and `assignees` are replacements, not merges — re-send the full desired list.

--- a/skills/01-issue-tracking/devboy-update-issue/SKILL.md
+++ b/skills/01-issue-tracking/devboy-update-issue/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: devboy-update-issue
+description: Change an issue's state, labels, assignees, or priority with a partial update, leaving unrelated fields untouched.
+category: issue-tracking
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "close this issue"
+  - "update the ticket"
+  - "move to done"
+  - "assign to X"
+  - "relabel issue"
+  - "reopen ticket"
+tools:
+  - get_issue
+  - update_issue
+  - add_issue_comment
+  - get_available_statuses
+---
+
+# devboy-update-issue
+
+Apply a targeted change to an existing issue — transition state, swap labels, hand it to someone else, bump priority — without disturbing fields the user did not mention. The skill always inspects the current record first so the update is informed.
+
+## When to use
+
+- The user says "close DEV-123", "move this to in progress", "assign to @alice", or similar.
+- Another skill finished work and needs to transition the originating ticket (but see the guardrail on auto-closing in `devboy-solve-issue`).
+- A label taxonomy change requires bulk relabelling — run the skill once per ticket.
+
+## Procedure
+
+### 1. Read the current state first
+
+Never update blind. Fetch the issue so you know what you are overwriting:
+
+```bash
+devboy tools call get_issue '{"key": "DEV-123"}'
+```
+
+Note the current `state`, `labels`, `assignees`, and `priority` before deciding on the diff. This also surfaces whether the issue is already in the desired state (in which case no call is needed).
+
+### 2. Understand the tracker's state vocabulary
+
+GitLab / GitHub use `open` / `closed`. ClickUp and Jira use custom workflows — "To Do", "In Progress", "In Review", "Done", "Blocked". When the user asks for something semantic ("mark it done"), check what the tracker actually offers:
+
+```bash
+devboy tools call get_available_statuses
+```
+
+Pick the status that matches the user's intent. If none fits, ask before guessing.
+
+### 3. Apply the minimal update
+
+`update_issue` is **partial** — fields you omit are preserved. Send only what actually changes:
+
+```bash
+# Close an issue
+devboy tools call update_issue '{"key": "DEV-123", "state": "closed"}'
+
+# Reassign without touching anything else
+devboy tools call update_issue '{"key": "DEV-123", "assignees": ["bob"]}'
+
+# Swap the label set (replaces — not additive)
+devboy tools call update_issue '{"key": "DEV-123", "labels": ["bug", "regression"]}'
+
+# Transition a ClickUp / Jira status by string — pass the literal status name
+devboy tools call update_issue '{"key": "CU-abc123", "status": "In Review"}'
+```
+
+Tool fields you can pass: `title`, `description`, `state`, `labels`, `assignees`, `parentId` (ClickUp subtasks), `markdown`. `labels` and `assignees` are replacements, not merges — re-send the full desired list.
+
+### 4. Narrate the change in a comment
+
+When the state change carries meaning the field itself does not capture, follow up with a comment so the history is readable:
+
+```bash
+devboy tools call add_issue_comment '{
+  "key": "DEV-123",
+  "body": "Moving to **Blocked** — waiting on vendor fix for upstream auth (ETA Friday)."
+}'
+```
+
+Good triggers for a comment: state → blocked, reassignment, priority escalation, a close-as-wontfix that needs context.
+
+### 5. Verify
+
+Re-read the issue and confirm the intended fields changed while the others did not:
+
+```bash
+devboy tools call get_issue '{"key": "DEV-123", "includeComments": false, "includeRelations": false}'
+```
+
+## Guardrails
+
+- **Never overwrite fields the user did not explicitly mention.** If the user said "close it", do not also clear labels or drop assignees. Send only the fields that matter for the stated intent.
+- **Do not batch unrelated changes into a single tool call** if the user can realistically reject one and accept the other — make each change auditable.
+- **Status names are case-sensitive** on some providers. Use the exact casing from `get_available_statuses`.
+
+## Success criteria
+
+- The targeted fields reflect the user's request after step 5.
+- All other fields remain identical to the pre-update snapshot from step 1.
+- Where the change needs context, there is a comment explaining it.

--- a/skills/02-code-review/devboy-fix-review-comments/SKILL.md
+++ b/skills/02-code-review/devboy-fix-review-comments/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: devboy-fix-review-comments
+description: Apply reviewer feedback on an MR — fix the code, run local checks, commit, push, and reply to each discussion.
+category: code-review
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "fix review comments"
+  - "address MR review"
+  - "apply reviewer feedback"
+  - "address PR feedback"
+tools:
+  - get_merge_request_discussions
+  - get_merge_request_diffs
+  - create_merge_request_comment
+---
+
+# devboy-fix-review-comments
+
+Address a reviewer's feedback on one MR / PR. For every unresolved discussion: decide whether to accept, push back, or clarify; if accepting, make the change locally and verify it; then reply to the thread with a short acknowledgement.
+
+## When to use
+
+- A reviewer left comments on your MR and you are ready to address them.
+- The user says "fix review comments", "apply reviewer feedback", or similar with an MR key.
+- You are the author of the MR. For reviewing **someone else's** MR use `devboy-review-mr`.
+
+## Procedure
+
+### 1. Pull every open discussion
+
+```bash
+devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
+```
+
+Filter to unresolved threads. Each discussion returns a list of notes and — for inline discussions — a file path, line number, and `discussion_id`. The `discussion_id` is what you reply to later.
+
+### 2. Pull the current diff for context
+
+```bash
+devboy tools call get_merge_request_diffs '{"key": "mr#374"}'
+```
+
+You need the diff to reason about where each comment applies — reviewers sometimes comment on context lines, not changed lines.
+
+### 3. Classify each discussion
+
+Walk the discussions in the order the reviewer posted them. For each one, pick exactly one disposition:
+
+- **Accept** — the reviewer is right; apply the fix locally.
+- **Push back** — you disagree or the suggestion is out of scope; reply with a one- or two-sentence reason and keep the scope to this thread.
+- **Clarify** — the comment is ambiguous; reply asking for the specific piece of information you need.
+
+Do not batch dispositions. Decide per discussion.
+
+### 4. Apply fixes (for "accept")
+
+Edit the files locally. Keep the change minimal — a review fix is a fix, not a refactor (see guardrails below). After **each** logical fix, run the local checks appropriate for the stack touched. For `devboy-tools`:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test -p <the-crate-you-touched>
+```
+
+If any of those fails, fix the root cause before moving on — do not commit a half-green state.
+
+### 5. Commit and push
+
+Group related fixes into one commit where it reads naturally. Commit messages reference the scope, not the reviewer:
+
+```bash
+git add -- <paths>
+git commit -m "fix(cli): surface a real error when the env var is unset (DEV-XXX)"
+git push
+```
+
+Note the commit SHA of each fix — you will reference it in the reply. For fixes that span multiple discussions, one commit covering several threads is fine as long as the body of the commit lists them.
+
+### 6. Reply to each discussion
+
+Use `create_merge_request_comment` in **reply mode** by passing the `discussion_id`. Keep the reply one or two sentences.
+
+- **Accepted**: `fixed in <sha>` or `fixed in <sha> — <one-line what changed>`.
+- **Pushed back**: `keeping as-is because <specific technical reason>`.
+- **Clarified**: `could you clarify <specific point>? <short reason you're asking>`.
+
+```bash
+devboy tools call create_merge_request_comment '{
+  "key": "mr#374",
+  "discussion_id": "abc123",
+  "body": "fixed in 9f2a1e4 — switched to `Error::Config` so the CLI prints a real message."
+}'
+```
+
+Do not pass `file_path` / `line` when replying — the discussion already owns a position.
+
+### 7. Verify
+
+```bash
+devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
+```
+
+Every thread you handled should now have your reply as the latest note. If a thread is missing your reply, the call either targeted the wrong `discussion_id` or the provider rejected the body — re-try.
+
+## Success criteria
+
+- Every previously-unresolved discussion has a reply from you.
+- Every "accept" reply names the SHA that contains the fix.
+- Local `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the relevant `cargo test` pass.
+- The branch is pushed; the MR shows the new commits.
+- No discussion is left silent because you "could not figure it out" — clarify instead.
+
+## Guardrails
+
+- **Never mark a discussion resolved for a reviewer who did not ask you to.** Some hosts expose a "resolve" action; do not call it. Resolution is the reviewer's prerogative on their next pass. Your job ends at replying.
+- **Keep the push-back scoped to the thread it belongs to.** If the reviewer is wrong across several threads, reply per thread — do not escalate in a single omnibus comment.
+- **Do not amend past commits from the branch** unless the reviewer explicitly asked for a squash. New commits are easier to review.
+- **Do not change the MR target branch, title, or description** as part of a "fix comments" pass unless the reviewer asked for exactly that.
+- **Do not introduce unrelated cleanup.** A review fix touches the lines under discussion and whatever is strictly required to make them work. Larger refactors get their own MR.
+
+## Non-goals
+
+- Approving or closing the MR. Resolution and merge remain with the reviewer / author's separate actions.
+- Running CI for the reviewer. Pushing commits is enough — the pipeline will trigger on its own.

--- a/skills/02-code-review/devboy-fix-review-comments/SKILL.md
+++ b/skills/02-code-review/devboy-fix-review-comments/SKILL.md
@@ -33,7 +33,14 @@ Address a reviewer's feedback on one MR / PR. For every unresolved discussion: d
 devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
 ```
 
-Filter to unresolved threads. Each discussion returns a list of notes and — for inline discussions — a file path, line number, and `discussion_id`. The `discussion_id` is what you reply to later.
+The tool returns `Discussion { id, resolved, comments, position }`. `comments` is the thread's list of messages; `position` carries the file path + line number for inline discussions. Reply later using the discussion's `id` (for GitLab) or the numeric id of one of `comments[*]` (for GitHub — see the reply section below).
+
+**Do not rely on `resolved` alone to pick threads that need a reply.** On GitHub the provider has no reliable resolved-state signal in the REST data it reads, so `resolved` is always `false` — treating "unresolved" as "needs reply" will pick every thread and produce infinite reply loops on re-runs. Use a deterministic filter instead:
+
+- threads where the latest comment is not authored by the MR author, **or**
+- threads where the MR author has not replied since the reviewer's last comment.
+
+On GitLab the `resolved` field is populated correctly and you may lean on it as a hint, but keep the author-based check as a fallback — it works across providers.
 
 ### 2. Pull the current diff for context
 
@@ -79,13 +86,21 @@ Note the commit SHA of each fix — you will reference it in the reply. For fixe
 
 ### 6. Reply to each discussion
 
-Use `create_merge_request_comment` in **reply mode** by passing the `discussion_id`. Keep the reply one or two sentences.
+Use `create_merge_request_comment` in **reply mode**. The right reply id depends on the provider:
+
+- **GitLab** — reply with the discussion's `id` as `discussion_id`. GitLab threads are first-class objects and the `Discussion.id` is what you pass back.
+- **GitHub** — GitHub's REST reply goes through `in_reply_to` on a **review comment id**, which is numeric. The provider packs that into a `Discussion.comments[*].id`; pass the id of the comment you are replying to (typically the last one in the thread) as `discussion_id`.
+
+If you get a 404 on reply, the value was the wrong one for the provider — fall back to a top-level comment rather than looping.
+
+Keep the reply one or two sentences:
 
 - **Accepted**: `fixed in <sha>` or `fixed in <sha> — <one-line what changed>`.
 - **Pushed back**: `keeping as-is because <specific technical reason>`.
 - **Clarified**: `could you clarify <specific point>? <short reason you're asking>`.
 
 ```bash
+# GitLab example
 devboy tools call create_merge_request_comment '{
   "key": "mr#374",
   "discussion_id": "abc123",
@@ -93,7 +108,7 @@ devboy tools call create_merge_request_comment '{
 }'
 ```
 
-Do not pass `file_path` / `line` when replying — the discussion already owns a position.
+Do not pass `file_path` / `line` when replying — the thread already owns a position.
 
 ### 7. Verify
 

--- a/skills/02-code-review/devboy-review-mr/SKILL.md
+++ b/skills/02-code-review/devboy-review-mr/SKILL.md
@@ -93,7 +93,9 @@ devboy tools call create_merge_request_comment '{
 }'
 ```
 
-For a comment on an unchanged (context) line, use `"line_type": "old"`. If the provider requires a `commit_sha`, pick the head SHA from `get_merge_request_diffs` output.
+`line_type` is an `old` / `new` selector for which side of the diff the `line` number refers to: `"new"` for added or unchanged (context) lines, `"old"` only for deleted lines. Using `"old"` on a context line can place the comment on the wrong side or fail outright. Default to `"new"`.
+
+Do not pass `commit_sha` unless you already have a concrete SHA from outside this skill's tool set. `get_merge_request_diffs` returns `FileDiff` without a head SHA, so there is no head commit to lift from the tool output. On GitHub the provider fills in the PR head SHA automatically when `commit_sha` is omitted; on GitLab it is not required for line-scoped comments.
 
 ### 8. Post the summary comment
 

--- a/skills/02-code-review/devboy-review-mr/SKILL.md
+++ b/skills/02-code-review/devboy-review-mr/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: devboy-review-mr
+description: Strict but calibrated code review of a single MR or PR — checklist, inline comments, one overall summary.
+category: code-review
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "review this MR"
+  - "review this PR"
+  - "do a code review"
+  - "check this PR"
+tools:
+  - get_merge_requests
+  - get_merge_request_diffs
+  - get_merge_request_discussions
+  - create_merge_request_comment
+---
+
+# devboy-review-mr
+
+Perform a strict, calibrated code review of a single merge request / pull request. Output is one summary comment plus a handful of targeted inline comments — each tagged with `[nit]`, `[suggestion]`, or `[issue]` so the author can triage quickly.
+
+## When to use
+
+- The user asks "review this MR / PR" and gives an identifier (e.g. `mr#374`, `pr#128`) or a URL.
+- The user pastes an MR URL without further instructions — default to this skill.
+- You have been asked to gate-keep a branch before merge.
+
+For reviewing your **own** MR before asking a human reviewer, use `devboy-self-review` — it keeps findings private instead of posting them.
+
+## Procedure
+
+### 1. Resolve the MR key
+
+The tools take a key in the form `mr#<n>` (GitLab) or `pr#<n>` (GitHub). If the user gave a URL, extract the numeric id and prefix accordingly. If the user only said "this MR", ask for the key — do not guess.
+
+### 2. Pull the MR metadata
+
+```bash
+devboy tools call get_merge_requests '{"state": "open", "limit": 50}'
+```
+
+Use this to confirm the MR exists and to pick up title, author, target branch, and labels. If only one MR is in question, you can skip this and go straight to diffs.
+
+### 3. Pull the diff
+
+```bash
+devboy tools call get_merge_request_diffs '{"key": "mr#374"}'
+```
+
+Record every changed file and the line ranges that moved. Diffs are the primary review surface — read them before anything else.
+
+### 4. Pull existing discussions
+
+```bash
+devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
+```
+
+Skim every thread. Do not duplicate a comment that a previous reviewer already left — if the same concern is still unresolved, reference the existing thread in your summary instead of opening a new inline.
+
+### 5. Walk the checklist
+
+For every changed file, ask the following questions in order. Stop early on a file once you find one serious finding — the goal is signal, not exhaustive noise.
+
+- **Type safety.** Are new public APIs fully typed? Are `unwrap()` / `expect()` calls justified by a local invariant, or are they latent panics? Are `Option` / `Result` chained with combinators rather than unwrapped?
+- **Error handling.** Do new error paths surface a useful message the caller can act on? Are errors propagated with `?` rather than swallowed with `let _ = …` or `.ok()`? Are new error variants added to the relevant enum?
+- **Tests.** Is every new behaviour covered by a unit test or an integration test? Are edge cases (empty input, provider-unsupported, parse failure) exercised? Do the new tests actually assert on meaningful output, not just "did not panic"?
+- **Docs.** Are new public items documented with a short rustdoc / JSDoc block? Does the `README` or relevant `docs/` page change when the public surface changes?
+- **i18n / user-facing copy.** If the diff touches a `SKILL.md` body, a CLI message, or any user-facing string, is it English? Mixed-language strings do not ship.
+- **Cross-platform.** Does anything assume POSIX paths (hard-coded `/`), the presence of `bash`, or Unix-only tools? `std::path::Path` and portable commands are required.
+
+### 6. Draft the inline comments
+
+For each finding that deserves inline attention, prepare a short comment. Keep each one under ~150 words and start with a severity tag:
+
+- `[nit]` — cosmetic, take-it-or-leave-it (whitespace, naming, tiny refactor).
+- `[suggestion]` — real improvement that is not strictly blocking.
+- `[issue]` — blocking; the reviewer wants this fixed before merge.
+
+Long explanations, context, or cross-file reasoning belong in the summary comment, not inline.
+
+### 7. Post the inline comments
+
+One tool call per inline comment. File path and line must match the diff exactly.
+
+```bash
+devboy tools call create_merge_request_comment '{
+  "key": "mr#374",
+  "file_path": "crates/devboy-core/src/provider.rs",
+  "line": 142,
+  "line_type": "new",
+  "body": "[issue] `unwrap()` on the env-var lookup will panic when the variable is unset. Return `Err(Error::Config(...))` instead so the caller can surface a useful message."
+}'
+```
+
+For a comment on an unchanged (context) line, use `"line_type": "old"`. If the provider requires a `commit_sha`, pick the head SHA from `get_merge_request_diffs` output.
+
+### 8. Post the summary comment
+
+One final, top-level comment. Structure it so the author can skim in ten seconds:
+
+```
+### Review summary
+
+- Strengths: <one or two short bullets>
+- Blocking issues: <count>  (see inline [issue] tags)
+- Suggestions: <count>      (see inline [suggestion] tags)
+- Nits: <count>             (see inline [nit] tags)
+
+Overall: <approve / needs changes / comment>, because <one sentence>.
+```
+
+```bash
+devboy tools call create_merge_request_comment '{
+  "key": "mr#374",
+  "body": "### Review summary\n\n- Strengths: …\n- Blocking issues: 1 (see inline [issue])\n- Suggestions: 2\n- Nits: 0\n\nOverall: needs changes, because the new provider path panics on missing env."
+}'
+```
+
+Do not pass `file_path` / `line` here — a top-level comment has no position.
+
+## Success criteria
+
+- Every `[issue]` you raise points at a line the author can act on, with a concrete fix path.
+- The summary is a single comment, not one per finding.
+- No duplicate comments — you read prior discussions before posting.
+- Inline comments are short; long prose lives in the summary.
+- No language other than English in any posted body.
+
+## Guardrails
+
+- **Do not approve or merge.** This skill posts comments only. Approval is a human action.
+- **Do not resolve other reviewers' threads.** Reply if you have an opinion, but leave resolution to the person who opened the thread.
+- **Do not review your own MR with this skill.** Use `devboy-self-review` instead — self-comments clutter the reviewer's view.
+
+## Non-goals
+
+- Running the tests yourself. The review is based on the diff and whatever CI signal is visible; actually executing the code is `devboy-self-review`'s job for the author, not the reviewer's.
+- Refactoring suggestions that are out of scope for the MR. Flag them as `[suggestion]` and let the author decide.

--- a/skills/02-code-review/devboy-self-review/SKILL.md
+++ b/skills/02-code-review/devboy-self-review/SKILL.md
@@ -46,7 +46,11 @@ Read every changed file end-to-end. This is the only piece of ground truth you n
 devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
 ```
 
-Flag any thread that is still unresolved. Self-review is incomplete as long as an open discussion exists — either reply to it (see `devboy-fix-review-comments`) or, if you are pushing back, at least have the reasoning ready so the reviewer is not left waiting.
+Flag any thread that is clearly awaiting your response — for example, the latest comment was not authored by you, or it contains an explicit request for changes / clarification / follow-up.
+
+If the provider exposes a reliable `resolved` field you may use it as a hint (GitLab does), but do not treat `unresolved` on its own as a universal blocking signal: on GitHub the provider has no reliable resolved-state signal in the REST data and `resolved` is always `false`, so a naive check would tag every thread and make self-review impossible on GitHub-hosted PRs.
+
+Self-review is incomplete while a reviewer is still waiting on you — either reply to the thread (see `devboy-fix-review-comments`) or, if you are pushing back, have the reasoning ready so the reviewer is not left waiting.
 
 ### 4. Walk the checklist
 

--- a/skills/02-code-review/devboy-self-review/SKILL.md
+++ b/skills/02-code-review/devboy-self-review/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: devboy-self-review
+description: Dry-run a review pass over your own MR before asking a human reviewer — local checklist, no inline posting.
+category: code-review
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "self review my MR"
+  - "self review my PR"
+  - "check my own PR"
+  - "dry-run review before requesting"
+tools:
+  - get_merge_request_diffs
+  - get_merge_request_discussions
+---
+
+# devboy-self-review
+
+Run the `devboy-review-mr` checklist over your **own** MR before handing it to a reviewer. Findings stay local — the output is a plain-text report to the user, not comments on the MR. If anything serious turns up, you fix it and amend the branch first.
+
+## When to use
+
+- You are about to mark an MR as "ready for review" and want a sanity pass.
+- A previous review round finished; you want to confirm nothing new slipped in while addressing the comments.
+- The user says "self-review my PR" or similar.
+
+For reviewing **someone else's** MR, use `devboy-review-mr` — it posts inline comments and a summary. Self-review deliberately does not.
+
+## Procedure
+
+### 1. Resolve the MR key
+
+`mr#<n>` or `pr#<n>`. If the user did not give one, ask — do not guess from branch state.
+
+### 2. Pull the diff
+
+```bash
+devboy tools call get_merge_request_diffs '{"key": "mr#374"}'
+```
+
+Read every changed file end-to-end. This is the only piece of ground truth you need — metadata (title, labels, target branch) is out of scope for self-review.
+
+### 3. Pull existing discussions
+
+```bash
+devboy tools call get_merge_request_discussions '{"key": "mr#374", "limit": 100}'
+```
+
+Flag any thread that is still unresolved. Self-review is incomplete as long as an open discussion exists — either reply to it (see `devboy-fix-review-comments`) or, if you are pushing back, at least have the reasoning ready so the reviewer is not left waiting.
+
+### 4. Walk the checklist
+
+Same list as `devboy-review-mr`, applied to your own code. For each item, record one of three outcomes: `ok`, `minor` (note it for the reviewer), `fix-before-review` (you are going to change the code right now).
+
+- **Type safety.** Are new public APIs fully typed? Are `unwrap()` / `expect()` calls justified? Option / Result combinators rather than unwrapped access?
+- **Error handling.** Do new error paths surface a useful message? Errors propagated rather than swallowed? New variants added to the right enum?
+- **Tests.** Is every new behaviour covered? Edge cases (empty input, provider-unsupported, parse failure)? Assertions meaningful, not just "did not panic"?
+- **Docs.** Public items documented? README / `docs/` change if the public surface changes?
+- **i18n / user-facing copy.** Any `SKILL.md` body, CLI output, error message — English only?
+- **Cross-platform.** No POSIX-only paths, no `bash`-only scripting, no Unix-only tools?
+
+### 5. If any item is `fix-before-review` — fix it
+
+Make the change, then re-run the local checks appropriate for the stack touched. For `devboy-tools`:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test -p <the-crate-you-touched>
+```
+
+Amend the branch — a new commit is fine, a squash is fine, whatever matches the project's convention. Push. Then **go back to step 2** and re-read the diff. Self-review is iterative; do not short-circuit after a fix.
+
+### 6. Produce the report
+
+When the list has no `fix-before-review` items left, emit a compact text report to the user. Example shape:
+
+```
+Self-review — mr#374
+
+Type safety:         ok
+Error handling:      minor — new variant `Error::ProviderStale` is not in the README table yet
+Tests:               ok
+Docs:                minor — new --remote-config-url flag missing from README cheatsheet
+i18n:                ok
+Cross-platform:      ok
+
+Open discussions:    0
+Recommendation:      ready for review — two minor notes to call out in the MR description
+```
+
+The report goes to the user in the chat. **Do not** post it as an MR comment. Any item flagged `minor` is something you mention in the MR description or a cover letter to the reviewer, not a self-posted review.
+
+## Success criteria
+
+- The report covers every checklist item with one of `ok` / `minor` / `fix-before-review`.
+- No `fix-before-review` item is left unfixed by the time the report is written.
+- Open discussions from previous rounds are counted and acknowledged.
+- Nothing was posted to the MR as part of this skill.
+
+## Guardrails
+
+- **Never post inline comments on your own MR.** Self-posted comments clutter the reviewer's view and muddy the signal about what a fresh pair of eyes actually flagged.
+- **Do not mark anything as resolved.** Resolution belongs to whichever reviewer opened the thread.
+- **Do not approve, merge, or change MR state.** This skill is strictly a dry-run.
+- **Do not expand scope during the fix pass.** A self-review fix is still a fix — refactors belong in a separate MR.
+
+## Non-goals
+
+- Replacing a human reviewer. Self-review catches the obvious; the human still needs to sign off.
+- Running the full CI pipeline locally. Local checks (`cargo fmt`, `cargo clippy`, targeted `cargo test`) are enough for a self-review pass — CI is what the reviewer sees.

--- a/skills/03-self-feedback/devboy-daily-report/SKILL.md
+++ b/skills/03-self-feedback/devboy-daily-report/SKILL.md
@@ -53,9 +53,12 @@ SESSION_ID=$(echo "$result" | jq -r .session_id)
 This skill is itself traceable — retro runs will see that a daily
 report ran, how long it took, and whether it succeeded.
 
-### 3. Walk the per-skill subdirectories
+### 3. Walk the per-session subdirectories
 
-For each `<skill>/` directory under the day:
+The trace subsystem writes each session under
+`<YYYY-MM-DD>/<skill>/<session_id>/`, so a single skill can produce
+several sibling session directories on the same day. Walk every
+`<skill>/<session_id>/` pair under the day:
 
 1. If `meta.json` is missing, skip the directory — the session is
    still in flight. Record a single `note` event listing the skipped
@@ -63,15 +66,16 @@ For each `<skill>/` directory under the day:
 2. Otherwise, read `meta.json` and pull:
    - `skill`, `outcome`, `tool_calls`, `errors`,
    - `summary`, `started_at`, `ended_at`.
-3. Aggregate per-skill counts: total runs, success / failure /
-   aborted, total tool-calls, total errors, average duration.
+3. Aggregate per-skill counts across **all** that skill's session
+   directories: total runs, success / failure / aborted, total
+   tool-calls, total errors, average duration.
 
-Emit an `artifact` event per skill directory so the retro skill can
-later find the raw data:
+Emit an `artifact` event per session directory so the retro skill
+can later find the raw data:
 
 ```bash
 devboy trace event ... --phase artifact \
-  --payload "$(jq -nc --arg path "$SKILL_DIR" '{path:$path,kind:"session-dir"}')"
+  --payload "$(jq -nc --arg path "$SESSION_DIR" '{path:$path,kind:"session-dir"}')"
 ```
 
 ### 4. Cross-reference with the provider

--- a/skills/03-self-feedback/devboy-daily-report/SKILL.md
+++ b/skills/03-self-feedback/devboy-daily-report/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: devboy-daily-report
+description: Summarise today's trace activity, merged MRs, and closed issues into a single report.
+category: self-feedback
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "daily report"
+  - "what did I do today"
+  - "summarise today"
+tools:
+  - trace
+  - get_merge_requests
+  - get_issues
+---
+
+# devboy-daily-report
+
+Reads today's session traces and cross-references them with the git
+provider's recent activity to produce a short Markdown report. The
+output goes to stdout — nothing is posted anywhere. Users who want the
+report delivered to a chat pipe it into `devboy-notify` (category 5).
+
+## When to use
+
+- At the end of a working day, to answer "what did I actually do
+  today?".
+- Before a standup, to compile a from-the-trace view of yesterday's
+  activity (run with `--date 2026-04-16`).
+- Any time an auditor wants a reproducible summary of session outcomes
+  against real git-provider events.
+
+## Procedure
+
+### 1. Resolve the sessions directory for the day
+
+Pick the date (default: today in the local timezone) and the scope:
+
+- Repo-local (default): `<repo>/.devboy/sessions/<YYYY-MM-DD>/`.
+- Global (`--global`): `~/.devboy/sessions/<YYYY-MM-DD>/`.
+
+If neither directory exists, exit with an error that tells the user
+which path was checked.
+
+### 2. Begin a trace for this report
+
+```bash
+result=$(devboy trace begin --skill devboy-daily-report)
+SESSION_DIR=$(echo "$result" | jq -r .session_dir)
+SESSION_ID=$(echo "$result" | jq -r .session_id)
+```
+
+This skill is itself traceable — retro runs will see that a daily
+report ran, how long it took, and whether it succeeded.
+
+### 3. Walk the per-skill subdirectories
+
+For each `<skill>/` directory under the day:
+
+1. If `meta.json` is missing, skip the directory — the session is
+   still in flight. Record a single `note` event listing the skipped
+   sessions so they show up in the report as "in progress".
+2. Otherwise, read `meta.json` and pull:
+   - `skill`, `outcome`, `tool_calls`, `errors`,
+   - `summary`, `started_at`, `ended_at`.
+3. Aggregate per-skill counts: total runs, success / failure /
+   aborted, total tool-calls, total errors, average duration.
+
+Emit an `artifact` event per skill directory so the retro skill can
+later find the raw data:
+
+```bash
+devboy trace event ... --phase artifact \
+  --payload "$(jq -nc --arg path "$SKILL_DIR" '{path:$path,kind:"session-dir"}')"
+```
+
+### 4. Cross-reference with the provider
+
+Two tool calls, each wrapped in a `tool_call` / `tool_result` pair:
+
+```bash
+devboy tools call get_merge_requests \
+  '{"state":"merged","limit":50}'
+devboy tools call get_issues \
+  '{"state":"closed","limit":50}'
+```
+
+Filter the returned lists down to items whose merge / close timestamp
+falls on the report's date. Neither `get_merge_requests` nor
+`get_issues` has a first-class `since` parameter in the current
+schema — do the date filter in the skill, not on the provider side.
+
+Record `ok:false` on the `tool_result` if the call fails, but keep
+going; a daily report is useful even if the tracker is offline.
+
+### 5. Assemble the Markdown report
+
+Structure:
+
+```markdown
+# Daily report — <YYYY-MM-DD>
+
+## Sessions
+- devboy-run-and-verify — 8 runs (7 success, 1 failure, avg 4.2s)
+- devboy-solve-issue — 2 runs (2 success, avg 2m31s)
+...
+
+## Merged MRs
+- mr#482 — "fix(auth): refresh token rotation"
+- mr#485 — "refactor(api): split user service"
+
+## Closed issues
+- DEV-411 — "Cannot invite user with plus-sign email"
+
+## Notable failures
+- devboy-run-and-verify 14:02 — "cargo test" failed on integration::auth
+```
+
+Skip any section that has no entries. Keep the report short — a
+hundred lines at most.
+
+### 6. End the trace
+
+```bash
+devboy trace end \
+  --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill devboy-daily-report \
+  --outcome "$OUTCOME" \
+  --summary "<N> sessions, <M> MRs merged, <K> issues closed"
+```
+
+Print the assembled Markdown to stdout and exit.
+
+## Success criteria
+
+- The report lists one line per skill that ran today, with accurate
+  counts drawn from `meta.json`.
+- In-flight sessions (no `meta.json`) are listed under "in progress"
+  rather than silently dropped.
+- MRs and issues with a date-stamp outside the target day are not
+  shown.
+- The skill never mutates anything — no comments posted, no issues
+  touched.
+
+## Guardrails
+
+- Redacted trace payloads stay opaque. If a trace line contains
+  `<redacted:...>`, carry it into the report verbatim; do not try to
+  reconstruct the original value.
+- If both the repo-local and `--global` trace directories are absent,
+  exit with a non-zero status rather than producing an empty report.
+
+## Non-goals
+
+- This skill does not post the report. Use `devboy-notify` from
+  category 5 if delivery is needed.
+- It does not create issues, update tickets, or touch git in any way.
+- It does not analyse long-term trends — that is `devboy-retro`.

--- a/skills/03-self-feedback/devboy-knowledge-extract/SKILL.md
+++ b/skills/03-self-feedback/devboy-knowledge-extract/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: devboy-knowledge-extract
+description: Extract the lesson from a session that failed, then succeeded, and propose where to codify it.
+category: self-feedback
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "extract the lesson"
+  - "what did we learn"
+  - "codify this fix"
+tools:
+  - trace
+---
+
+# devboy-knowledge-extract
+
+Inspects a single session trace that went from a failure streak to a
+clean success, pulls out what changed between "not working" and
+"working", and proposes where the lesson belongs — a SKILL.md edit, an
+`AGENTS.md` / `CLAUDE.md` bullet, or a ticket. **The skill is
+read-only.** It prints a proposal to stdout; the user decides whether
+to act on it.
+
+## When to use
+
+- Right after a painful debug that eventually passed — the shape of
+  what worked is still fresh, but will fade within a day.
+- On a session that `devboy-daily-report` flagged as "recovered after
+  multiple failures".
+- When reviewing a teammate's trace to understand how they unblocked
+  themselves.
+
+## Procedure
+
+### 1. Locate the session
+
+Accept one of:
+
+- `--session-dir <path>` — absolute or relative path to a
+  `.devboy/sessions/<YYYY-MM-DD>/<skill>/` directory. If the directory
+  contains `meta.json` and `trace.jsonl`, use it directly.
+- `--pick` — interactive mode: list today's sessions where `outcome
+  = success` but `errors > 0` and let the user pick one. This is the
+  common follow-up after `devboy-daily-report`.
+
+Exit with a clear error if neither flag is set or the directory is
+not a well-formed session.
+
+### 2. Begin the meta-trace
+
+The extract itself is traced — retros care about how often the team
+reaches for this skill.
+
+```bash
+result=$(devboy trace begin --skill devboy-knowledge-extract)
+SESSION_DIR=$(echo "$result" | jq -r .session_dir)
+SESSION_ID=$(echo "$result" | jq -r .session_id)
+```
+
+Record a `decision` event naming the target session dir.
+
+### 3. Parse the target trace
+
+Read `trace.jsonl` line by line. Lines that fail to deserialise as
+JSON are skipped with a single `note` event — do not abort. For each
+valid record keep: `ts`, `phase`, `payload`.
+
+Compute three spans:
+
+- **Failure streak.** A contiguous run of events where either
+  `tool_result.ok = false` or `verify.ok = false` — possibly
+  interleaved with `note`, `decision`, or further `tool_call` events
+  that target the same tool or check.
+- **Flip point.** The first event after the streak where
+  `tool_result.ok = true` or `verify.ok = true` on the same tool or
+  check as the streak.
+- **Setup delta.** The `decision` and `note` events that appear
+  between the last failing event and the flip point — those record
+  what the agent or user tried differently.
+
+If the trace has no failure streak (only clean successes), print a
+short message saying there is nothing to extract and end the meta-
+trace with `outcome: aborted`.
+
+### 4. Draft the lesson
+
+One short paragraph, plain English. Template:
+
+> After failing `<tool-or-check>` `<N>` times with `<common-error>`,
+> switching to `<approach-described-in-setup-delta>` fixed it
+> because `<why, if the decision/note events state it>`.
+
+If the trace does not justify the "because" clause, leave it out
+rather than making something up.
+
+### 5. Suggest where to codify the lesson
+
+Classify the fix and propose exactly one home:
+
+- **Tool invocation pattern** (e.g. "call `get_pipeline` with
+  `includeFailedLogs: false` when the MR is large") — propose a
+  SKILL.md edit on the skill that owns the call. Name the file
+  (`skills/<category>/<skill>/SKILL.md`) and quote the exact
+  sentence to add.
+- **Project convention** (e.g. "this repo requires migrations in
+  snake_case") — propose a bullet for `CLAUDE.md`, `AGENTS.md`, or
+  the project's own guide, quoting the sentence.
+- **Systemic infra bug** (e.g. "CI cache corrupts itself on
+  concurrent merges") — propose a ticket via
+  `devboy-create-issue`, including a draft title and two-sentence
+  reproduction, but do not create it.
+
+Only one home per lesson. If the fix really belongs in two places,
+split the extraction into two successive invocations.
+
+### 6. Emit the proposal
+
+Print to stdout:
+
+```markdown
+# Lesson extracted from <session-dir>
+
+## What happened
+<one paragraph>
+
+## Lesson
+<one paragraph>
+
+## Proposed codification
+Target: skills/02-code-review/devboy-review-mr/SKILL.md
+Edit:
+> Add the following to the "Procedure" section, after step 3:
+> "When the MR touches more than 50 files, pass
+>  includeFailedLogs: false to get_pipeline — otherwise the response
+>  overflows the context window."
+```
+
+Do **not** apply the edit. Do **not** open the file. Do **not** create
+the ticket.
+
+### 7. End the meta-trace
+
+```bash
+devboy trace end \
+  --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill devboy-knowledge-extract \
+  --outcome "$OUTCOME" \
+  --summary "lesson proposal for <original-skill>"
+```
+
+## Success criteria
+
+- Every proposal cites a specific file path or a concrete ticket
+  target — no "maybe add a note somewhere".
+- The "What happened" paragraph points at real `tool_call` /
+  `tool_result` / `verify` events with timestamps from the trace.
+- Running the skill twice on the same session produces the same
+  proposal.
+
+## Guardrails
+
+- **Read-only.** The skill never writes into another skill's
+  `SKILL.md`, never opens a PR, never calls `create_issue` or
+  `add_issue_comment`. Proposals are text on stdout.
+- Redacted trace fields are opaque. If the failure streak's error
+  message was redacted, quote it verbatim (`<redacted:token-pattern>
+  in response body`). Do not guess at the underlying value.
+- If the trace is malformed or the session has no failure-to-success
+  transition, say so and end with `outcome: aborted`.
+
+## Non-goals
+
+- Does not build a knowledge base or index of past lessons.
+- Does not rank lessons by importance.
+- Does not replace a human reviewer — the user still decides whether
+  the proposed edit is worth making.

--- a/skills/03-self-feedback/devboy-knowledge-extract/SKILL.md
+++ b/skills/03-self-feedback/devboy-knowledge-extract/SKILL.md
@@ -36,12 +36,14 @@ to act on it.
 
 Accept one of:
 
-- `--session-dir <path>` — absolute or relative path to a
-  `.devboy/sessions/<YYYY-MM-DD>/<skill>/` directory. If the directory
-  contains `meta.json` and `trace.jsonl`, use it directly.
-- `--pick` — interactive mode: list today's sessions where `outcome
-  = success` but `errors > 0` and let the user pick one. This is the
-  common follow-up after `devboy-daily-report`.
+- `--session-dir <path>` — absolute or relative path to a real
+  per-session directory such as
+  `.devboy/sessions/<YYYY-MM-DD>/<skill>/<session_id>/`. If the
+  directory contains `meta.json` and `trace.jsonl`, use it directly.
+- `--pick` — interactive mode: enumerate today's `<skill>/<session_id>/`
+  directories whose `meta.json` has `outcome = success` and `errors > 0`,
+  and let the user pick one. This is the common follow-up after
+  `devboy-daily-report`.
 
 Exit with a clear error if neither flag is set or the directory is
 not a well-formed session.

--- a/skills/03-self-feedback/devboy-retro/SKILL.md
+++ b/skills/03-self-feedback/devboy-retro/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: devboy-retro
+description: Aggregate the last N days of traces, MRs, and CI runs to surface patterns worth fixing.
+category: self-feedback
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "weekly retro"
+  - "what patterns are there"
+  - "where should I improve"
+tools:
+  - trace
+  - get_merge_requests
+  - get_merge_request_discussions
+  - get_pipeline
+  - get_job_logs
+---
+
+# devboy-retro
+
+Looks back over the last N days of session traces, recent merge
+requests, and CI pipelines to surface recurring patterns: skills whose
+success rate slipped, review feedback that keeps coming back, flaky
+jobs. The output is a user-facing report with suggestions — the skill
+never files tickets, never edits other skills, and never opens MRs.
+
+## When to use
+
+- At a weekly or bi-weekly retro, to anchor the conversation in
+  evidence instead of anecdote.
+- When a skill seems unreliable and you want to quantify the failure
+  shape before rewriting it.
+- Before an upgrade, to see which tool calls are most at risk if
+  something changes.
+
+## Procedure
+
+### 1. Pick the window
+
+- `--days 7` (default). Collect traces from the last N calendar days
+  under `<scope>/.devboy/sessions/<YYYY-MM-DD>/` where `<scope>` is
+  either the repo root (default) or `~/.devboy/` when `--global` is
+  passed.
+- If fewer than two days of data exist, warn on stderr — retros over
+  a tiny window are noisy.
+
+### 2. Begin the trace
+
+```bash
+result=$(devboy trace begin --skill devboy-retro)
+SESSION_DIR=$(echo "$result" | jq -r .session_dir)
+SESSION_ID=$(echo "$result" | jq -r .session_id)
+```
+
+Emit a `decision` event recording the window and the scope.
+
+### 3. Aggregate per-skill session stats
+
+Walk every `<date>/<skill>/meta.json` in the window. Per skill,
+collect: total runs, success / failure / aborted counts, total
+`tool_calls`, total `errors`, total duration, average duration, and
+the most common `summary` strings for failing runs.
+
+Additionally, read each failing session's `trace.jsonl` to find
+retry loops — sequences of `verify` events with `ok: false` followed
+by more `tool_call` attempts. A skill with many retry loops is a
+skill that could benefit from a stronger precondition check; record
+the ratio `retried / total_failures` per skill.
+
+Emit one `note` event per skill containing the aggregate numbers so
+future retros have a stable trail.
+
+### 4. Cross-reference CI history
+
+For every merged MR in the window:
+
+```bash
+devboy tools call get_merge_requests '{"state":"merged","limit":100}'
+```
+
+Filter the result to merge timestamps inside the window, then for the
+first ~20 call:
+
+```bash
+devboy tools call get_pipeline \
+  '{"mrKey":"mr#482","includeFailedLogs":true}'
+```
+
+Collect failing-job frequency keyed by job name. For the top three
+failing jobs, call `get_job_logs` in search mode to pull the most
+common error signature:
+
+```bash
+devboy tools call get_job_logs \
+  '{"jobId":"<id>","pattern":"error|fail|panic","context":2,"maxMatches":10}'
+```
+
+Keep only the error shapes that repeat across multiple runs — a
+single broken job is signal for the developer, not a pattern.
+
+### 5. Cross-reference review feedback
+
+For the same merged MRs:
+
+```bash
+devboy tools call get_merge_request_discussions \
+  '{"key":"mr#482","limit":50}'
+```
+
+Group the discussion bodies by naïve keyword bucket (type-safety,
+error-handling, testing, naming, i18n, performance, security). Count
+how often each bucket appears across MRs. The top three buckets go
+into the report.
+
+### 6. Produce the report
+
+Markdown to stdout:
+
+```markdown
+# Retro — last 7 days
+
+## Skills with degraded success rate
+- devboy-solve-issue — 6/10 success (was 9/10 the previous week);
+  60% of failures retry more than twice; top summary:
+  "gitlab returned 429".
+
+## Frequent review feedback
+- testing (mentioned in 9 MRs)
+- error-handling (mentioned in 5 MRs)
+- type-safety (mentioned in 4 MRs)
+
+## Flaky CI signal
+- integration::auth — 5/20 runs failed with "connection refused"
+- clippy — 3/20 runs failed with "-D warnings" on a single rule
+
+## Suggestions
+- Add a 429 back-off to the get_issues call inside devboy-solve-issue.
+- Update devboy-review-mr's checklist to call out type-safety explicitly.
+- Investigate integration::auth — likely a race on the test fixture.
+```
+
+Omit sections with no entries. Keep the report tight; two screens of
+text at most.
+
+### 7. End the trace
+
+```bash
+devboy trace end \
+  --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill devboy-retro \
+  --outcome "$OUTCOME" \
+  --summary "<N> sessions, <M> MRs, <K> jobs analysed"
+```
+
+## Success criteria
+
+- The report is driven entirely by numbers pulled from traces, MR
+  history, and pipeline data — no hand-waving.
+- Every suggestion points at a concrete skill, job, or feedback
+  bucket.
+- The skill is idempotent: running it twice over the same window
+  produces the same report (modulo clock drift in timestamps).
+
+## Guardrails
+
+- Never auto-create issues, never edit a `SKILL.md`, never post a
+  comment. The suggestions are text for a human to read.
+- Redacted trace payloads (`<redacted:credential>`, `<redacted:token-pattern>`)
+  are treated as opaque. Count them, do not try to un-redact them.
+- If `get_pipeline` or `get_merge_request_discussions` fails, note
+  the degradation in the report ("CI section omitted — pipeline
+  lookup failed") rather than pretending everything is fine.
+
+## Non-goals
+
+- Does not compare across projects or repositories.
+- Does not score individual developers; retros look at skills and
+  systems, not people.
+- Does not overlap with `devboy-daily-report` — that is a single-day
+  summary, this one is a multi-day pattern detector.

--- a/skills/03-self-feedback/devboy-retro/SKILL.md
+++ b/skills/03-self-feedback/devboy-retro/SKILL.md
@@ -56,10 +56,12 @@ Emit a `decision` event recording the window and the scope.
 
 ### 3. Aggregate per-skill session stats
 
-Walk every `<date>/<skill>/meta.json` in the window. Per skill,
-collect: total runs, success / failure / aborted counts, total
-`tool_calls`, total `errors`, total duration, average duration, and
-the most common `summary` strings for failing runs.
+Walk every `<date>/<skill>/<session_id>/meta.json` in the window —
+the trace subsystem nests each session one level below `<skill>/`.
+Per skill, aggregate across **all** its session directories:
+total runs, success / failure / aborted counts, total `tool_calls`,
+total `errors`, total duration, average duration, and the most
+common `summary` strings for failing runs.
 
 Additionally, read each failing session's `trace.jsonl` to find
 retry loops — sequences of `verify` events with `ok: false` followed

--- a/skills/03-self-feedback/devboy-run-and-verify/SKILL.md
+++ b/skills/03-self-feedback/devboy-run-and-verify/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: devboy-run-and-verify
+description: Run a command, trace every step, verify the expected outcome, and retry on failure.
+category: self-feedback
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "run and verify"
+  - "verify this command worked"
+  - "retry until green"
+tools:
+  - trace
+---
+
+# devboy-run-and-verify
+
+The opinionated wrapper that the other skills in this category assume.
+It runs one command, emits a structured session trace for every attempt,
+checks the expected outcome, and decides whether to retry. Downstream
+skills (`devboy-daily-report`, `devboy-retro`,
+`devboy-knowledge-extract`) consume the trace this skill produces.
+
+## When to use
+
+- You need to run a shell command whose success is not obvious from the
+  exit code alone (e.g. "the build exited 0 but printed WARNING lines we
+  want to catch").
+- You want a trace that later skills can read to understand what
+  happened and how long it took.
+- You want one, predictable retry policy rather than hand-rolling
+  retries inside each calling skill.
+
+## Procedure
+
+### 1. Parse the caller's intent
+
+Collect the following arguments from the caller:
+
+- `--command "<shell command>"` — the command to execute.
+- An expected-outcome specification. One of:
+  - `--expect-exit 0` — exact exit code.
+  - `--expect-stdout "<substring>"` — stdout must contain this string.
+  - `--expect-file "<path>"` — this path must exist after the run.
+  - `--expect-check "<verification command>"` — a shell command whose
+    exit code 0 means "the main command did what it was supposed to".
+- `--max-retries 2` (default `2`). The command runs up to
+  `1 + max-retries` times.
+- `--skill-name <name>` — the name of the skill that invoked this
+  wrapper. Traces are written under
+  `.devboy/sessions/<YYYY-MM-DD>/<skill-name>/` so downstream readers
+  attribute the work correctly.
+- `--allow-destructive` — required before running anything that matches
+  the destructive-command guardrail (see below).
+
+If an expected-outcome flag is missing, the skill exits with an error —
+there is nothing to verify against.
+
+### 2. Begin the session
+
+```bash
+result=$(devboy trace begin --skill "$SKILL_NAME")
+SESSION_DIR=$(echo "$result" | jq -r .session_dir)
+SESSION_ID=$(echo "$result" | jq -r .session_id)
+```
+
+Emit a `decision` event that records what the caller asked for:
+
+```bash
+devboy trace event \
+  --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill "$SKILL_NAME" --phase decision \
+  --payload "$(jq -nc --arg cmd "$COMMAND" --arg expect "$EXPECT" \
+               '{question:"what to run",decision:$cmd,expected:$expect}')"
+```
+
+### 3. Per-attempt loop
+
+For `attempt` in `1..=1+max_retries`:
+
+1. Emit a `tool_call` event describing the command about to run and
+   the attempt number.
+2. Run the command with stdout + stderr captured to a temporary file.
+   Record the start time, the end time, and the exit status.
+3. Summarise the output: keep the first 20 lines, the last 20 lines,
+   and every line matching `ERROR|WARN|FAIL|panic`. Everything else
+   can be dropped — trace payloads should stay small (ADR-015 risks).
+4. Emit a `tool_result` event with `{ok, exit, duration_ms, summary}`.
+5. Run the expected-outcome check. Emit a `verify` event with
+   `{check, ok, detail}`. The check is:
+   - exit code comparison, or
+   - substring search in the captured stdout, or
+   - `test -e <path>`, or
+   - the `--expect-check` shell command.
+6. If the verify event is `ok: true`, break out of the loop.
+7. Otherwise, if retries remain, emit a `note` event explaining why
+   the next attempt is happening ("expect-exit 0 but got 1; retrying"),
+   and continue. If retries are exhausted, fall through to step 4.
+
+### 4. End the session
+
+Pick the outcome:
+
+- `success` — some attempt produced `ok: true` on both tool-result and
+  verify.
+- `failure` — every attempt failed the verification.
+- `aborted` — the caller interrupted mid-run, or a destructive command
+  was rejected by the guardrail.
+
+```bash
+devboy trace end \
+  --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+  --skill "$SKILL_NAME" --outcome "$OUTCOME" \
+  --summary "$SHORT_SUMMARY"
+```
+
+### 5. Surface the result
+
+Print a 3-to-5-line summary to stdout naming: the command, attempts
+used, final outcome, and the path to the trace directory. Do not
+reprint the full captured output — the caller can `cat` the trace if
+they want it.
+
+## Success criteria
+
+- Exactly one `start` and one `end` event per invocation.
+- Every attempt contributes a matching `tool_call` / `tool_result` /
+  `verify` trio.
+- `meta.json` lands with `outcome` set to one of `success | failure |
+  aborted`.
+- A failing run still produces a complete, well-formed trace.
+
+## Guardrails
+
+Destructive commands are refused unless the caller passes
+`--allow-destructive`. The refusal path still opens a session, emits a
+`note` event describing the rejection, and ends with
+`outcome: aborted` so downstream skills can see what happened.
+
+Treat the following substrings (case-insensitive) as destructive:
+
+- `git push --force`, `git push -f`, `git reset --hard`,
+  `git clean -fdx`, `git branch -D`
+- `rm -rf`
+- `drop table`, `drop database`, `truncate`
+- `kubectl delete`, `helm uninstall`
+
+## Non-goals
+
+- This skill does not parse structured output to extract metrics; the
+  trace summary is intentionally textual.
+- It does not chain multiple commands. A pipeline of commands is
+  multiple invocations of this skill, one per step.
+- It does not post results anywhere. Notification belongs to
+  `devboy-notify` (category 5).

--- a/skills/03-self-feedback/devboy-run-and-verify/SKILL.md
+++ b/skills/03-self-feedback/devboy-run-and-verify/SKILL.md
@@ -47,8 +47,8 @@ Collect the following arguments from the caller:
   `1 + max-retries` times.
 - `--skill-name <name>` — the name of the skill that invoked this
   wrapper. Traces are written under
-  `.devboy/sessions/<YYYY-MM-DD>/<skill-name>/` so downstream readers
-  attribute the work correctly.
+  `.devboy/sessions/<YYYY-MM-DD>/<skill-name>/<session_id>/` so
+  downstream readers attribute the work correctly.
 - `--allow-destructive` — required before running anything that matches
   the destructive-command guardrail (see below).
 

--- a/skills/04-meeting-notes/devboy-meeting-search/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-search/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: devboy-meeting-search
+description: Find meetings by keyword, participant, host, or date range and surface a short, rankable hit list.
+category: meeting-notes
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "find meeting about"
+  - "when did we discuss"
+  - "list meetings last week"
+  - "search meetings"
+  - "find calls with"
+tools:
+  - search_meeting_notes
+  - get_meeting_notes
+---
+
+# devboy-meeting-search
+
+Answer "which meeting did we talk about X?" without making the user scroll through a calendar. The skill narrows a corpus of meeting notes down to a short hit list the user can act on — drill-down into a single meeting's metadata is a follow-up step, and pulling the full transcript is the job of `devboy-meeting-transcript`.
+
+## When to use
+
+- The user names a topic, keyword, or phrase ("the migration call", "anything about SSO") and wants to locate the meeting.
+- The user wants a window of recent meetings ("what did we have this week?", "list calls with Alice last month").
+- Before running `devboy-meeting-to-tasks` or `devboy-meeting-transcript`, confirm the target meeting id.
+
+If no search term is given — just a window or a participant — skip the keyword search and go straight to `get_meeting_notes` with the filter.
+
+## Procedure
+
+### 1. Keyword search
+
+Use `search_meeting_notes` when the user supplied a topic. All filters (date range, participants, host) combine with the keyword on the provider side — there is no client-side filter.
+
+```bash
+devboy tools call search_meeting_notes '{
+  "query": "migration",
+  "from_date": "2026-03-01T00:00:00Z",
+  "to_date":   "2026-04-17T00:00:00Z",
+  "limit": 20
+}'
+```
+
+Dates are ISO 8601. The tool caps `limit` at 50 per call; paginate with `offset` if you need a deeper sweep.
+
+### 2. Filter-only listing (no keyword)
+
+```bash
+devboy tools call get_meeting_notes '{
+  "from_date": "2026-04-10T00:00:00Z",
+  "participants": ["alice@example.com"],
+  "limit": 20
+}'
+```
+
+Use this for "last N days" or "calls with Alice" — no keyword means do not invent one.
+
+### 3. Rank the hits
+
+The provider returns meetings newest-first but is not topic-ranked. When several hits look plausible, resolve ties by:
+
+1. **Recency** — the user usually wants the most recent occurrence.
+2. **Participant overlap** — prefer meetings whose attendees match the user's context (the person they are collaborating with, the team they asked about).
+3. **Keyword density** — if the provider surfaces `summary`, `keywords`, or `topics_discussed`, a meeting that hits multiple of them is a stronger match than one that mentions the term in passing.
+
+Present at most 5–10 candidates. If more exist, say so and offer to narrow by date or participant rather than dumping them all.
+
+### 4. Drill down to one meeting
+
+Once the user picks a hit, fetch its metadata for a short card — title, date, duration, participants, action-items count, a one-line summary:
+
+```bash
+devboy tools call get_meeting_notes '{
+  "from_date": "<date of the hit>",
+  "to_date":   "<+1 day>",
+  "limit": 5
+}'
+```
+
+(There is no single-meeting "get by id" helper — narrow the date window and match on `id`.)
+
+## Success criteria
+
+- The user can name the meeting they meant without reading a transcript.
+- For every hit the agent shows, at minimum: title, date, 1-line summary or top keyword.
+- If zero hits come back, the skill suggests a broader filter (wider date range, different keyword) rather than inventing a meeting.
+
+## Guardrails
+
+- **Do not dump transcripts here.** A search result is metadata + a one-line summary. Full transcript retrieval lives in `devboy-meeting-transcript`.
+- **Do not paraphrase the summary.** Quote the provider's summary verbatim — it is short and PII-sensitive; rewording risks distortion.
+- **Participants are emails.** When the user says "calls with Alice", ask for the email before filtering — display names from the provider are not guaranteed unique.
+
+## Non-goals
+
+- Ranking by semantic similarity beyond what the provider returns. The tool is a keyword search, not a vector search.
+- Cross-provider search. Only the meeting-notes provider that is configured (e.g. Fireflies) is queried.

--- a/skills/04-meeting-notes/devboy-meeting-to-tasks/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-to-tasks/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: devboy-meeting-to-tasks
+description: Extract deduplicated action items from a meeting, confirm with the user, then create issues in the configured tracker.
+category: meeting-notes
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "turn this meeting into tickets"
+  - "create tasks from the meeting"
+  - "extract action items"
+  - "file tickets from the call"
+  - "make issues from the transcript"
+tools:
+  - get_meeting_notes
+  - get_meeting_transcript
+  - create_issue
+  - link_issues
+---
+
+# devboy-meeting-to-tasks
+
+Convert a meeting into concrete, trackable work. The skill is deliberately conservative: extract → deduplicate → **confirm with the user** → create. Automatic creation from a transcript produces nonsense tickets far too often — human review before the first `create_issue` is not optional.
+
+## When to use
+
+- The user references a meeting that produced to-dos and wants them in the tracker.
+- A standup, planning, or retro transcript exists and the commitments need a paper trail.
+- Follow-up from `devboy-meeting-search` when the user says "file tickets for this one".
+
+## Procedure
+
+### 1. Pin the meeting
+
+The skill operates on one meeting at a time. If the id is not known, fetch the short metadata list and confirm with the user:
+
+```bash
+devboy tools call get_meeting_notes '{
+  "from_date": "<window start ISO>",
+  "to_date":   "<window end ISO>",
+  "limit": 10
+}'
+```
+
+### 2. Prefer the provider's action items
+
+`get_meeting_notes` returns an `action_items` array populated by the provider's summariser. When it is non-empty, use it — it is already filtered to imperative commitments:
+
+```bash
+devboy tools call get_meeting_notes '{
+  "from_date": "<narrow window around the meeting>",
+  "to_date":   "<+1 day>",
+  "limit": 5
+}'
+```
+
+Take the `action_items` field from the matching meeting. This is cheaper and more reliable than parsing a transcript.
+
+### 3. Fallback: parse the transcript
+
+If `action_items` is empty or missing, fetch the transcript and extract candidates manually:
+
+```bash
+devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' --budget 6000
+```
+
+Look for:
+
+- Imperative verb phrases attributed to a specific participant ("I'll draft the RFC", "Alice will open a ticket about X").
+- "Let's…" / "We need to…" statements where someone assented.
+
+Skip hypotheticals, questions, and vague intentions ("we should probably look into that" with no commitment attached).
+
+### 4. Deduplicate ruthlessly
+
+A 45-minute call will restate the same commitment three or four times. Before creating anything, collapse the list:
+
+- Normalise the verb + object (e.g. "update the docs", "fix docs", "I'll update the documentation" → one item).
+- Merge paraphrases of the same commitment made by the same person.
+- Keep distinct items when the owner differs, even if the action is similar.
+
+The deduplicated list is what the user will see next.
+
+### 5. Confirm with the user before creating
+
+**Show the dedup'd list and wait for a go-ahead.** Offer three options:
+
+1. Create all of them as-is.
+2. Create a named subset.
+3. Edit titles / owners / descriptions first.
+
+Never skip this step — automatic creation from a transcript is the single biggest source of tracker clutter this skill can cause.
+
+### 6. Create one issue per item
+
+Keep each ticket small — **one action, one ticket**. For each approved item:
+
+```bash
+devboy tools call create_issue '{
+  "title": "Short imperative title (one line)",
+  "description": "Source: meeting \"<meeting title>\" on <ISO date>.\nOwner committed: <name>.\n\nContext:\n<2–4 lines from the transcript or action_items entry>",
+  "assignees": ["<handle>"],
+  "labels": ["from-meeting"]
+}'
+```
+
+Guidelines:
+
+- Title is imperative and under ~80 chars. "Draft RFC for auth migration" not "We should probably think about the RFC".
+- Description always cites the meeting title + date so the ticket is traceable back to its source.
+- Assign to the committed owner when known. If unknown, leave unassigned and note the speaker in the body.
+
+### 7. Optional: link issues that share a parent
+
+If several of the new issues clearly belong to one epic the user named, link them:
+
+```bash
+devboy tools call link_issues '{
+  "sourceIssueKey": "<new issue key>",
+  "targetIssueKey": "<epic key>",
+  "linkType": "relates_to"
+}'
+```
+
+Use `relates_to` by default; only use `blocks` when the user stated an ordering.
+
+### 8. Report back
+
+Reply with:
+
+- The meeting source (title + date).
+- The deduplicated list of created tickets (one line each: `KEY — title`).
+- Items that were discussed but **not** created (because the user dropped them), so the audit trail is complete.
+
+## Success criteria
+
+- Zero tickets are created before the user confirms the deduplicated list.
+- Every created ticket cites the source meeting in its description.
+- Each ticket is one action (no multi-bullet tickets). If the extracted item has two distinct actions, it was two items and should have been split during dedup.
+- The count of created tickets matches the count of approved items — no silent drops, no silent extras.
+
+## Guardrails
+
+- **Never auto-create.** Even when the user says "just do it", show the list once and wait for one-key confirmation. One extra round-trip beats filing 20 bad tickets.
+- **Do not re-create on re-run.** If the user re-runs the skill on the same meeting, check for existing tickets with the `from-meeting` label plus the source-meeting citation before creating duplicates.
+- **Respect privacy.** Do not paste full transcript quotes into ticket descriptions — 2–4 lines of context is enough, more is a PII leak in a system that is often more widely shared than the meeting itself.
+
+## Non-goals
+
+- Estimating or prioritising the created tickets. The skill files them; triage is a separate step.
+- Cross-meeting aggregation. One meeting → one batch of tickets.
+- Updating existing tickets based on a meeting. Use `update_issue` directly for that — this skill only creates.

--- a/skills/04-meeting-notes/devboy-meeting-to-tasks/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-to-tasks/SKILL.md
@@ -58,10 +58,10 @@ Take the `action_items` field from the matching meeting. This is cheaper and mor
 
 ### 3. Fallback: parse the transcript
 
-If `action_items` is empty or missing, fetch the transcript and extract candidates manually:
+If `action_items` is empty or missing, fetch the transcript and extract candidates manually. `devboy tools call` has no `--budget` flag — the format-pipeline trims the response to fit the configured tool budget internally, so just call the tool and the runtime handles truncation:
 
 ```bash
-devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' --budget 6000
+devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}'
 ```
 
 Look for:

--- a/skills/04-meeting-notes/devboy-meeting-to-tasks/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-to-tasks/SKILL.md
@@ -13,6 +13,7 @@ activation:
 tools:
   - get_meeting_notes
   - get_meeting_transcript
+  - get_issues
   - create_issue
   - link_issues
 ---
@@ -141,7 +142,7 @@ Reply with:
 ## Guardrails
 
 - **Never auto-create.** Even when the user says "just do it", show the list once and wait for one-key confirmation. One extra round-trip beats filing 20 bad tickets.
-- **Do not re-create on re-run.** If the user re-runs the skill on the same meeting, check for existing tickets with the `from-meeting` label plus the source-meeting citation before creating duplicates.
+- **Do not re-create on re-run.** If the user re-runs the skill on the same meeting, use `get_issues` with the `from-meeting` label (plus the source-meeting citation in the body) to find already-created tickets before creating duplicates.
 - **Respect privacy.** Do not paste full transcript quotes into ticket descriptions — 2–4 lines of context is enough, more is a PII leak in a system that is often more widely shared than the meeting itself.
 
 ## Non-goals

--- a/skills/04-meeting-notes/devboy-meeting-transcript/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-transcript/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: devboy-meeting-transcript
+description: Fetch a meeting transcript — full, paginated, or filtered to a single speaker or phrase — without leaking raw PII into long-term storage.
+category: meeting-notes
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "transcript of meeting"
+  - "what did Alice say about"
+  - "show the meeting transcript"
+  - "quote from the meeting"
+  - "what was said about"
+tools:
+  - get_meeting_transcript
+  - get_meeting_notes
+---
+
+# devboy-meeting-transcript
+
+Retrieve the speaker-attributed, timestamped transcript for a single meeting. Transcripts are routinely large (thousands of sentences for a one-hour call), so the skill is built around pulling only what the question actually needs rather than the whole thing.
+
+## When to use
+
+- The user asks for a transcript by meeting title, id, or relative reference ("the call yesterday", "the one with Alice on Tuesday").
+- The user wants a specific quote ("what did Bob say about the migration?").
+- A follow-up skill (`devboy-meeting-to-tasks`) needs the raw text to extract action items that are not already in `action_items`.
+
+If the user does not yet know which meeting — route through `devboy-meeting-search` first.
+
+## Procedure
+
+### 1. Resolve the meeting id
+
+You need a `meeting_id`. If the user already pasted one, skip this step. Otherwise confirm the id via `get_meeting_notes` (or via `devboy-meeting-search` for a keyword lookup) and pin the id before fetching:
+
+```bash
+devboy tools call get_meeting_notes '{
+  "from_date": "2026-04-16T00:00:00Z",
+  "to_date":   "2026-04-17T00:00:00Z",
+  "limit": 10
+}'
+```
+
+Confirm the title and date with the user before proceeding — pulling the wrong transcript is an irreversible PII leak into the chat.
+
+### 2. Fetch the transcript with a budget
+
+```bash
+devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' --budget 4000
+```
+
+`--budget` is the format pipeline's token cap. A full-length call does not fit in a single chunk — the response comes back with:
+
+- `truncated: true` and a pagination hint when there is more to fetch.
+- `chunked: true` + `total_chunks` + `chunk_number` when the output was split.
+
+### 3. Navigate chunks, do not re-fetch the whole thing
+
+If chunk 1 is not the interesting bit, ask for the next chunk rather than re-running the call with a higher budget:
+
+```bash
+devboy tools call get_meeting_transcript '{"meeting_id": "<id>", "chunk": 2}' --budget 4000
+```
+
+`chunk` is the enricher's universal navigation parameter — it is added to every tool, not specific to transcripts. Chunk 1 is the default.
+
+### 4. Prefer a targeted fetch over a full dump
+
+When the question is specific ("what did Alice say about X?"), do not scroll the whole transcript in the chat. Two patterns:
+
+1. **Search first, transcript second.** Run `devboy-meeting-search` with the topic word, confirm this is the right meeting, then open the relevant chunk.
+2. **Grep the chunk.** Once you have the transcript text, filter locally to sentences from the speaker of interest. The transcript output is speaker-attributed (`speaker_name`, `speaker_id`, `text`, `start_time`), so a simple line filter works:
+
+   ```bash
+   devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' --budget 6000 \
+     | jq '.[] | select(.speaker_name == "Alice")'
+   ```
+
+### 5. Quote, do not paste
+
+When you respond to the user, reply with the minimum quote that answers the question — typically one to three sentences plus the speaker and timestamp. Never paste the full transcript into the chat unless the user explicitly asked for it.
+
+## Success criteria
+
+- The user gets an answer grounded in the transcript, with speaker + timestamp, in fewer than 10 lines for a targeted question.
+- For a "give me the whole transcript" request, the skill streams chunk 1, reports `total_chunks`, and waits for the user to ask for more rather than pre-fetching all chunks.
+- No untrimmed transcript content is copy-pasted into files the user did not name.
+
+## Guardrails
+
+- **PII.** Transcripts contain names, emails, internal project names, and sometimes customer data. Do not write them to long-term storage (new docs, new issues, commit messages) unless the user explicitly asks for a specific excerpt. Summarise; do not mirror.
+- **Do not translate or edit quotes.** If the user asks "what did Alice say?", answer with her words, not a paraphrase — downstream uses (legal, HR, customer conversations) rely on the exact phrasing.
+- **Confirm the meeting before fetching.** A wrong `meeting_id` leaks a different meeting's contents into the chat and is not retractable.
+
+## Non-goals
+
+- Editing or redacting transcripts. The skill is read-only.
+- Summarising a full meeting. Use the `summary` and `action_items` fields returned by `get_meeting_notes` — those are provider-generated and cheaper to fetch than the full transcript.
+- Cross-meeting aggregation. One transcript at a time.

--- a/skills/04-meeting-notes/devboy-meeting-transcript/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-transcript/SKILL.md
@@ -80,7 +80,7 @@ When you respond to the user, reply with the minimum quote that answers the ques
 ## Success criteria
 
 - The user gets an answer grounded in the transcript, with speaker + timestamp, in fewer than 10 lines for a targeted question.
-- For a "give me the whole transcript" request, the skill streams chunk 1, reports `total_chunks`, and waits for the user to ask for more rather than pre-fetching all chunks.
+- For a "give me the whole transcript" request, the skill streams chunk 1, explains how to request chunk 2+ if the user wants more, and waits for the user to ask rather than pre-fetching all chunks. (The pipeline does not surface a total-chunk count, so the skill must not promise one.)
 - No untrimmed transcript content is copy-pasted into files the user did not name.
 
 ## Guardrails

--- a/skills/04-meeting-notes/devboy-meeting-transcript/SKILL.md
+++ b/skills/04-meeting-notes/devboy-meeting-transcript/SKILL.md
@@ -43,37 +43,34 @@ devboy tools call get_meeting_notes '{
 
 Confirm the title and date with the user before proceeding — pulling the wrong transcript is an irreversible PII leak into the chat.
 
-### 2. Fetch the transcript with a budget
+### 2. Fetch the transcript
 
 ```bash
-devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' --budget 4000
+devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}'
 ```
 
-`--budget` is the format pipeline's token cap. A full-length call does not fit in a single chunk — the response comes back with:
+`devboy tools call` takes a tool name + a JSON argument object — it does not accept `--budget` (or any other CLI flag) for the tool itself. The format-pipeline budget is applied inside the tool runtime. The transcript output is rendered as plain text, not JSON; a long transcript may be shortened by the pipeline and picked up again via a subsequent call.
 
-- `truncated: true` and a pagination hint when there is more to fetch.
-- `chunked: true` + `total_chunks` + `chunk_number` when the output was split.
+### 3. If the rendered transcript is incomplete, fetch the next chunk
 
-### 3. Navigate chunks, do not re-fetch the whole thing
-
-If chunk 1 is not the interesting bit, ask for the next chunk rather than re-running the call with a higher budget:
+If the response ends mid-thought, pull the next segment:
 
 ```bash
-devboy tools call get_meeting_transcript '{"meeting_id": "<id>", "chunk": 2}' --budget 4000
+devboy tools call get_meeting_transcript '{"meeting_id": "<id>", "chunk": 2}'
 ```
 
-`chunk` is the enricher's universal navigation parameter — it is added to every tool, not specific to transcripts. Chunk 1 is the default.
+`chunk` is a per-call argument understood by the transcript tool (the default is 1). The response is still text — do not expect a JSON body with fields like `total_chunks` or `chunk_number`. The tell for "more to fetch" is that the text ends mid-sentence, not a structured field.
 
 ### 4. Prefer a targeted fetch over a full dump
 
 When the question is specific ("what did Alice say about X?"), do not scroll the whole transcript in the chat. Two patterns:
 
 1. **Search first, transcript second.** Run `devboy-meeting-search` with the topic word, confirm this is the right meeting, then open the relevant chunk.
-2. **Grep the chunk.** Once you have the transcript text, filter locally to sentences from the speaker of interest. The transcript output is speaker-attributed (`speaker_name`, `speaker_id`, `text`, `start_time`), so a simple line filter works:
+2. **Grep the chunk.** The transcript is rendered as text lines shaped like `[mm:ss] <speaker>: <sentence>`, so filter with `grep` / `ripgrep`:
 
    ```bash
-   devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' --budget 6000 \
-     | jq '.[] | select(.speaker_name == "Alice")'
+   devboy tools call get_meeting_transcript '{"meeting_id": "<id>"}' \
+     | grep -F '] Alice: '
    ```
 
 ### 5. Quote, do not paste

--- a/skills/05-messenger/devboy-chat-search/SKILL.md
+++ b/skills/05-messenger/devboy-chat-search/SKILL.md
@@ -36,7 +36,7 @@ If the user said something like "in #eng" or "in the deploys channel", resolve t
 devboy tools call get_messenger_chats '{"search": "eng", "limit": 10}'
 ```
 
-Useful filters: `chat_type` (`direct` / `group` / `channel`), `include_inactive` (archived chats are hidden by default), `cursor` for pagination.
+Useful filters: `chat_type` (`direct` / `group` / `channel`), `include_inactive` (archived chats are hidden by default). Note: `cursor`-based pagination is accepted by the tool's argument schema today but the response is formatted as text and does not surface a `next_cursor` back to the caller — narrow the hit list with `search` / `limit` instead, or refine the query.
 
 ### 2. Run the search
 
@@ -63,15 +63,16 @@ devboy tools call search_chat_messages '{
 
 `since` / `until` are provider-native timestamps (Slack passes them straight through — floating-point epoch seconds, as strings). If the user phrases a window in natural language ("yesterday", "last week"), convert to epoch seconds before calling.
 
-### 3. Page through large result sets
+### 3. Narrow a too-large result set
 
-`search_chat_messages` returns at most `limit` hits per call (capped at 1000). If the response carries a `cursor`, walk the pages:
+`search_chat_messages` returns at most `limit` hits per call (capped at 1000). The response is rendered as formatted text and **does not surface a `next_cursor` back to the caller** today, so cursor-based pagination is not actionable from the tool output. Instead of trying to page, narrow the query:
 
-```bash
-devboy tools call search_chat_messages '{"query": "rollback", "limit": 100, "cursor": "<cursor-from-previous-call>"}'
-```
+- Tighten `since` / `until` to a smaller window.
+- Add distinguishing words to `query`.
+- Scope with `chat_id` to the channel the user actually meant.
+- Raise `limit` as a last resort, but the hit list gets harder to skim fast.
 
-Stop when a page returns no cursor, or when you have enough recent material to answer.
+If cursor pagination becomes genuinely necessary for a user's workflow, that requires a tool-side change to expose the pagination metadata, not a skill-side workaround.
 
 ### 4. Rank and present
 
@@ -80,12 +81,12 @@ Before handing the hits back to the user:
 - **Sort by recency.** Messengers default to relevance; users almost always want "the most recent mention" first. Override the order client-side.
 - **One line per hit.** Channel (or DM partner) + author + date + a one-line excerpt (≤ 120 chars, collapse newlines).
 - **Deduplicate threads.** If multiple hits belong to the same thread, show the root hit once with a count of matching replies.
-- **Link when the provider supports it.** Slack responses include permalinks — surface them so the user can jump straight to the message.
+- **Cite coordinates, not permalinks.** The unified `MessengerMessage` type does not include a `permalink` field, so do not promise jump-to-message URLs. Surface the `chat_id` + message `id` / `timestamp` instead — that's enough for the user to open the message directly in Slack (`slack://channel?team=…&id=<chat_id>&message=<ts>`) or paste into a helper script.
 
 Example render:
 
 ```
-#eng        alice   2026-04-15 14:02   "…rolling back v2.4.1, see incident-204…"  (permalink)
+#eng        alice   2026-04-15 14:02   "…rolling back v2.4.1, see incident-204…"  (C0123/ts=1712584920.010)
 DM bob      bob     2026-04-14 09:31   "feature flag cutover is done on staging"
 ```
 

--- a/skills/05-messenger/devboy-chat-search/SKILL.md
+++ b/skills/05-messenger/devboy-chat-search/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: devboy-chat-search
+description: Search messenger history for messages mentioning a keyword, optionally scoped to one chat or a date window.
+category: messenger
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "find slack message about"
+  - "search messenger for"
+  - "who mentioned X in slack"
+  - "find the message where"
+  - "search chat for"
+tools:
+  - get_messenger_chats
+  - search_chat_messages
+---
+
+# devboy-chat-search
+
+Locate one or more messages across the configured messenger (Slack today, additional providers as they come online) by keyword, optional chat scope, and optional time window. The skill returns a ranked list of hits — it does **not** condense a long conversation into a narrative; for that, use `devboy-chat-summary`.
+
+## When to use
+
+- The user asks "find the slack message where Alice mentioned the rollback", "search messenger for 'feature flag cutover'", or similar.
+- Another skill (e.g. `devboy-solve-issue`) needs to cite the originating chat discussion before acting on a ticket.
+- The user remembers a phrase but not the channel or the author.
+
+## Procedure
+
+### 1. Resolve a chat scope (only if the user named one)
+
+If the user said something like "in #eng" or "in the deploys channel", resolve the humanised name to a `chat_id` first. Searching without a scope is also fine — it's just slower and noisier.
+
+```bash
+# Narrow by name — pick the best match from the returned list
+devboy tools call get_messenger_chats '{"search": "eng", "limit": 10}'
+```
+
+Useful filters: `chat_type` (`direct` / `group` / `channel`), `include_inactive` (archived chats are hidden by default), `cursor` for pagination.
+
+### 2. Run the search
+
+`search_chat_messages` takes a free-text `query` and optional `chat_id`, plus a provider-timestamp `since` / `until` window when the user cares about recency:
+
+```bash
+# Global search
+devboy tools call search_chat_messages '{"query": "rollback", "limit": 30}'
+
+# Scoped to one chat
+devboy tools call search_chat_messages '{
+  "query": "feature flag cutover",
+  "chat_id": "C0123456789",
+  "limit": 50
+}'
+
+# Last week, any chat
+devboy tools call search_chat_messages '{
+  "query": "incident",
+  "since": "1712448000.000000",
+  "until": "1713052800.000000"
+}'
+```
+
+`since` / `until` are provider-native timestamps (Slack passes them straight through — floating-point epoch seconds, as strings). If the user phrases a window in natural language ("yesterday", "last week"), convert to epoch seconds before calling.
+
+### 3. Page through large result sets
+
+`search_chat_messages` returns at most `limit` hits per call (capped at 1000). If the response carries a `cursor`, walk the pages:
+
+```bash
+devboy tools call search_chat_messages '{"query": "rollback", "limit": 100, "cursor": "<cursor-from-previous-call>"}'
+```
+
+Stop when a page returns no cursor, or when you have enough recent material to answer.
+
+### 4. Rank and present
+
+Before handing the hits back to the user:
+
+- **Sort by recency.** Messengers default to relevance; users almost always want "the most recent mention" first. Override the order client-side.
+- **One line per hit.** Channel (or DM partner) + author + date + a one-line excerpt (≤ 120 chars, collapse newlines).
+- **Deduplicate threads.** If multiple hits belong to the same thread, show the root hit once with a count of matching replies.
+- **Link when the provider supports it.** Slack responses include permalinks — surface them so the user can jump straight to the message.
+
+Example render:
+
+```
+#eng        alice   2026-04-15 14:02   "…rolling back v2.4.1, see incident-204…"  (permalink)
+DM bob      bob     2026-04-14 09:31   "feature flag cutover is done on staging"
+```
+
+## Success criteria
+
+- The hits all contain the query term (the provider did real matching, not a partial / fuzzy miss the skill silently tolerated).
+- The list is ordered newest-first and limited to what the user asked for — no dumping 500 rows when the user said "find the message".
+- Channel, author, and date are present for every hit; excerpts are truncated, not walls of text.
+
+## Guardrails
+
+- Messenger content is often confidential. Do not forward raw message bodies to external systems (trackers, PR descriptions, documentation) without the user explicitly asking for that forwarding.
+- If the configured Slack token lacks the read scopes (`channels:history`, `groups:history`, `im:history`, `mpim:history`), search results will be incomplete or empty. When hits look suspiciously thin, run `devboy test slack` and check the "Missing scopes" line.
+
+## Non-goals
+
+- This skill does not summarise a long channel or catch the user up on a day — use `devboy-chat-summary` for that.
+- It does not send or forward anything — use `devboy-notify` when the user wants to post.

--- a/skills/05-messenger/devboy-chat-summary/SKILL.md
+++ b/skills/05-messenger/devboy-chat-summary/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: devboy-chat-summary
+description: Catch the user up on a channel or DM by summarising messages over a time window, chunk by chunk, into grouped bullet points.
+category: messenger
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "summarise today's messages"
+  - "what happened in #eng this week"
+  - "catch me up on the deploy channel"
+  - "summarise slack"
+  - "summary of chat"
+tools:
+  - get_messenger_chats
+  - get_chat_messages
+---
+
+# devboy-chat-summary
+
+Produce a concise, grouped summary of what happened in a chat (channel, group, or DM) over a user-specified window. The skill pulls message history in pages, summarises each page, then merges the page-level summaries into a single grouped bullet list — it does **not** keyword-search across chats (that's `devboy-chat-search`) and it does **not** send anything (that's `devboy-notify`).
+
+## When to use
+
+- The user asks "catch me up on the deploy channel", "what did #eng discuss this morning?", or "summary of my DMs with Alice this week".
+- Another skill needs a short narrative of what a channel has been talking about before making a decision.
+- The user was offline and wants a quick briefing before opening the messenger UI.
+
+## Procedure
+
+### 1. Resolve the chat
+
+If the user named the chat by a humanised handle (`#eng`, "the deploy channel", "DMs with Alice"), look up the `chat_id`:
+
+```bash
+devboy tools call get_messenger_chats '{"search": "eng", "limit": 10}'
+# Pick the match whose name / topic clearly corresponds to what the user said.
+```
+
+If the user already handed over a `chat_id`, skip this step.
+
+### 2. Convert the window to provider timestamps
+
+`get_chat_messages` takes `since` / `until` as provider-native timestamps (for Slack: floating-point epoch seconds, as strings — e.g. `"1712448000.000000"`). Convert the user's natural-language window ("today", "this week", "since Monday") into those before calling. Default to **the last 24 hours** when the user does not name a window.
+
+### 3. Pull messages in pages — do not load the whole history
+
+Paginate via the response `cursor`. Cap each page at 200 messages to keep chunks small enough to summarise cleanly:
+
+```bash
+# First page
+devboy tools call get_chat_messages '{
+  "chat_id": "C0123456789",
+  "since": "1713052800.000000",
+  "until": "1713139200.000000",
+  "limit": 200
+}'
+
+# Follow-up pages: pass the cursor from the previous response
+devboy tools call get_chat_messages '{
+  "chat_id": "C0123456789",
+  "since": "1713052800.000000",
+  "until": "1713139200.000000",
+  "limit": 200,
+  "cursor": "<cursor-from-previous-call>"
+}'
+```
+
+If a response carries no cursor, you have the full window. If a thread is referenced by `thread_id` and the user asked about a specific thread, pull its replies separately:
+
+```bash
+devboy tools call get_chat_messages '{"chat_id": "C0123456789", "thread_id": "1712450000.001500", "limit": 200}'
+```
+
+### 4. Summarise chunk by chunk, then merge
+
+Rather than feeding the entire history into one summary prompt:
+
+1. **Per page**, draft 3–6 bullet points: decisions, open questions, action items, notable quotes (with author handle).
+2. **Merge** the page-level bullets into a single list, collapsing duplicates and merging threads that span pages.
+3. **Group the final list by topic**, not by time. Suggested top-level groups: `Decisions`, `Action items`, `Open questions`, `Context / FYI`. Omit groups that have no bullets.
+4. Keep each bullet to **one line**, prefixed with the author when it matters (`alice: shipped v2.4.2`). Link threads by their `thread_id` permalink where the provider supplies one.
+
+### 5. Render the summary
+
+Target shape (adjust headings based on what actually came up):
+
+```
+Summary of #eng — 2026-04-14 00:00 UTC → 2026-04-15 00:00 UTC (312 messages, 4 threads)
+
+Decisions
+- Rolled back v2.4.1 after staging regression (alice, bob)
+- Ship v2.4.2 with the patched migration tomorrow at 09:00 UTC
+
+Action items
+- @alice: draft incident-204 post-mortem by Thursday
+- @carol: add regression test covering the migration case
+
+Open questions
+- Is the feature flag cutover still on for Friday?
+
+Context
+- Customer X asked about the GitLab SAML change — redirected to #support
+```
+
+If the window had fewer than ~20 messages, skip the grouping and render a single flat list.
+
+## Success criteria
+
+- The summary covers the requested window — the earliest and latest messages are reflected.
+- Bullets are grouped, not a flat timestamp dump. Duplicates across threads are collapsed.
+- Author handles are present where they add signal (decisions, action items).
+- Pagination was actually used — the skill did not truncate silently at the first page.
+
+## Guardrails
+
+- Messages frequently reference confidential business decisions, customer names, or unreleased work. **Never forward the raw message content** to external systems — the issue tracker, a PR description, an email, a public channel — without the user's explicit ask. A summary surfaced in the conversation with the requesting user is fine; cross-posting it is not.
+- If the Slack token lacks `channels:history`, `groups:history`, `im:history`, or `mpim:history`, the corresponding chat types will return empty. When a summary feels suspiciously short, run `devboy test slack` and check the "Missing scopes" line before blaming the users.
+
+## Non-goals
+
+- This skill does not search across many chats for a keyword — that is `devboy-chat-search`.
+- It does not post the summary anywhere — if the user wants that, hand the summary to `devboy-notify` after confirming the target.

--- a/skills/05-messenger/devboy-chat-summary/SKILL.md
+++ b/skills/05-messenger/devboy-chat-summary/SKILL.md
@@ -42,30 +42,29 @@ If the user already handed over a `chat_id`, skip this step.
 
 `get_chat_messages` takes `since` / `until` as provider-native timestamps (for Slack: floating-point epoch seconds, as strings — e.g. `"1712448000.000000"`). Convert the user's natural-language window ("today", "this week", "since Monday") into those before calling. Default to **the last 24 hours** when the user does not name a window.
 
-### 3. Pull messages in pages — do not load the whole history
+### 3. Pull messages in narrow slices — do not load the whole history
 
-Paginate via the response `cursor`. Cap each page at 200 messages to keep chunks small enough to summarise cleanly:
+The tool returns formatted text and **does not surface a `next_cursor`** in the output today, so you cannot page by cursor from the tool result. Instead, split a large window into several narrow `since` / `until` calls and summarise each slice independently:
 
 ```bash
-# First page
+# Morning slice
 devboy tools call get_chat_messages '{
   "chat_id": "C0123456789",
   "since": "1713052800.000000",
-  "until": "1713139200.000000",
+  "until": "1713091200.000000",
   "limit": 200
 }'
 
-# Follow-up pages: pass the cursor from the previous response
+# Afternoon slice
 devboy tools call get_chat_messages '{
   "chat_id": "C0123456789",
-  "since": "1713052800.000000",
+  "since": "1713091200.000000",
   "until": "1713139200.000000",
-  "limit": 200,
-  "cursor": "<cursor-from-previous-call>"
+  "limit": 200
 }'
 ```
 
-If a response carries no cursor, you have the full window. If a thread is referenced by `thread_id` and the user asked about a specific thread, pull its replies separately:
+Cap `limit` at 200 per call to keep each response small enough to summarise cleanly. If a slice comes back close to the cap, halve the window and re-run. If a thread is referenced by `thread_id` and the user asked about a specific thread, pull its replies separately:
 
 ```bash
 devboy tools call get_chat_messages '{"chat_id": "C0123456789", "thread_id": "1712450000.001500", "limit": 200}'
@@ -78,7 +77,7 @@ Rather than feeding the entire history into one summary prompt:
 1. **Per page**, draft 3–6 bullet points: decisions, open questions, action items, notable quotes (with author handle).
 2. **Merge** the page-level bullets into a single list, collapsing duplicates and merging threads that span pages.
 3. **Group the final list by topic**, not by time. Suggested top-level groups: `Decisions`, `Action items`, `Open questions`, `Context / FYI`. Omit groups that have no bullets.
-4. Keep each bullet to **one line**, prefixed with the author when it matters (`alice: shipped v2.4.2`). Link threads by their `thread_id` permalink where the provider supplies one.
+4. Keep each bullet to **one line**, prefixed with the author when it matters (`alice: shipped v2.4.2`). Cite threads by their `chat_id` + `thread_id` pair — the unified messenger output does not supply a permalink field.
 
 ### 5. Render the summary
 

--- a/skills/05-messenger/devboy-notify/SKILL.md
+++ b/skills/05-messenger/devboy-notify/SKILL.md
@@ -27,7 +27,7 @@ Send a one-shot, structured notification — a short subject line, 2–3 body bu
 ## Preconditions
 
 1. **The user must have asked.** If the user said something like "maybe we should tell #eng" or "should we notify?", treat that as a **draft** — confirm the target and the text with the user before calling `send_message`. Never post on an ambiguous signal.
-2. **Slack write scope present.** `send_message` on Slack requires the `chat:write` scope. The full list of scopes the devboy Slack integration expects is defined by `default_slack_required_scopes` in `crates/devboy-core/src/config.rs` (`channels:read`, `channels:history`, `groups:read`, `groups:history`, `im:read`, `im:history`, `mpim:read`, `mpim:history`, `chat:write`, `users:read`). Verify the token has them before posting — see step 2 below.
+2. **Slack write scope present.** `send_message` on Slack requires the `chat:write` scope. The full list of scopes the devboy Slack integration expects is defined by the `default_slack_required_scopes()` function in `crates/devboy-core/src/config.rs` (`channels:read`, `channels:history`, `groups:read`, `groups:history`, `im:read`, `im:history`, `mpim:read`, `mpim:history`, `chat:write`, `users:read`). Verify the token has them before posting — see step 2 below.
 
 ## Procedure
 
@@ -104,7 +104,7 @@ devboy tools call send_message '{
 
 ### 6. Report back
 
-After `send_message` returns, tell the user where you posted (chat name + permalink if the response supplies one) and echo the final text. If the call failed, surface the provider error verbatim — don't swallow it.
+After `send_message` returns, tell the user where you posted (chat name + the returned message `chat_id` / `id` / `timestamp` — the unified `MessengerMessage` does not include a `permalink` field, so don't promise a jump-to link) and echo the final text. If the call failed, surface the provider error verbatim — don't swallow it.
 
 ## Success criteria
 

--- a/skills/05-messenger/devboy-notify/SKILL.md
+++ b/skills/05-messenger/devboy-notify/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: devboy-notify
+description: Post a short, structured notification — subject, bullets, optional link — to a chat or channel the user explicitly names.
+category: messenger
+version: 1
+compatibility: devboy-tools >= 0.18
+activation:
+  - "post to"
+  - "notify the team"
+  - "send a message to slack"
+  - "announce in"
+  - "ping the channel"
+tools:
+  - get_messenger_chats
+  - send_message
+---
+
+# devboy-notify
+
+Send a one-shot, structured notification — a short subject line, 2–3 body bullets, and an optional link — to a chat or channel the user has explicitly asked you to post in. The skill confirms the target and verifies the required write scope **before** calling `send_message`; it never posts speculatively.
+
+## When to use
+
+- The user says "post to #eng that the rollback is done", "notify the team about the release", or "send a quick message to #support".
+- Another skill finished a long operation (deploy, migration, review sweep) and the user explicitly asked for a chat notification at the end of it.
+
+## Preconditions
+
+1. **The user must have asked.** If the user said something like "maybe we should tell #eng" or "should we notify?", treat that as a **draft** — confirm the target and the text with the user before calling `send_message`. Never post on an ambiguous signal.
+2. **Slack write scope present.** `send_message` on Slack requires the `chat:write` scope. The full list of scopes the devboy Slack integration expects is defined by `default_slack_required_scopes` in `crates/devboy-core/src/config.rs` (`channels:read`, `channels:history`, `groups:read`, `groups:history`, `im:read`, `im:history`, `mpim:read`, `mpim:history`, `chat:write`, `users:read`). Verify the token has them before posting — see step 2 below.
+
+## Procedure
+
+### 1. Resolve the target chat
+
+If the user named the chat by a handle (`#eng`, "the release channel", "DM to alice"), look up the `chat_id`:
+
+```bash
+devboy tools call get_messenger_chats '{"search": "eng", "limit": 10}'
+```
+
+Pick the match whose name clearly corresponds to what the user asked for. If more than one chat matches and the correct one is not obvious, **stop and ask** rather than guessing. Posting to the wrong channel is hard to undo.
+
+### 2. Verify the write scope — fail fast if it's missing
+
+Before the first `send_message` of a session, confirm the Slack token carries the required scopes. Run the built-in health check:
+
+```bash
+devboy test slack
+```
+
+The command prints the granted scopes and a `Missing scopes` line if anything on the required list is absent. Relevant for notifications:
+
+- `chat:write` — required to post.
+- `channels:read` / `groups:read` / `im:read` / `mpim:read` — required for the `get_messenger_chats` lookup in step 1.
+
+If `Missing scopes` is non-empty, **do not call `send_message`.** Surface the missing-scope list back to the user with a clear remediation message, e.g.:
+
+> The Slack token is missing `chat:write`. Re-issue the bot token with the scope added (`channels:read`, `groups:read`, `im:read`, `mpim:read`, `chat:write`, …) and re-run `devboy test slack` to confirm.
+
+The exact default list lives in `default_slack_required_scopes()` — follow that source rather than hardcoding the scope list in a conversation.
+
+### 3. Compose the message — short and structured
+
+Keep notifications skimmable. Target format:
+
+```
+*Release v2.4.2 deployed*
+- Rollback of v2.4.1 complete, staging + prod green
+- Follow-up: regression test in MR !842
+- Incident post-mortem: <https://wiki/.../incident-204|incident-204>
+```
+
+Conventions:
+
+- **One-line subject** in `*bold*`.
+- **2–3 body bullets** — each a single line.
+- **Optional link** on the last bullet (Slack link syntax: `<url|label>`).
+- Slack markup: `*bold*`, `_italic_`, inline `` `code` ``, and triple-backtick fences for short snippets. Do not paste long logs — link to them instead.
+- Mentions only when the user asked for them. On Slack: `<@U0123ABCD>` for a user, `<!subteam^SXXXXXXX>` for a group, `<!here>` / `<!channel>` sparingly.
+
+### 4. Confirm the draft with the user (if there's any ambiguity)
+
+If the user's wording left the text or the target open, show the drafted subject + bullets + target chat name and wait for a "go". If the user was explicit ("post exactly this to #eng"), skip the confirmation.
+
+### 5. Send
+
+```bash
+devboy tools call send_message '{
+  "chat_id": "C0123456789",
+  "text": "*Release v2.4.2 deployed*\n- Rollback of v2.4.1 complete, staging + prod green\n- Follow-up: regression test in MR !842\n- Incident post-mortem: <https://wiki/.../incident-204|incident-204>"
+}'
+```
+
+For a threaded reply, add `thread_id` (or `reply_to_id` where the provider supports it):
+
+```bash
+devboy tools call send_message '{
+  "chat_id": "C0123456789",
+  "thread_id": "1713052800.001500",
+  "text": "Patch merged — closing the thread."
+}'
+```
+
+### 6. Report back
+
+After `send_message` returns, tell the user where you posted (chat name + permalink if the response supplies one) and echo the final text. If the call failed, surface the provider error verbatim — don't swallow it.
+
+## Success criteria
+
+- The message was posted to the chat the user named, not a near-miss.
+- The subject, bullets, and any link render cleanly in the target messenger (Slack markup, not raw Markdown).
+- If scopes were missing, the skill failed **early** with a clear remediation rather than silently dropping the notification.
+
+## Guardrails
+
+- **Never post without an explicit ask.** "We could maybe tell the team" is not an ask. Draft and confirm.
+- **Never post unreviewed generated content** (logs, AI-generated summaries, raw tool output) into a channel. Summarise first, show the user, then send.
+- **Honour channel audience.** Ask for the target when the user says "the team" without naming a chat — there is almost always more than one plausible channel.
+
+## Non-goals
+
+- **No scheduling or recurring sends.** The tool bundle does not expose scheduled messages today — if the user asks for one, say so and suggest the native messenger scheduler.
+- **No multi-channel fan-out.** This skill posts to one `chat_id` per invocation. For cross-posts, call it once per target and surface each result.
+- **No message edits / deletes.** `send_message` is the only write tool in the messenger bundle today.


### PR DESCRIPTION
## Blocker — main is missing 20 of 21 skills from epic #156

## What went wrong

The skills epic #156 shipped as a stack:

\`\`\`
main
 └─ #167 infra ◄── ONLY this one actually reached main
     ├─ #168 cat-0 self-bootstrap     (mergeCommit a4d6bb2e in feat/skills-infra-157-158)
     │   ├─ #169 cat-5 messenger      (mergeCommit 9b38566a in feat/skills-category-0-…-159)
     │   ├─ #170 cat-1 issues         (mergeCommit ec3cc262 in …-159)
     │   ├─ #171 cat-2 code-review    (mergeCommit 50abd7c5 in …-159)
     │   └─ #172 cat-4 meetings       (mergeCommit 7f643f23 in …-159)
     └─ #173 session traces           (mergeCommit b4819f30 in feat/skills-infra-157-158)
         └─ #175 cat-3 self-feedback  (mergeCommit 81ef6f24 in feat/skills-session-traces-i)
             └─ #176 docs             (mergeCommit cb90ecf9 in feat/skills-category-3-…)
\`\`\`

All eight of #168/#169/#170/#171/#172/#173/#175/#176 were merged — but into their stack bases, not into \`main\`. GitHub marks them \"MERGED\" because the merge commit exists; it just never rippled up once #167 landed.

## Observed regression

\`\`\`
$ devboy skills list
[self-bootstrap]
  devboy-setup                     v1   Walk the user through initial devboy configuration from scratch.
\`\`\`

**One skill. Not twenty-one.** On disk \`find skills -name SKILL.md\` returns a single file on \`main\`.

Category 3's \`SessionTracer\` / \`Redactor\` (ADR-015) and the \`devboy trace {begin,event,end}\` CLI shim are also missing, plus the \`docs/guide/skills/index.md\` Rspress page.

## This PR

Merges the two branches that between them hold everything the epic produced:

- \`origin/feat/skills-category-0-self-bootstrap-159\` — 17 SKILL.md files (cats 0/1/2/4/5 and the Copilot review fixes merged on top).
- \`origin/feat/skills-docs-epic-close\` — 4 cat-3 SKILL.md files, \`crates/devboy-skills/src/trace.rs\` + \`trace/redact.rs\`, the \`devboy trace\` CLI subcommands in \`crates/devboy-cli/src/skills_cmd.rs\` and \`main.rs\`, and the \`docs/guide/skills/index.md\` guide page + nav entry.

Net content: **+21 SKILL.md files**, **+1** \`trace\` module, **+2** docs files on top of main. Zero conflicts — the two branches are non-overlapping except for the baseline \`devboy-setup\` which both carry identically.

## Verification

- \`find skills -name SKILL.md | wc -l\` → **21**
- \`target/release/devboy skills list\` — lists all six categories with the expected skill counts (3 / 5 / 3 / 4 / 3 / 3).
- \`cargo test --workspace --lib\` — **1202/1202 passing**
- \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- \`cargo fmt --all -- --check\` — clean

## After merge

Re-delete the orphaned stack branches (\`feat/skills-category-0-…\`, \`feat/skills-session-traces-i\`, \`feat/skills-category-3-…\`, \`feat/skills-docs-epic-close\`) — they have served their purpose and staying around invites more stack-merge confusion.