### PR TITLE
fix(github): strip review-/comment- prefix from Discussion.id before in_reply_to parse (#188, #103)

### DIFF
--- a/crates/plugins/api/github/src/client.rs
+++ b/crates/plugins/api/github/src/client.rs
@@ -696,7 +696,17 @@ impl MergeRequestProvider for GitHubClient {
                 } else {
                     "RIGHT".to_string()
                 }),
-                in_reply_to: input.discussion_id.and_then(|id| id.parse().ok()),
+                // Unified `Discussion.id` is prefixed (`review-<n>` for a
+                // review thread, `comment-<n>` for a general issue
+                // comment) — see `get_discussions` below. Strip either
+                // prefix before parsing so callers can feed the id they
+                // received from `get_merge_request_discussions` straight
+                // back into `create_merge_request_comment` and have the
+                // new comment actually thread into the existing review.
+                in_reply_to: input
+                    .discussion_id
+                    .as_deref()
+                    .and_then(parse_discussion_numeric_id),
             };
 
             let gh_comment: GitHubReviewComment = self.post(&url, &request).await?;
@@ -1438,6 +1448,19 @@ fn parse_pr_key(key: &str) -> Result<u64> {
         .ok_or_else(|| Error::InvalidData(format!("Invalid PR key: {}", key)))
 }
 
+/// Turn a unified `Discussion.id` (prefixed by `get_discussions` as
+/// `review-<n>` for a review thread or `comment-<n>` for a general
+/// issue comment) back into the numeric comment id GitHub expects in
+/// `in_reply_to`. Raw numeric strings are accepted for forward
+/// compatibility / test fixtures.
+fn parse_discussion_numeric_id(id: &str) -> Option<u64> {
+    let trimmed = id
+        .strip_prefix("review-")
+        .or_else(|| id.strip_prefix("comment-"))
+        .unwrap_or(id);
+    trimmed.parse::<u64>().ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1458,6 +1481,29 @@ mod tests {
         assert_eq!(parse_pr_key("pr#1").unwrap(), 1);
         assert!(parse_pr_key("gh#123").is_err());
         assert!(parse_pr_key("456").is_err());
+    }
+
+    #[test]
+    fn test_parse_discussion_numeric_id_strips_prefixes() {
+        // Regression for #188 bug #6/#18: Discussion.id returned by
+        // get_discussions is prefixed. Callers feed it straight back
+        // into create_merge_request_comment expecting it to thread.
+        assert_eq!(
+            parse_discussion_numeric_id("review-3694869522"),
+            Some(3694869522)
+        );
+        assert_eq!(
+            parse_discussion_numeric_id("comment-4147511088"),
+            Some(4147511088)
+        );
+        // Raw numeric id passes through (forward compat).
+        assert_eq!(parse_discussion_numeric_id("12345"), Some(12345));
+        // Unknown prefix / non-numeric tail yields None — in_reply_to
+        // stays unset and we fall back to a standalone comment rather
+        // than panicking.
+        assert_eq!(parse_discussion_numeric_id("weird-42"), None);
+        assert_eq!(parse_discussion_numeric_id("review-notnumeric"), None);
+        assert_eq!(parse_discussion_numeric_id(""), None);
     }
 
     #[test]


### PR DESCRIPTION
Fixes bug #6/#18 from the QA sweep #188 and unblocks open issue #103.

## Symptom (live repro from the QA sweep)

```
$ devboy tools call get_merge_request_discussions '{"key":"pr#4"}'
{... "id":"comment-3694869522" ...}

$ devboy tools call create_merge_request_comment \
    '{"key":"pr#4","body":"reply test","discussionId":"comment-3694869522",
      "filePath":"test-mcp.md","line":1}'
→ "Comment added to pr#4 (id: 4300438828)"

$ devboy tools call get_merge_request_discussions '{"key":"pr#4"}'
# new discussion "comment-4300438828" — standalone, NOT threaded into "comment-3694869522"
```

## Root cause

`get_discussions` on GitHub (`plugins/api/github/src/client.rs`) namespaces unified `Discussion.id` with `review-` / `comment-` prefixes so callers can tell a review thread from a general PR comment. `create_merge_request_comment` then did:

```rust
in_reply_to: input.discussion_id.and_then(|id| id.parse().ok()),
```

`"review-3694869522".parse::<u64>()` → `None` → no `in_reply_to` sent → GitHub created a standalone review comment.

## Fix

New `parse_discussion_numeric_id` helper:

```rust
fn parse_discussion_numeric_id(id: &str) -> Option<u64> {
    let trimmed = id
        .strip_prefix("review-")
        .or_else(|| id.strip_prefix("comment-"))
        .unwrap_or(id);
    trimmed.parse::<u64>().ok()
}
```

Strips either prefix before parsing. Raw numeric ids pass through unchanged for forward compatibility and for test fixtures that construct ids by hand. Unknown-prefix / non-numeric inputs yield `None` — `in_reply_to` stays unset and the comment falls back to standalone (rather than panicking).

Call site:

```rust
in_reply_to: input.discussion_id.as_deref().and_then(parse_discussion_numeric_id),
```

## Test plan

- [x] New unit test `test_parse_discussion_numeric_id_strips_prefixes` covers all four branches:
    - `"review-<n>"` → `Some(n)`.
    - `"comment-<n>"` → `Some(n)`.
    - `"<n>"` (raw) → `Some(n)`.
    - `"weird-42"` / `"review-notnumeric"` / `""` → `None`.
- [x] `cargo test --workspace --lib` — 1192/1192 (was 1191; the new test is the delta).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

## What's still out of scope (tracked in #188)

- For `comment-<n>` (general PR comment — not a review thread), GitHub doesn't actually support threading: `POST /issues/:n/comments` ignores `in_reply_to`. This PR only fixes the **review-thread** path (`Some(position)` branch in `add_comment`). For general issue-comments, threading remains a no-op on GitHub's side — that is a platform limitation, not a bug in our code. A follow-up issue should warn the caller when `discussion_id` is passed for a non-position comment on GitHub.

Closes (in part) #188. Unblocks #103.