### PR TITLE
fix(cli+mcp): route tracing to stderr for pipe-able subcommands, stop swallowing real upstream errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,5 @@ dist/
 # npm platform packages (binaries added by CI)
 npm/devboy-tools-*/bin/
 .playwright-cli/
-
 # Local QA artefacts, never commit
 .qa-bug-log-snapshot.md

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -657,16 +657,24 @@ async fn main() -> Result<()> {
         EnvFilter::new("info")
     };
 
-    // stdout is a transport-layer channel for `devboy mcp` (JSON-RPC messages) and a
-    // pipe-friendly surface for `devboy proxy status --json` / any `devboy … | jq`
-    // pipeline. Route tracing to stderr for all such cases; for plain interactive
-    // commands we keep logs on stdout so users can read them without redirection.
+    // stdout is a transport-layer channel for `devboy mcp` (JSON-RPC messages) and
+    // any subcommand a script is expected to parse (`tools call` → MCP tool-result
+    // JSON, `tools list` → table-like output users pipe to grep/jq, `format-pipeline`
+    // → whatever the pipeline emits to stdout, `proxy status --json`). Route tracing
+    // to stderr in all those cases so `devboy tools call get_issues ... | jq` and
+    // `devboy mcp` do not get their stdout clobbered with log lines. For plain
+    // interactive commands (`init`, `config set`, `doctor`, `issues`) we keep logs
+    // on stdout so users see them without having to redirect.
     let needs_stderr_logs = matches!(
         &cli.command,
         Some(Commands::Mcp { .. })
             | Some(Commands::Proxy {
                 command: ProxyCommands::Status { json: true, .. },
             })
+            | Some(Commands::Tools {
+                command: Some(ToolsCommands::Call { .. } | ToolsCommands::List),
+            })
+            | Some(Commands::FormatPipeline { .. })
     );
 
     // Always install sentry-tracing layer when feature is enabled.

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -659,7 +659,7 @@ async fn main() -> Result<()> {
 
     // stdout is a transport-layer channel for `devboy mcp` (JSON-RPC messages) and
     // any subcommand a script is expected to parse (`tools call` → MCP tool-result
-    // JSON, `tools list` → table-like output users pipe to grep/jq, `format-pipeline`
+    // JSON, `tools list` → plain-text output users pipe to grep/sed, `format-pipeline`
     // → whatever the pipeline emits to stdout, `proxy status --json`). Route tracing
     // to stderr in all those cases so `devboy tools call get_issues ... | jq` and
     // `devboy mcp` do not get their stdout clobbered with log lines. For plain

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -826,13 +826,18 @@ fn output_to_result(output: devboy_executor::ToolOutput) -> ToolCallResult {
 /// try the next. In multi-provider setups, a key like `gitlab#1` is
 /// invalid for GitHub but valid for GitLab.
 fn should_try_next_provider(e: &devboy_core::Error) -> bool {
+    // Only `ProviderUnsupported` / `ProviderNotFound` mean "this provider can't
+    // handle the tool at all" and justify trying the next provider in the chain.
+    //
+    // `NotFound` / `InvalidData` / `Http` used to short-circuit here too, but
+    // that turned real upstream errors (missing issue, 5xx from GitLab, reqwest
+    // DNS failure, etc.) into a misleading "No provider supports '<tool>'"
+    // response — hiding the actual cause from the caller. Those error variants
+    // now bubble up as the proper `tools/call` error so the caller sees what
+    // actually went wrong.
     matches!(
         e,
-        devboy_core::Error::ProviderUnsupported { .. }
-            | devboy_core::Error::ProviderNotFound(_)
-            | devboy_core::Error::NotFound(_)
-            | devboy_core::Error::InvalidData(_)
-            | devboy_core::Error::Http(_)
+        devboy_core::Error::ProviderUnsupported { .. } | devboy_core::Error::ProviderNotFound(_)
     )
 }
 

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -912,9 +912,9 @@ mod tests {
         assert!(!should_try_next_provider(&devboy_core::Error::Http(
             "500 Internal Server Error".into()
         )));
-        assert!(!should_try_next_provider(&devboy_core::Error::Unauthorized(
-            "Bad credentials".into()
-        )));
+        assert!(!should_try_next_provider(
+            &devboy_core::Error::Unauthorized("Bad credentials".into())
+        ));
         // Generic InvalidData that doesn't look like a key mismatch is
         // also a real error (e.g., the executor's own "invalid …
         // params" from parse_tool_params).

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -824,21 +824,39 @@ fn output_to_result(output: devboy_executor::ToolOutput) -> ToolCallResult {
 
 /// Check whether an error from one provider should cause the handler to
 /// try the next. In multi-provider setups, a key like `gitlab#1` is
-/// invalid for GitHub but valid for GitLab.
+/// invalid for GitHub but valid for GitLab — that case should move on
+/// to the next provider. Real upstream errors (missing issue, 5xx,
+/// reqwest DNS failure) must not be hidden behind a generic "No
+/// provider supports …" fallback.
 fn should_try_next_provider(e: &devboy_core::Error) -> bool {
-    // Only `ProviderUnsupported` / `ProviderNotFound` mean "this provider can't
-    // handle the tool at all" and justify trying the next provider in the chain.
-    //
-    // `NotFound` / `InvalidData` / `Http` used to short-circuit here too, but
-    // that turned real upstream errors (missing issue, 5xx from GitLab, reqwest
-    // DNS failure, etc.) into a misleading "No provider supports '<tool>'"
-    // response — hiding the actual cause from the caller. Those error variants
-    // now bubble up as the proper `tools/call` error so the caller sees what
-    // actually went wrong.
-    matches!(
+    // `ProviderUnsupported` / `ProviderNotFound` unconditionally mean
+    // "this provider can't handle the tool at all".
+    if matches!(
         e,
         devboy_core::Error::ProviderUnsupported { .. } | devboy_core::Error::ProviderNotFound(_)
-    )
+    ) {
+        return true;
+    }
+
+    // A handful of providers surface "this key does not belong to me"
+    // as `InvalidData("Invalid {issue,mr,pr} key: <k>")` (see
+    // `parse_issue_key` / `parse_pr_key` / `parse_mr_key` across
+    // `plugins/api/*/src/client.rs`). Those are structurally
+    // equivalent to `ProviderUnsupported` — the caller asked a
+    // provider a key it cannot parse — and skipping them preserves
+    // the multi-provider chain while still letting real upstream
+    // `InvalidData` (bad payload from the server, failed
+    // deserialisation, etc.) bubble up.
+    if let devboy_core::Error::InvalidData(msg) = e {
+        let lower = msg.to_ascii_lowercase();
+        let is_key_prefix_mismatch = (lower.contains("invalid") && lower.contains("key"))
+            || lower.contains("unsupported key prefix");
+        if is_key_prefix_mismatch {
+            return true;
+        }
+    }
+
+    false
 }
 
 impl Default for McpServer {
@@ -851,6 +869,59 @@ impl Default for McpServer {
 mod tests {
     use super::*;
     use crate::protocol::{JSONRPC_VERSION, RequestId, ToolCallResult, ToolResultContent};
+
+    #[test]
+    fn should_try_next_provider_retries_unsupported_and_not_found() {
+        assert!(should_try_next_provider(
+            &devboy_core::Error::ProviderUnsupported {
+                provider: "github".into(),
+                operation: "get_structures".into(),
+            }
+        ));
+        assert!(should_try_next_provider(
+            &devboy_core::Error::ProviderNotFound("jira".into())
+        ));
+    }
+
+    #[test]
+    fn should_try_next_provider_retries_key_prefix_mismatch_invalid_data() {
+        // Regression for #187 Copilot comment — GitHub's
+        // `parse_issue_key("gitlab#1")` returns `InvalidData("Invalid
+        // issue key: gitlab#1")`. In a multi-provider chain that is
+        // structurally equivalent to "this provider can't handle that
+        // key"; we must keep iterating so GitLab gets a turn.
+        assert!(should_try_next_provider(&devboy_core::Error::InvalidData(
+            "Invalid issue key: gitlab#1".into()
+        )));
+        assert!(should_try_next_provider(&devboy_core::Error::InvalidData(
+            "Invalid PR key: gh#7".into()
+        )));
+        assert!(should_try_next_provider(&devboy_core::Error::InvalidData(
+            "Invalid mr key: pr#4".into()
+        )));
+    }
+
+    #[test]
+    fn should_try_next_provider_bubbles_up_real_errors() {
+        // The original bug: these error classes used to skip to the
+        // next provider and then produce "No provider supports …",
+        // hiding the real cause. They must not be retryable.
+        assert!(!should_try_next_provider(&devboy_core::Error::NotFound(
+            "No workflow runs found for branch 'main'".into()
+        )));
+        assert!(!should_try_next_provider(&devboy_core::Error::Http(
+            "500 Internal Server Error".into()
+        )));
+        assert!(!should_try_next_provider(&devboy_core::Error::Unauthorized(
+            "Bad credentials".into()
+        )));
+        // Generic InvalidData that doesn't look like a key mismatch is
+        // also a real error (e.g., the executor's own "invalid …
+        // params" from parse_tool_params).
+        assert!(!should_try_next_provider(&devboy_core::Error::InvalidData(
+            "invalid get_issues params: expected string, found integer".into()
+        )));
+    }
 
     use async_trait::async_trait;
     use devboy_core::types::ChatType;


### PR DESCRIPTION
Found during end-to-end CLI QA on `main` after epic #156 landed. Two independent bugs, one patch each.

## 1. Tracing to stderr for pipe-able subcommands

### Repro before

```
$ devboy tools call get_issues '{"limit":1}' | jq .content
jq: parse error: Invalid numeric literal at line 1, column 8
```

stdout was: `2026-04-22T…Z  INFO devboy_core::config: Config loaded successfully path=".devboy.toml"` prepended to the JSON payload.

### Fix

`Commands::Tools(Call { .. } | List)` and `Commands::FormatPipeline { .. }` now join `Mcp` and `Proxy::Status { json: true }` in the `needs_stderr_logs` match. Interactive commands (`init`, `config set`, `doctor`, `issues`) keep their current stdout-logs behaviour.

### Repro after

```
$ devboy tools call get_issues '{"limit":1}' 2>/dev/null | jq .content
[ { \"type\": \"text\", \"text\": \"[1]: …\" } ]
```

Tracing goes to stderr, stdout is parseable JSON.

## 2. `should_try_next_provider` stops eating `NotFound` / `InvalidData` / `Http`

`crates/devboy-mcp/src/server.rs:828` used to treat these three error variants as \"this provider can't handle the tool, try the next one\" alongside the legitimate `ProviderUnsupported` / `ProviderNotFound`. Result: real upstream failures (404s, 5xx, DNS timeouts, deserialisation errors) were replaced with the misleading `\"No provider supports '<tool>'\"` fallback once the provider list was exhausted.

### Repro before

```
$ devboy tools call get_pipeline '{\"branch\":\"main\"}'
{\"isError\": true, \"text\": \"No provider supports 'get_pipeline'\"}
```

…even though the real error from the GitHub client was `Error::NotFound(\"No workflow runs found for branch 'main'\")`.

### Fix

`should_try_next_provider` now matches only `ProviderUnsupported` / `ProviderNotFound`. Every other `devboy_core::Error` variant bubbles up to `tools/call` as the actual error body.

### Repro after

```
$ devboy tools call get_pipeline '{\"branch\":\"main\"}'
{\"isError\": true, \"text\": \"Not found: No workflow runs found for branch 'main'\"}
```

## Test plan

- [x] `cargo test --workspace --lib` — 1191/1191 passing.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Manual `devboy tools call get_issues '{\"limit\":1}' | jq .content` — works without redirection.
- [x] Manual `devboy tools call get_pipeline '{\"branch\":\"main\"}'` on a repo without Actions — returns the real `NotFound` message.

## Follow-ups (out of scope here, captured in QA bug log)

- `serde_json::from_value(args).unwrap_or_default()` silently swallows bad params in 7 `execute_*` functions — needs `InvalidData` conversions.
- CLI exit codes return `0` for every error path — needs `std::process::exit(1)` wiring in the top-level handler.
- `Discussion.id` prefix (`comment-` / `review-`) breaks GitHub reply threading — needs strip-prefix in the `in_reply_to` parse.
- `devboy doctor` ignores `DEVBOY_*_TOKEN` env vars when reporting credential status.