### PR TITLE
fix(init): seed .devboy.toml with comment template when no providers detected (#188)

### DIFF
--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -1041,8 +1041,18 @@ async fn handle_init_command(
 
     // Build configuration
     let config = build_config(&options);
-    let toml_content =
+    let mut toml_content =
         toml::to_string_pretty(&config).context("Failed to serialize configuration")?;
+
+    // When `build_config` produced an empty TOML (no providers detected
+    // and the user did not opt into any proxy / remote-config settings),
+    // serialize_with-skip leaves us with a zero-byte file. Seed it with a
+    // short header comment so `cat .devboy.toml` is not blank and so that
+    // `doctor` / `config list` have something to key off of. The content
+    // is valid TOML (comments only) and does not change behaviour.
+    if toml_content.trim().is_empty() {
+        toml_content = minimal_devboy_toml_template();
+    }
 
     // Dry-run mode: just print what would be done
     if dry_run {
@@ -1569,6 +1579,27 @@ fn should_skip_git_detect(
         return true;
     }
     remote_config_url.is_some() && !detect_git
+}
+
+/// Placeholder `.devboy.toml` content used when `init --yes` is run in
+/// a directory without a detectable git remote and without any
+/// agent / proxy / remote-config flag. The file is valid TOML (only
+/// comments), so subsequent `config set` writes drop real keys into it
+/// without any cleanup needed.
+fn minimal_devboy_toml_template() -> String {
+    "# DevBoy tools configuration\n\
+     #\n\
+     # No providers were detected from git or passed on the command line.\n\
+     # Add one with:\n\
+     #   devboy config set github.owner <owner>\n\
+     #   devboy config set github.repo <repo>\n\
+     #   devboy config set-secret github.token <token>\n\
+     #\n\
+     # Or, register an agent MCP server via:\n\
+     #   devboy init --claude | --kimi | --codex-cli | --copilot | --gemini | --opencode | --forge\n\
+     #\n\
+     # See `devboy --help` for the full command surface.\n"
+        .to_string()
 }
 
 /// Build Config from collected options.


### PR DESCRIPTION
Fixes bug #3 from the QA tracking issue #188.

## Before

```
$ mkdir /tmp/x && cd /tmp/x && devboy init --yes
No git remote detected. Creating minimal config.
Created: .devboy.toml

Initialization complete!
Next steps:
  1. Review the configuration: cat .devboy.toml
  2. Test connection: devboy test <provider>
  3. Start using: devboy mcp

$ wc -c .devboy.toml
0
```

Zero-byte `.devboy.toml`. The "next step" `cat .devboy.toml` shows nothing.

## Why it happened

`build_config()` correctly returns `Config::default()` when:
- git remote detection found nothing,
- no `--claude` / `--kimi` / etc. agent flag was passed,
- no `--proxy-*` / `--remote-config-*` flag was passed.

Every field in `Config` is `#[serde(skip_serializing_if = "is_empty")]`, so `toml::to_string_pretty(&Config::default())` returns `""`.

## Fix

Detect the empty-string result and substitute a short comment-only TOML template that tells the user what to do next:

```toml
# DevBoy tools configuration
#
# No providers were detected from git or passed on the command line.
# Add one with:
#   devboy config set github.owner <owner>
#   devboy config set github.repo <repo>
#   devboy config set-secret github.token <token>
#
# Or, register an agent MCP server via:
#   devboy init --claude | --kimi | --codex-cli | --copilot | --gemini | --opencode | --forge
#
# See `devboy --help` for the full command surface.
```

The template is **valid TOML** (comments only). Later `devboy config set foo bar` writes append real keys to the same file without any cleanup. Behaviour for non-empty configs is unchanged.

## Test plan

- [x] `cargo test --workspace --lib` — 1191/1191.
- [x] `cargo test -p devboy-cli --tests` — 356/356 (existing init tests cover all non-empty paths; this PR only affects the `toml_content.trim().is_empty()` branch).
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Manual smoke:
    ```
    $ mkdir /tmp/x && cd /tmp/x && devboy init --yes
    $ cat .devboy.toml
    # DevBoy tools configuration
    # ...
    ```