### PR TITLE
fix(cli): exit non-zero when tools call returns isError=true (#188)

### DIFF
--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -4112,9 +4112,19 @@ async fn handle_tools_call(name: &str, args: &str) -> Result<()> {
         std::process::exit(1);
     }
 
+    // MCP tools/call represents "the tool ran but returned an
+    // application-level error" via `result.isError: true`. That's not
+    // a JSON-RPC error, so the CLI used to print the body and exit 0
+    // — making shell scripting impossible. Mirror the MCP convention:
+    // print the body, but exit 1 so `$?` tells callers the tool
+    // rejected the call.
     if let Some(result) = resp.result {
+        let is_error = result.get("isError").and_then(|v| v.as_bool()) == Some(true);
         let json = serde_json::to_string_pretty(&result)?;
         println!("{}", json);
+        if is_error {
+            std::process::exit(1);
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Fixes bug #4 — more precisely the one concrete exit-code leak that remained after the tokio/anyhow integration was already doing the right thing for every `Err` handler return.

## Before

```
$ devboy tools call bogus_tool '{}'
{
  "content": [{"type":"text","text":"No providers configured"}],
  "isError": true
}
$ echo $?
0                # ← 0, even though the tool rejected the call
```

`devboy tools call get_structures '{}'` on a GitHub-only setup had the same problem — `isError: true` + exit 0.

## After

```
$ devboy tools call bogus_tool '{}'
{
  "content": [{"type":"text","text":"No providers configured"}],
  "isError": true
}
$ echo $?
1
```

The body is printed unchanged — scripts that parse stdout for the error text still work. Only the exit code changes.

## Why not always-1 for every response?

MCP semantics:

- JSON-RPC `error` object → protocol-level failure (bad method, parse error). Already exits 1 in the handler.
- `result.isError: true` → the tool ran but returned an application-level error. Adding exit 1 for this case.
- `result` without `isError` → success. Stays exit 0.

## Manually verified

- `tools call bogus_tool '{}'`                     → 1 ✓
- `tools call get_issues '{}'` without providers   → 1 ✓
- `tools call get_issue '{"key":"gh#7"}'` success  → 0 ✓
- `tools call get_issues 'not-json'` (JSON parse)  → 1 ✓ (anyhow path, unchanged)

## Test plan

- [x] `cargo test --workspace --lib` — 1191/1191 (behaviour change is in `handle_tools_call`, which is not unit-tested at the module level; would need a MCP-server integration harness in `crates/devboy-cli/tests/` — deferred).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

Note: the other "exit 0 on error" cases from the original QA sweep report (`skills show nonexistent`, `test gitlab` with bad token, `context use nonexistent`, `skills install` no args, `tools call` bad JSON) were tested again on the current `main` and already exit 1 through the `tokio::main` + `anyhow::Result` integration. The QA bug log overstated bug #4; this PR fixes the actual one remaining leak.