### PR TITLE
fix(cli): validate issues --state and mrs --state against a fixed value list (#188)

### DIFF
--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -229,7 +229,7 @@ enum Commands {
     /// Get information about issues
     Issues {
         /// Filter by state
-        #[arg(short, long, default_value = "open")]
+        #[arg(short, long, default_value = "open", value_parser = ["open", "closed", "all"])]
         state: String,
 
         /// Maximum number of issues to display
@@ -240,7 +240,7 @@ enum Commands {
     /// Get information about merge requests / pull requests
     Mrs {
         /// Filter by state
-        #[arg(short, long, default_value = "open")]
+        #[arg(short, long, default_value = "open", value_parser = ["open", "merged", "closed", "all"])]
         state: String,
 
         /// Maximum number of MRs to display


### PR DESCRIPTION
Fixes bug #12 from the QA sweep tracking issue #188.

## Before

```
$ devboy mrs --state weirdo
Pull Requests (2): ...              # silent success with garbage state
```

## After

```
$ devboy mrs --state weirdo
error: invalid value 'weirdo' for '--state <STATE>'
  [possible values: open, merged, closed, all]

For more information, try '--help'.
$ echo $?
2
```

## Change

Bound both flags to clap's `value_parser = [...]`:

- `devboy issues --state ∈ {open, closed, all}` (matches what IssueFilter already accepts).
- `devboy mrs --state ∈ {open, merged, closed, all}` (matches what MrFilter already accepts; `merged` is the GitLab/GitHub-specific state).

## Test plan

- [x] `cargo test --workspace --lib` — 1191/1191.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Manual: `mrs --state weirdo` → exit 2; `mrs --state merged` → exit 0 (accepted, runs normally).