### PR TITLE
feat(jira): components + Sprint + Structure generators/automation/delete (#197 #198 #179 #180)

### DIFF
--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -44,18 +44,19 @@ pub use provider::{
 
 // Re-export all types
 pub use types::{
-    AddStructureRowsInput, CodePosition, Comment, CreateCommentInput, CreateIssueInput,
-    CreateMergeRequestInput, CreateStructureInput, Discussion, FailedJob, FileDiff,
-    ForestModifyResult, GetChatsParams, GetForestOptions, GetMessagesParams, GetPipelineInput,
-    GetStructureValuesInput, GetUsersOptions, Issue, IssueFilter, IssueLink, IssueRelations,
-    IssueStatus, JobLogMode, JobLogOptions, JobLogOutput, MeetingFilter, MeetingNote,
-    MeetingSpeaker, MeetingTranscript, MergeRequest, MessageAttachment, MessageAuthor,
-    MessengerChat, MessengerMessage, MoveStructureRowsInput, MrFilter, Pagination, PipelineInfo,
-    PipelineJob, PipelineStage, PipelineStatus, PipelineSummary, ProviderResult, Release,
-    ReleaseAsset, SaveStructureViewInput, SearchMessagesParams, SendMessageParams, SortInfo,
-    SortOrder, Structure, StructureColumnValue, StructureForest, StructureNode, StructureRowItem,
-    StructureRowValues, StructureValues, StructureView, StructureViewColumn, TranscriptSentence,
-    UpdateIssueInput, UpdateMergeRequestInput, User,
+    AddStructureGeneratorInput, AddStructureRowsInput, AssignToSprintInput, CodePosition, Comment,
+    CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, CreateStructureInput,
+    Discussion, FailedJob, FileDiff, ForestModifyResult, GetChatsParams, GetForestOptions,
+    GetMessagesParams, GetPipelineInput, GetStructureValuesInput, GetUsersOptions, Issue,
+    IssueFilter, IssueLink, IssueRelations, IssueStatus, JobLogMode, JobLogOptions, JobLogOutput,
+    MeetingFilter, MeetingNote, MeetingSpeaker, MeetingTranscript, MergeRequest, MessageAttachment,
+    MessageAuthor, MessengerChat, MessengerMessage, MoveStructureRowsInput, MrFilter, Pagination,
+    PipelineInfo, PipelineJob, PipelineStage, PipelineStatus, PipelineSummary, ProviderResult,
+    Release, ReleaseAsset, SaveStructureViewInput, SearchMessagesParams, SendMessageParams,
+    SortInfo, SortOrder, Sprint, SprintState, Structure, StructureColumnValue, StructureForest,
+    StructureGenerator, StructureNode, StructureRowItem, StructureRowValues, StructureValues,
+    StructureView, StructureViewColumn, SyncStructureGeneratorInput, TranscriptSentence,
+    UpdateIssueInput, UpdateMergeRequestInput, UpdateStructureAutomationInput, User,
 };
 
 // Re-export enricher traits and utilities

--- a/crates/devboy-core/src/lib.rs
+++ b/crates/devboy-core/src/lib.rs
@@ -39,7 +39,7 @@ pub use error::{Error, Result};
 // Re-export provider traits
 pub use provider::{
     IssueProvider, MeetingNotesProvider, MergeRequestProvider, MessengerProvider, PipelineProvider,
-    Provider,
+    Provider, UserProvider,
 };
 
 // Re-export all types

--- a/crates/devboy-core/src/provider.rs
+++ b/crates/devboy-core/src/provider.rs
@@ -10,14 +10,16 @@ use crate::error::{Error, Result};
 #[cfg(test)]
 use crate::types::JobLogMode;
 use crate::types::{
-    AddStructureRowsInput, Comment, CreateCommentInput, CreateIssueInput, CreateMergeRequestInput,
-    CreateStructureInput, Discussion, FileDiff, ForestModifyResult, GetChatsParams,
-    GetForestOptions, GetMessagesParams, GetPipelineInput, GetStructureValuesInput,
-    GetUsersOptions, Issue, IssueFilter, IssueRelations, IssueStatus, JobLogOptions, JobLogOutput,
-    MeetingFilter, MeetingNote, MeetingTranscript, MergeRequest, MessengerChat, MessengerMessage,
-    MoveStructureRowsInput, MrFilter, PipelineInfo, ProviderResult, Release,
-    SaveStructureViewInput, SearchMessagesParams, SendMessageParams, Structure, StructureForest,
-    StructureValues, StructureView, UpdateIssueInput, UpdateMergeRequestInput, User,
+    AddStructureGeneratorInput, AddStructureRowsInput, AssignToSprintInput, Comment,
+    CreateCommentInput, CreateIssueInput, CreateMergeRequestInput, CreateStructureInput,
+    Discussion, FileDiff, ForestModifyResult, GetChatsParams, GetForestOptions, GetMessagesParams,
+    GetPipelineInput, GetStructureValuesInput, GetUsersOptions, Issue, IssueFilter, IssueRelations,
+    IssueStatus, JobLogOptions, JobLogOutput, MeetingFilter, MeetingNote, MeetingTranscript,
+    MergeRequest, MessengerChat, MessengerMessage, MoveStructureRowsInput, MrFilter, PipelineInfo,
+    ProviderResult, Release, SaveStructureViewInput, SearchMessagesParams, SendMessageParams,
+    Sprint, SprintState, Structure, StructureForest, StructureGenerator, StructureValues,
+    StructureView, SyncStructureGeneratorInput, UpdateIssueInput, UpdateMergeRequestInput,
+    UpdateStructureAutomationInput, User,
 };
 
 /// Provider for working with issues.
@@ -254,6 +256,89 @@ pub trait IssueProvider: Send + Sync {
         Err(Error::ProviderUnsupported {
             provider: self.provider_name().to_string(),
             operation: "create_structure".to_string(),
+        })
+    }
+
+    // --- Structure generators (issue #179) -----------------------------
+
+    /// List generators configured on a structure.
+    async fn get_structure_generators(
+        &self,
+        _structure_id: u64,
+    ) -> Result<ProviderResult<StructureGenerator>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "get_structure_generators".to_string(),
+        })
+    }
+
+    /// Attach a new generator to a structure.
+    async fn add_structure_generator(
+        &self,
+        _input: AddStructureGeneratorInput,
+    ) -> Result<StructureGenerator> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "add_structure_generator".to_string(),
+        })
+    }
+
+    /// Force a generator to refresh its produced rows.
+    async fn sync_structure_generator(&self, _input: SyncStructureGeneratorInput) -> Result<()> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "sync_structure_generator".to_string(),
+        })
+    }
+
+    // --- Structure delete + automation (issue #180) --------------------
+
+    /// Delete a structure permanently.
+    async fn delete_structure(&self, _structure_id: u64) -> Result<()> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "delete_structure".to_string(),
+        })
+    }
+
+    /// Replace a structure's automation configuration.
+    async fn update_structure_automation(
+        &self,
+        _input: UpdateStructureAutomationInput,
+    ) -> Result<()> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "update_structure_automation".to_string(),
+        })
+    }
+
+    /// Run a structure's automation pass on demand.
+    async fn trigger_structure_automation(&self, _structure_id: u64) -> Result<()> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "trigger_structure_automation".to_string(),
+        })
+    }
+
+    // --- Agile / Sprint (issue #198) -----------------------------------
+
+    /// List sprints visible on a board, optionally filtered by state.
+    async fn get_board_sprints(
+        &self,
+        _board_id: u64,
+        _state: SprintState,
+    ) -> Result<ProviderResult<Sprint>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "get_board_sprints".to_string(),
+        })
+    }
+
+    /// Move one or more issues onto a sprint.
+    async fn assign_to_sprint(&self, _input: AssignToSprintInput) -> Result<()> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "assign_to_sprint".to_string(),
         })
     }
 

--- a/crates/devboy-core/src/provider.rs
+++ b/crates/devboy-core/src/provider.rs
@@ -346,6 +346,43 @@ pub trait IssueProvider: Send + Sync {
     fn provider_name(&self) -> &'static str;
 }
 
+/// Provider for working with user profiles across issue trackers and
+/// messengers (issue #177).
+///
+/// Existing providers expose users piecemeal: `IssueProvider::get_users`
+/// returns a paginated list scoped to an issue tracker, `MessengerProvider`
+/// resolves user IDs inside a chat. This trait standardises the "fetch a
+/// `User` by stable id / email" surface so cross-provider lookups (e.g.
+/// when a meeting participant mentioned by email needs to be matched to a
+/// Slack handle) have a single contract.
+///
+/// Default methods return [`Error::ProviderUnsupported`] so providers only
+/// implement what they actually support.
+#[async_trait]
+pub trait UserProvider: Send + Sync {
+    /// Provider name for logging / error reporting.
+    fn provider_name(&self) -> &'static str;
+
+    /// Resolve a user by their provider-native id (Slack `U0123`, Jira
+    /// `accountId` / `name`, ClickUp user id, etc.).
+    async fn get_user_profile(&self, _user_id: &str) -> Result<User> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "get_user_profile".to_string(),
+        })
+    }
+
+    /// Look up a user by email. Returns `None` if the provider can issue
+    /// the query but there is no match, [`Error::ProviderUnsupported`]
+    /// when the provider simply doesn't expose an email lookup.
+    async fn lookup_user_by_email(&self, _email: &str) -> Result<Option<User>> {
+        Err(Error::ProviderUnsupported {
+            provider: self.provider_name().to_string(),
+            operation: "lookup_user_by_email".to_string(),
+        })
+    }
+}
+
 /// Provider for working with merge requests / pull requests.
 ///
 /// Only `provider_name()` is required. All other methods have default implementations

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -1359,3 +1359,108 @@ pub struct CreateStructureInput {
     /// Structure description
     pub description: Option<String>,
 }
+
+// =============================================================================
+// Agile (Sprint) types — issue #198
+// =============================================================================
+
+/// A Jira Agile Sprint as returned by `/rest/agile/1.0/board/{id}/sprint`.
+///
+/// Jira serialises fields in `camelCase` — `origin_board_id` matches
+/// `originBoardId`, `start_date` matches `startDate`, etc.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Sprint {
+    pub id: u64,
+    pub name: String,
+    /// `future`, `active`, or `closed`.
+    pub state: String,
+    /// Board this sprint belongs to (when returned from a board query).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_board_id: Option<u64>,
+    /// Planned start of the sprint, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_date: Option<String>,
+    /// Planned end of the sprint, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_date: Option<String>,
+    /// Sprint goal, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal: Option<String>,
+}
+
+/// Filter applied when listing sprints for a board.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum SprintState {
+    Active,
+    Future,
+    Closed,
+    All,
+}
+
+impl SprintState {
+    pub fn as_query_value(&self) -> Option<&'static str> {
+        match self {
+            SprintState::Active => Some("active"),
+            SprintState::Future => Some("future"),
+            SprintState::Closed => Some("closed"),
+            // `all` → omit the state query param, Jira returns every sprint.
+            SprintState::All => None,
+        }
+    }
+}
+
+/// Input for moving a set of issues onto a sprint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssignToSprintInput {
+    /// Target sprint id.
+    pub sprint_id: u64,
+    /// Issue keys to move (e.g. `["PROJ-1", "PROJ-2"]`).
+    pub issue_keys: Vec<String>,
+}
+
+// =============================================================================
+// Structure plugin extensions — issues #179 / #180
+// =============================================================================
+
+/// Reference to a Structure "generator" — the rule engine that auto-populates
+/// rows from JQL / Agile boards / manual lists. Issue #179.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StructureGenerator {
+    /// Generator id within the structure.
+    pub id: String,
+    /// Generator type (e.g. `"jql"`, `"agile-board"`, `"insert"`).
+    #[serde(rename = "type")]
+    pub generator_type: String,
+    /// Arbitrary generator-specific configuration — opaque to us.
+    #[serde(default)]
+    pub spec: Value,
+}
+
+/// Input for `add_structure_generator` (issue #179).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddStructureGeneratorInput {
+    pub structure_id: u64,
+    /// Generator type, e.g. `"jql"` or `"agile-board"`.
+    #[serde(rename = "type")]
+    pub generator_type: String,
+    /// Generator configuration passed through verbatim.
+    pub spec: Value,
+}
+
+/// Input for `sync_structure_generator` (issue #179).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncStructureGeneratorInput {
+    pub structure_id: u64,
+    pub generator_id: String,
+}
+
+/// Input for `update_structure_automation` (issue #180).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateStructureAutomationInput {
+    pub structure_id: u64,
+    /// Full automation configuration — passed through verbatim so we don't
+    /// need to mirror every field Structure supports.
+    pub config: Value,
+}

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -166,9 +166,12 @@ pub struct CreateIssueInput {
     /// ClickUp: Array `[{"id": "field_id", "value": val}]` — set via separate API.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_fields: Option<Value>,
-    /// Component IDs to associate with the issue (Jira-only, issue #197).
-    /// Each entry is a component `id` obtained from project metadata
-    /// (`JiraComponent.id`). Ignored by providers that don't have a
+    /// Component **names** to associate with the issue (Jira-only, issue
+    /// #197). Each entry is a component name obtained from project
+    /// metadata (`JiraComponent.name`). Jira accepts both id- and
+    /// name-based references in `fields.components`; we use names to line
+    /// up with the schema enricher, which enumerates component *names* in
+    /// the `components` enum. Ignored by providers that don't have a
     /// first-class Components concept (GitHub/GitLab/ClickUp).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub components: Vec<String>,
@@ -224,7 +227,8 @@ pub struct UpdateIssueInput {
     pub custom_fields: Option<Value>,
     /// Replace components on the issue (Jira-only, issue #197).
     /// `None` leaves components untouched. `Some(vec![])` clears all
-    /// components. `Some(vec![...])` replaces with the given component IDs.
+    /// components. `Some(vec![...])` replaces with the given component
+    /// **names** (see [`CreateIssueInput::components`] for rationale).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub components: Option<Vec<String>>,
 }
@@ -1457,10 +1461,21 @@ pub struct SyncStructureGeneratorInput {
 }
 
 /// Input for `update_structure_automation` (issue #180).
+///
+/// Structure plugin exposes automation as a collection of rules —
+/// `PUT /rest/structure/2.0/structure/{structureId}/automation/{automationId}`
+/// replaces a specific rule, and a bare
+/// `PUT /rest/structure/2.0/structure/{structureId}/automation` replaces
+/// the entire set. We support both via `automation_id` being optional:
+/// `Some(id)` → replaces that rule, `None` → replaces all rules.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateStructureAutomationInput {
     pub structure_id: u64,
-    /// Full automation configuration — passed through verbatim so we don't
-    /// need to mirror every field Structure supports.
+    /// Automation rule id. `None` means replace the entire automation
+    /// collection on the structure (legacy "set everything" behaviour).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub automation_id: Option<String>,
+    /// Automation payload — passed through verbatim so we don't need to
+    /// mirror every field Structure supports.
     pub config: Value,
 }

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -166,6 +166,12 @@ pub struct CreateIssueInput {
     /// ClickUp: Array `[{"id": "field_id", "value": val}]` — set via separate API.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_fields: Option<Value>,
+    /// Component IDs to associate with the issue (Jira-only, issue #197).
+    /// Each entry is a component `id` obtained from project metadata
+    /// (`JiraComponent.id`). Ignored by providers that don't have a
+    /// first-class Components concept (GitHub/GitLab/ClickUp).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub components: Vec<String>,
 }
 
 impl Default for CreateIssueInput {
@@ -181,6 +187,7 @@ impl Default for CreateIssueInput {
             project_id: None,
             issue_type: None,
             custom_fields: None,
+            components: Vec::new(),
         }
     }
 }
@@ -215,6 +222,11 @@ pub struct UpdateIssueInput {
     /// Provider-specific custom fields (same format as CreateIssueInput).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_fields: Option<Value>,
+    /// Replace components on the issue (Jira-only, issue #197).
+    /// `None` leaves components untouched. `Some(vec![])` clears all
+    /// components. `Some(vec![...])` replaces with the given component IDs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub components: Option<Vec<String>>,
 }
 
 impl Default for UpdateIssueInput {
@@ -229,6 +241,7 @@ impl Default for UpdateIssueInput {
             parent_id: None,
             markdown: true,
             custom_fields: None,
+            components: None,
         }
     }
 }

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -710,6 +710,10 @@ struct CreateIssueParams {
     project_id: Option<String>,
     #[serde(rename = "issueType")]
     issue_type: Option<String>,
+    /// Jira component names (issue #197). Serde rejects non-string-array
+    /// input instead of silently dropping entries (Copilot review on PR #205).
+    #[serde(default)]
+    components: Vec<String>,
 }
 
 async fn execute_create_issue(
@@ -719,15 +723,6 @@ async fn execute_create_issue(
     let params: CreateIssueParams = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("invalid create_issue params: {e}")))?;
     let custom_fields = args.get("customFields").cloned();
-    let components: Vec<String> = args
-        .get("components")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
     let input = CreateIssueInput {
         title: params.title,
         description: params.description,
@@ -739,7 +734,7 @@ async fn execute_create_issue(
         project_id: params.project_id,
         issue_type: params.issue_type,
         custom_fields,
-        components,
+        components: params.components,
     };
     let issue = provider.create_issue(input).await?;
 
@@ -767,6 +762,11 @@ struct UpdateIssueParams {
     #[serde(rename = "parentId")]
     parent_id: Option<String>,
     markdown: Option<bool>,
+    /// Jira component names (issue #197). `None` (key absent) leaves
+    /// components untouched; `Some([])` clears all; `Some([...])` replaces.
+    /// Serde-parsed so non-array / non-string input errors fast.
+    #[serde(default)]
+    components: Option<Vec<String>>,
 }
 
 async fn execute_update_issue(
@@ -776,16 +776,6 @@ async fn execute_update_issue(
     let params: UpdateIssueParams = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("invalid update_issue params: {e}")))?;
     let custom_fields = args.get("customFields").cloned();
-    // Issue #197 — accept `components: [id, ...]` on update. If the key is
-    // absent we leave them untouched (None); an empty array clears them.
-    let components: Option<Vec<String>> =
-        args.get("components")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect()
-            });
     let input = UpdateIssueInput {
         title: params.title,
         description: params.description,
@@ -796,7 +786,7 @@ async fn execute_update_issue(
         parent_id: params.parent_id,
         markdown: params.markdown.unwrap_or(true),
         custom_fields,
-        components,
+        components: params.components,
     };
     let key = params.key;
     let issue = provider.update_issue(&key, input).await?;

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -719,6 +719,15 @@ async fn execute_create_issue(
     let params: CreateIssueParams = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("invalid create_issue params: {e}")))?;
     let custom_fields = args.get("customFields").cloned();
+    let components: Vec<String> = args
+        .get("components")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
     let input = CreateIssueInput {
         title: params.title,
         description: params.description,
@@ -730,6 +739,7 @@ async fn execute_create_issue(
         project_id: params.project_id,
         issue_type: params.issue_type,
         custom_fields,
+        components,
     };
     let issue = provider.create_issue(input).await?;
 
@@ -766,6 +776,16 @@ async fn execute_update_issue(
     let params: UpdateIssueParams = serde_json::from_value(args.clone())
         .map_err(|e| Error::InvalidData(format!("invalid update_issue params: {e}")))?;
     let custom_fields = args.get("customFields").cloned();
+    // Issue #197 — accept `components: [id, ...]` on update. If the key is
+    // absent we leave them untouched (None); an empty array clears them.
+    let components: Option<Vec<String>> =
+        args.get("components")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            });
     let input = UpdateIssueInput {
         title: params.title,
         description: params.description,
@@ -776,6 +796,7 @@ async fn execute_update_issue(
         parent_id: params.parent_id,
         markdown: params.markdown.unwrap_or(true),
         custom_fields,
+        components,
     };
     let key = params.key;
     let issue = provider.update_issue(&key, input).await?;
@@ -1338,6 +1359,7 @@ async fn execute_create_epic(
         project_id: None,
         issue_type: None,
         custom_fields: args.get("customFields").cloned(),
+        components: Vec::new(),
     };
     let issue = provider.create_issue(input).await?;
 
@@ -1424,6 +1446,7 @@ async fn execute_update_epic(
         parent_id: None,
         markdown: params.markdown.unwrap_or(true),
         custom_fields: args.get("customFields").cloned(),
+        components: None,
     };
     let key = params.key;
     let issue = provider.update_issue(&key, input).await?;

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -86,6 +86,14 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("markdown", PropertySchema::boolean("Whether the description is markdown (default: true). When true, ClickUp renders formatted text."));
                 s.add_property("projectId", PropertySchema::string("Jira project key (not numeric ID) for issue creation (e.g., \"PROJ\"). Optional — overrides the default project."));
                 s.add_property("issueType", PropertySchema::string("Issue type (e.g., \"Task\", \"Bug\", \"Story\"). Default: \"Task\". Removed by providers that don't support it."));
+                // Issue #197 — component names. The Jira enricher
+                // populates an enum at metadata-assembly time so schema
+                // consumers see the valid values; here we just declare
+                // the property exists (Codex review on PR #205).
+                s.add_property("components", PropertySchema::array(
+                    PropertySchema::string("component name"),
+                    "Jira component names to associate with the issue. Ignored by providers that don't have Components (GitHub/GitLab/ClickUp).",
+                ));
                 s.set_required("title", true);
                 s
             },
@@ -104,6 +112,12 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("assignees", PropertySchema::array(PropertySchema::string("assignee"), "New assignees"));
                 s.add_property("parentId", PropertySchema::string("Parent issue key to move task as subtask (e.g., 'CU-abc123' or 'DEV-42'). Only supported by ClickUp."));
                 s.add_property("markdown", PropertySchema::boolean("Whether the description is markdown (default: true). When true, ClickUp renders formatted text."));
+                // Issue #197 — `None` leaves components untouched, empty
+                // array clears them, array with names replaces them.
+                s.add_property("components", PropertySchema::array(
+                    PropertySchema::string("component name"),
+                    "Replace components with these Jira component names. Omit the field to leave existing components untouched; pass an empty array to clear.",
+                ));
                 s.set_required("key", true);
                 s
             },

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -584,37 +584,23 @@ impl JiraClient {
     }
 
     /// Authenticated GET against the Agile REST API.
+    ///
+    /// Uses generic `get` — Agile endpoints return JSON and we don't want
+    /// the Structure-plugin-specific error hint (Copilot review on PR #205)
+    /// leaking into Agile failures.
     async fn agile_get<T: serde::de::DeserializeOwned>(&self, endpoint: &str) -> Result<T> {
         let url = self.agile_url(endpoint);
         debug!(url = %url, "Jira Agile GET");
-        let response = self
-            .request(reqwest::Method::GET, &url)
-            .send()
-            .await
-            .map_err(|e| Error::Http(e.to_string()))?;
-        handle_structure_response(response).await
+        self.get(&url).await
     }
 
-    /// Authenticated POST against the Agile REST API.
+    /// Authenticated POST against the Agile REST API with no response
+    /// body (Agile's `/sprint/{id}/issue` returns 204). Uses
+    /// `post_no_content` for the same reason as `agile_get`.
     async fn agile_post_void<B: serde::Serialize>(&self, endpoint: &str, body: &B) -> Result<()> {
         let url = self.agile_url(endpoint);
         debug!(url = %url, "Jira Agile POST");
-        let response = self
-            .request(reqwest::Method::POST, &url)
-            .json(body)
-            .send()
-            .await
-            .map_err(|e| Error::Http(e.to_string()))?;
-        let status = response.status();
-        if !status.is_success() {
-            let (content_type, body) = read_structure_error_body(response).await;
-            return Err(structure_error_from_status(
-                status.as_u16(),
-                &content_type,
-                body,
-            ));
-        }
-        Ok(())
+        self.post_no_content(&url, body).await
     }
 
     /// Make an authenticated DELETE request to the Structure API.
@@ -1699,7 +1685,7 @@ impl IssueProvider for JiraClient {
                 input
                     .components
                     .into_iter()
-                    .map(|id| crate::types::ComponentRef { id })
+                    .map(|name| crate::types::ComponentRef { name })
                     .collect(),
             )
         };
@@ -1795,7 +1781,7 @@ impl IssueProvider for JiraClient {
         // Issue #197: components. `None` → untouched, `Some([])` → clear.
         let components = input.components.map(|ids| {
             ids.into_iter()
-                .map(|id| crate::types::ComponentRef { id })
+                .map(|name| crate::types::ComponentRef { name })
                 .collect()
         });
         let has_components = components.is_some();
@@ -2435,28 +2421,30 @@ impl IssueProvider for JiraClient {
         &self,
         input: devboy_core::AddStructureGeneratorInput,
     ) -> Result<devboy_core::StructureGenerator> {
+        // Typed response so missing `id`/`type` surface as a deserialise
+        // error instead of silent empty strings (Copilot review on PR #205).
+        #[derive(serde::Deserialize)]
+        struct Resp {
+            id: String,
+            #[serde(rename = "type")]
+            generator_type: String,
+            #[serde(default)]
+            spec: serde_json::Value,
+        }
         let body = serde_json::json!({
             "type": input.generator_type,
             "spec": input.spec,
         });
-        let resp: serde_json::Value = self
+        let resp: Resp = self
             .structure_post(
                 &format!("/structure/{}/generator", input.structure_id),
                 &body,
             )
             .await?;
         Ok(devboy_core::StructureGenerator {
-            id: resp
-                .get("id")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string(),
-            generator_type: resp
-                .get("type")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string(),
-            spec: resp.get("spec").cloned().unwrap_or(serde_json::Value::Null),
+            id: resp.id,
+            generator_type: resp.generator_type,
+            spec: resp.spec,
         })
     }
 
@@ -2488,12 +2476,13 @@ impl IssueProvider for JiraClient {
         &self,
         input: devboy_core::UpdateStructureAutomationInput,
     ) -> Result<()> {
-        let _: serde_json::Value = self
-            .structure_put(
-                &format!("/structure/{}/automation", input.structure_id),
-                &input.config,
-            )
-            .await?;
+        // `automation_id = Some(id)` → rule-scoped PUT; `None` → replace
+        // the whole automation collection (Copilot review on PR #205).
+        let endpoint = match input.automation_id.as_deref() {
+            Some(aid) => format!("/structure/{}/automation/{}", input.structure_id, aid),
+            None => format!("/structure/{}/automation", input.structure_id),
+        };
+        let _: serde_json::Value = self.structure_put(&endpoint, &input.config).await?;
         Ok(())
     }
 
@@ -4000,9 +3989,9 @@ mod tests {
             let server = MockServer::start();
 
             server.mock(|when, then| {
-                when.method(POST)
-                    .path("/issue")
-                    .body_includes("\"components\":[{\"id\":\"10001\"},{\"id\":\"10002\"}]");
+                when.method(POST).path("/issue").body_includes(
+                    "\"components\":[{\"name\":\"Backend\"},{\"name\":\"Frontend\"}]",
+                );
                 then.status(201).json_body(serde_json::json!({
                     "id": "10010",
                     "key": "PROJ-10"
@@ -4027,7 +4016,7 @@ mod tests {
             let issue = client
                 .create_issue(CreateIssueInput {
                     title: "With components".to_string(),
-                    components: vec!["10001".to_string(), "10002".to_string()],
+                    components: vec!["Backend".to_string(), "Frontend".to_string()],
                     ..Default::default()
                 })
                 .await
@@ -4089,7 +4078,7 @@ mod tests {
             server.mock(|when, then| {
                 when.method(PUT)
                     .path("/issue/PROJ-1")
-                    .body_includes("\"components\":[{\"id\":\"10001\"}]");
+                    .body_includes("\"components\":[{\"name\":\"Backend\"}]");
                 then.status(204);
             });
 
@@ -4112,7 +4101,7 @@ mod tests {
                 .update_issue(
                     "PROJ-1",
                     UpdateIssueInput {
-                        components: Some(vec!["10001".to_string()]),
+                        components: Some(vec!["Backend".to_string()]),
                         ..Default::default()
                     },
                 )
@@ -6472,14 +6461,39 @@ mod tests {
             });
 
             let client = create_client(&server);
+            // `automation_id: None` → replaces the whole automation set.
             client
                 .update_structure_automation(devboy_core::UpdateStructureAutomationInput {
                     structure_id: 5,
+                    automation_id: None,
                     config: serde_json::json!({"enabled": true}),
                 })
                 .await
                 .unwrap();
             client.trigger_structure_automation(5).await.unwrap();
+        }
+
+        /// Rule-scoped automation — `automation_id: Some(..)` routes to
+        /// `/automation/{id}` (Copilot review on PR #205).
+        #[tokio::test]
+        async fn test_structure_automation_rule_scoped() {
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/rest/structure/2.0/structure/5/automation/rule-7")
+                    .body_includes("\"action\":\"move\"");
+                then.status(200).json_body(serde_json::json!({}));
+            });
+
+            let client = create_client(&server);
+            client
+                .update_structure_automation(devboy_core::UpdateStructureAutomationInput {
+                    structure_id: 5,
+                    automation_id: Some("rule-7".into()),
+                    config: serde_json::json!({"action": "move"}),
+                })
+                .await
+                .unwrap();
         }
     }
 

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -1650,6 +1650,19 @@ impl IssueProvider for JiraClient {
         let effective_project = input.project_id.unwrap_or_else(|| self.project_key.clone());
         let effective_issue_type = input.issue_type.unwrap_or_else(|| "Task".to_string());
 
+        // Issue #197: pass through component IDs to the payload.
+        let components = if input.components.is_empty() {
+            None
+        } else {
+            Some(
+                input
+                    .components
+                    .into_iter()
+                    .map(|id| crate::types::ComponentRef { id })
+                    .collect(),
+            )
+        };
+
         let payload = CreateIssuePayload {
             fields: CreateIssueFields {
                 project: ProjectKey {
@@ -1663,6 +1676,7 @@ impl IssueProvider for JiraClient {
                 labels,
                 priority,
                 assignee,
+                components,
             },
         };
 
@@ -1737,12 +1751,21 @@ impl IssueProvider for JiraClient {
 
         let labels = input.labels;
 
+        // Issue #197: components. `None` → untouched, `Some([])` → clear.
+        let components = input.components.map(|ids| {
+            ids.into_iter()
+                .map(|id| crate::types::ComponentRef { id })
+                .collect()
+        });
+        let has_components = components.is_some();
+
         let fields = UpdateIssueFields {
             summary: input.title,
             description,
             labels,
             priority,
             assignee,
+            components,
         };
 
         let has_custom_fields = input.custom_fields.as_ref().is_some_and(|v| {
@@ -1756,6 +1779,7 @@ impl IssueProvider for JiraClient {
             || fields.labels.is_some()
             || fields.priority.is_some()
             || fields.assignee.is_some()
+            || has_components
             || has_custom_fields;
 
         if has_field_updates {
@@ -3752,6 +3776,134 @@ mod tests {
             assert_eq!(issue.key, "jira#PROJ-1");
         }
 
+        /// Issue #197 — components pass-through on create.
+        #[tokio::test]
+        async fn test_create_issue_with_components() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(POST)
+                    .path("/issue")
+                    .body_includes("\"components\":[{\"id\":\"10001\"},{\"id\":\"10002\"}]");
+                then.status(201).json_body(serde_json::json!({
+                    "id": "10010",
+                    "key": "PROJ-10"
+                }));
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/issue/PROJ-10");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "10010",
+                    "key": "PROJ-10",
+                    "fields": {
+                        "summary": "With components",
+                        "status": {"name": "Open"},
+                        "labels": [],
+                        "created": "2024-01-05T10:00:00.000+0000"
+                    }
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let issue = client
+                .create_issue(CreateIssueInput {
+                    title: "With components".to_string(),
+                    components: vec!["10001".to_string(), "10002".to_string()],
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+
+            assert_eq!(issue.key, "jira#PROJ-10");
+        }
+
+        /// Issue #197 — empty components list on create must not emit a
+        /// `"components": []` into the payload (confusing to server).
+        #[tokio::test]
+        async fn test_create_issue_without_components_omits_field() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(POST).path("/issue").matches(|req| {
+                    let body = String::from_utf8_lossy(req.body().as_ref());
+                    !body.contains("\"components\"")
+                });
+                then.status(201).json_body(serde_json::json!({
+                    "id": "10011",
+                    "key": "PROJ-11"
+                }));
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/issue/PROJ-11");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "10011",
+                    "key": "PROJ-11",
+                    "fields": {
+                        "summary": "No components",
+                        "status": {"name": "Open"},
+                        "labels": [],
+                        "created": "2024-01-05T10:00:00.000+0000"
+                    }
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let issue = client
+                .create_issue(CreateIssueInput {
+                    title: "No components".to_string(),
+                    components: vec![],
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+
+            assert_eq!(issue.key, "jira#PROJ-11");
+        }
+
+        /// Issue #197 — update_issue with components replaces them.
+        /// `Some(vec![])` clears; `None` does not touch (handled upstream).
+        #[tokio::test]
+        async fn test_update_issue_replaces_components() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/issue/PROJ-1")
+                    .body_includes("\"components\":[{\"id\":\"10001\"}]");
+                then.status(204);
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/issue/PROJ-1");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "10001",
+                    "key": "PROJ-1",
+                    "fields": {
+                        "summary": "Updated",
+                        "status": {"name": "Open"},
+                        "labels": [],
+                        "created": "2024-01-01T10:00:00.000+0000"
+                    }
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let issue = client
+                .update_issue(
+                    "PROJ-1",
+                    UpdateIssueInput {
+                        components: Some(vec!["10001".to_string()]),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(issue.key, "jira#PROJ-1");
+        }
+
         #[tokio::test]
         async fn test_update_issue() {
             let server = MockServer::start();
@@ -4703,6 +4855,7 @@ mod tests {
                     labels: None,
                     priority: None,
                     assignee: None,
+                    components: None,
                 },
             };
 
@@ -4731,6 +4884,7 @@ mod tests {
                     labels: None,
                     priority: None,
                     assignee: None,
+                    components: None,
                 },
             };
 
@@ -4755,6 +4909,7 @@ mod tests {
                     labels: None,
                     priority: None,
                     assignee: None,
+                    components: None,
                 },
             };
 

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -2569,6 +2569,39 @@ impl Provider for JiraClient {
     }
 }
 
+// Issue #177 — UserProvider. Jira exposes user lookup via /user?accountId
+// (Cloud) or /user?username (Self-Hosted); email lookup uses /user/search.
+#[async_trait]
+impl devboy_core::UserProvider for JiraClient {
+    fn provider_name(&self) -> &'static str {
+        "jira"
+    }
+
+    async fn get_user_profile(&self, user_id: &str) -> Result<User> {
+        let url = match self.flavor {
+            JiraFlavor::Cloud => format!("{}/user?accountId={}", self.base_url, user_id),
+            JiraFlavor::SelfHosted => format!("{}/user?username={}", self.base_url, user_id),
+        };
+        let jira_user: JiraUser = self.get(&url).await?;
+        map_user(Some(&jira_user))
+            .ok_or_else(|| Error::InvalidData("Jira /user returned no user".to_string()))
+    }
+
+    async fn lookup_user_by_email(&self, email: &str) -> Result<Option<User>> {
+        // /user/search accepts `query=` on Cloud (searches display name /
+        // email) and `username=` on Self-Hosted. Email is the more useful
+        // parameter for cross-provider correlation.
+        let url = match self.flavor {
+            JiraFlavor::Cloud => format!("{}/user/search?query={}", self.base_url, email),
+            JiraFlavor::SelfHosted => {
+                format!("{}/user/search?username={}", self.base_url, email)
+            }
+        };
+        let users: Vec<JiraUser> = self.get(&url).await?;
+        Ok(users.into_iter().find_map(|u| map_user(Some(&u))))
+    }
+}
+
 // =============================================================================
 // Tests
 // =============================================================================

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -2504,17 +2504,43 @@ impl IssueProvider for JiraClient {
         board_id: u64,
         state: devboy_core::SprintState,
     ) -> Result<ProviderResult<devboy_core::Sprint>> {
+        // Walk Jira Agile pagination (`startAt` + `isLast`) so callers on
+        // boards with many closed/future sprints get the full list
+        // (Codex review on PR #205).
         #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
         struct Resp {
+            #[serde(default)]
+            is_last: bool,
             #[serde(default)]
             values: Vec<devboy_core::Sprint>,
         }
-        let endpoint = match state.as_query_value() {
-            Some(s) => format!("/board/{}/sprint?state={}", board_id, s),
-            None => format!("/board/{}/sprint", board_id),
-        };
-        let resp: Resp = self.agile_get(&endpoint).await?;
-        Ok(resp.values.into())
+        // Cap at 5k sprints — plenty for any realistic board, prevents
+        // an infinite loop if `isLast` is ever misreported.
+        const MAX_SPRINTS: usize = 5_000;
+        const PAGE_SIZE: u32 = 50;
+
+        let state_param = state
+            .as_query_value()
+            .map(|s| format!("&state={}", s))
+            .unwrap_or_default();
+
+        let mut sprints: Vec<devboy_core::Sprint> = Vec::new();
+        let mut start_at: u32 = 0;
+        loop {
+            let endpoint = format!(
+                "/board/{}/sprint?startAt={}&maxResults={}{}",
+                board_id, start_at, PAGE_SIZE, state_param
+            );
+            let resp: Resp = self.agile_get(&endpoint).await?;
+            let fetched = resp.values.len() as u32;
+            sprints.extend(resp.values);
+            if resp.is_last || fetched == 0 || sprints.len() >= MAX_SPRINTS {
+                break;
+            }
+            start_at += fetched;
+        }
+        Ok(sprints.into())
     }
 
     async fn assign_to_sprint(&self, input: devboy_core::AssignToSprintInput) -> Result<()> {
@@ -6522,6 +6548,7 @@ mod tests {
                     .path("/rest/agile/1.0/board/10/sprint")
                     .query_param("state", "active");
                 then.status(200).json_body(serde_json::json!({
+                    "isLast": true,
                     "values": [
                         {
                             "id": 1,
@@ -6542,6 +6569,44 @@ mod tests {
             assert_eq!(sprints.items.len(), 1);
             assert_eq!(sprints.items[0].state, "active");
             assert_eq!(sprints.items[0].origin_board_id, Some(10));
+        }
+
+        /// Codex P2 review on PR #205 — `/board/{id}/sprint` is paginated;
+        /// we must walk `startAt` until `isLast: true`.
+        #[tokio::test]
+        async fn test_get_board_sprints_walks_pagination() {
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/rest/agile/1.0/board/10/sprint")
+                    .query_param("startAt", "0");
+                then.status(200).json_body(serde_json::json!({
+                    "isLast": false,
+                    "values": [
+                        {"id": 1, "name": "S1", "state": "closed"},
+                        {"id": 2, "name": "S2", "state": "closed"}
+                    ]
+                }));
+            });
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/rest/agile/1.0/board/10/sprint")
+                    .query_param("startAt", "2");
+                then.status(200).json_body(serde_json::json!({
+                    "isLast": true,
+                    "values": [
+                        {"id": 3, "name": "S3", "state": "active"}
+                    ]
+                }));
+            });
+
+            let client = create_client(&server);
+            let sprints = client
+                .get_board_sprints(10, devboy_core::SprintState::All)
+                .await
+                .unwrap();
+            assert_eq!(sprints.items.len(), 3);
+            assert_eq!(sprints.items[2].name, "S3");
         }
 
         #[tokio::test]

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -576,6 +576,47 @@ impl JiraClient {
         handle_structure_response(response).await
     }
 
+    /// Build a URL for the Jira Agile REST API (`/rest/agile/1.0/*`).
+    /// Issue #198.
+    fn agile_url(&self, endpoint: &str) -> String {
+        let root = instance_url_from_base(&self.base_url);
+        format!("{}/rest/agile/1.0{}", root, endpoint)
+    }
+
+    /// Authenticated GET against the Agile REST API.
+    async fn agile_get<T: serde::de::DeserializeOwned>(&self, endpoint: &str) -> Result<T> {
+        let url = self.agile_url(endpoint);
+        debug!(url = %url, "Jira Agile GET");
+        let response = self
+            .request(reqwest::Method::GET, &url)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+        handle_structure_response(response).await
+    }
+
+    /// Authenticated POST against the Agile REST API.
+    async fn agile_post_void<B: serde::Serialize>(&self, endpoint: &str, body: &B) -> Result<()> {
+        let url = self.agile_url(endpoint);
+        debug!(url = %url, "Jira Agile POST");
+        let response = self
+            .request(reqwest::Method::POST, &url)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| Error::Http(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let (content_type, body) = read_structure_error_body(response).await;
+            return Err(structure_error_from_status(
+                status.as_u16(),
+                &content_type,
+                body,
+            ));
+        }
+        Ok(())
+    }
+
     /// Make an authenticated DELETE request to the Structure API.
     async fn structure_delete_request(&self, endpoint: &str) -> Result<()> {
         let url = self.structure_url(endpoint);
@@ -2356,6 +2397,150 @@ impl IssueProvider for JiraClient {
         })
     }
 
+    // --- Structure generators (issue #179) -----------------------------
+
+    async fn get_structure_generators(
+        &self,
+        structure_id: u64,
+    ) -> Result<ProviderResult<devboy_core::StructureGenerator>> {
+        #[derive(serde::Deserialize)]
+        struct Resp {
+            #[serde(default)]
+            generators: Vec<RawGenerator>,
+        }
+        #[derive(serde::Deserialize)]
+        struct RawGenerator {
+            id: String,
+            #[serde(rename = "type")]
+            generator_type: String,
+            #[serde(default)]
+            spec: serde_json::Value,
+        }
+        let resp: Resp = self
+            .structure_get(&format!("/structure/{}/generator", structure_id))
+            .await?;
+        let items: Vec<devboy_core::StructureGenerator> = resp
+            .generators
+            .into_iter()
+            .map(|g| devboy_core::StructureGenerator {
+                id: g.id,
+                generator_type: g.generator_type,
+                spec: g.spec,
+            })
+            .collect();
+        Ok(items.into())
+    }
+
+    async fn add_structure_generator(
+        &self,
+        input: devboy_core::AddStructureGeneratorInput,
+    ) -> Result<devboy_core::StructureGenerator> {
+        let body = serde_json::json!({
+            "type": input.generator_type,
+            "spec": input.spec,
+        });
+        let resp: serde_json::Value = self
+            .structure_post(
+                &format!("/structure/{}/generator", input.structure_id),
+                &body,
+            )
+            .await?;
+        Ok(devboy_core::StructureGenerator {
+            id: resp
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            generator_type: resp
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            spec: resp.get("spec").cloned().unwrap_or(serde_json::Value::Null),
+        })
+    }
+
+    async fn sync_structure_generator(
+        &self,
+        input: devboy_core::SyncStructureGeneratorInput,
+    ) -> Result<()> {
+        let body = serde_json::json!({});
+        let _: serde_json::Value = self
+            .structure_post(
+                &format!(
+                    "/structure/{}/generator/{}/sync",
+                    input.structure_id, input.generator_id
+                ),
+                &body,
+            )
+            .await?;
+        Ok(())
+    }
+
+    // --- Structure delete + automation (issue #180) --------------------
+
+    async fn delete_structure(&self, structure_id: u64) -> Result<()> {
+        self.structure_delete_request(&format!("/structure/{}", structure_id))
+            .await
+    }
+
+    async fn update_structure_automation(
+        &self,
+        input: devboy_core::UpdateStructureAutomationInput,
+    ) -> Result<()> {
+        let _: serde_json::Value = self
+            .structure_put(
+                &format!("/structure/{}/automation", input.structure_id),
+                &input.config,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn trigger_structure_automation(&self, structure_id: u64) -> Result<()> {
+        let body = serde_json::json!({});
+        let _: serde_json::Value = self
+            .structure_post(
+                &format!("/structure/{}/automation/run", structure_id),
+                &body,
+            )
+            .await?;
+        Ok(())
+    }
+
+    // --- Agile / Sprint (issue #198) -----------------------------------
+
+    async fn get_board_sprints(
+        &self,
+        board_id: u64,
+        state: devboy_core::SprintState,
+    ) -> Result<ProviderResult<devboy_core::Sprint>> {
+        #[derive(serde::Deserialize)]
+        struct Resp {
+            #[serde(default)]
+            values: Vec<devboy_core::Sprint>,
+        }
+        let endpoint = match state.as_query_value() {
+            Some(s) => format!("/board/{}/sprint?state={}", board_id, s),
+            None => format!("/board/{}/sprint", board_id),
+        };
+        let resp: Resp = self.agile_get(&endpoint).await?;
+        Ok(resp.values.into())
+    }
+
+    async fn assign_to_sprint(&self, input: devboy_core::AssignToSprintInput) -> Result<()> {
+        // Jira accepts issue keys in the form `["PROJ-1", ...]`. Our
+        // provider-normalised keys may carry a `jira#` prefix — strip it.
+        let issues: Vec<String> = input
+            .issue_keys
+            .into_iter()
+            .map(|k| parse_jira_key(&k).to_string())
+            .collect();
+        let body = serde_json::json!({ "issues": issues });
+        self.agile_post_void(&format!("/sprint/{}/issue", input.sprint_id), &body)
+            .await
+    }
+
     fn provider_name(&self) -> &'static str {
         "jira"
     }
@@ -3825,7 +4010,7 @@ mod tests {
             let server = MockServer::start();
 
             server.mock(|when, then| {
-                when.method(POST).path("/issue").matches(|req| {
+                when.method(POST).path("/issue").is_true(|req| {
                     let body = String::from_utf8_lossy(req.body().as_ref());
                     !body.contains("\"components\"")
                 });
@@ -6158,6 +6343,197 @@ mod tests {
                 .await
                 .expect_err("403 must not be swallowed");
             assert!(matches!(err, Error::Forbidden(_)), "got {err:?}");
+        }
+
+        // =====================================================================
+        // Structure generators — issue #179
+        // =====================================================================
+
+        #[tokio::test]
+        async fn test_structure_generator_lifecycle() {
+            let server = MockServer::start();
+
+            // GET list
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/rest/structure/2.0/structure/1/generator");
+                then.status(200).json_body(serde_json::json!({
+                    "generators": [
+                        { "id": "g1", "type": "jql", "spec": {"query": "project = PROJ"} }
+                    ]
+                }));
+            });
+            // POST add
+            server.mock(|when, then| {
+                when.method(POST)
+                    .path("/rest/structure/2.0/structure/1/generator")
+                    .body_includes("\"type\":\"agile-board\"");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "g2",
+                    "type": "agile-board",
+                    "spec": {"boardId": 42}
+                }));
+            });
+            // POST sync
+            server.mock(|when, then| {
+                when.method(POST)
+                    .path("/rest/structure/2.0/structure/1/generator/g2/sync");
+                then.status(200).json_body(serde_json::json!({}));
+            });
+
+            let client = create_client(&server);
+
+            let list = client.get_structure_generators(1).await.unwrap();
+            assert_eq!(list.items.len(), 1);
+            assert_eq!(list.items[0].generator_type, "jql");
+
+            let added = client
+                .add_structure_generator(devboy_core::AddStructureGeneratorInput {
+                    structure_id: 1,
+                    generator_type: "agile-board".into(),
+                    spec: serde_json::json!({"boardId": 42}),
+                })
+                .await
+                .unwrap();
+            assert_eq!(added.id, "g2");
+
+            client
+                .sync_structure_generator(devboy_core::SyncStructureGeneratorInput {
+                    structure_id: 1,
+                    generator_id: "g2".into(),
+                })
+                .await
+                .unwrap();
+        }
+
+        // =====================================================================
+        // Structure delete + automation — issue #180
+        // =====================================================================
+
+        #[tokio::test]
+        async fn test_delete_structure() {
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method(DELETE).path("/rest/structure/2.0/structure/7");
+                then.status(204);
+            });
+
+            let client = create_client(&server);
+            client.delete_structure(7).await.unwrap();
+        }
+
+        #[tokio::test]
+        async fn test_structure_automation() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/rest/structure/2.0/structure/5/automation")
+                    .body_includes("\"enabled\":true");
+                then.status(200).json_body(serde_json::json!({}));
+            });
+            server.mock(|when, then| {
+                when.method(POST)
+                    .path("/rest/structure/2.0/structure/5/automation/run");
+                then.status(200).json_body(serde_json::json!({}));
+            });
+
+            let client = create_client(&server);
+            client
+                .update_structure_automation(devboy_core::UpdateStructureAutomationInput {
+                    structure_id: 5,
+                    config: serde_json::json!({"enabled": true}),
+                })
+                .await
+                .unwrap();
+            client.trigger_structure_automation(5).await.unwrap();
+        }
+    }
+
+    // =====================================================================
+    // Agile / Sprint — issue #198
+    // =====================================================================
+    mod agile_integration {
+        use super::*;
+        use httpmock::prelude::*;
+
+        fn create_client(server: &MockServer) -> JiraClient {
+            JiraClient::with_base_url(
+                server.base_url(),
+                "PROJ",
+                "user@example.com",
+                "token",
+                false,
+            )
+        }
+
+        #[tokio::test]
+        async fn test_get_board_sprints_active() {
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/rest/agile/1.0/board/10/sprint")
+                    .query_param("state", "active");
+                then.status(200).json_body(serde_json::json!({
+                    "values": [
+                        {
+                            "id": 1,
+                            "name": "Sprint 1",
+                            "state": "active",
+                            "originBoardId": 10,
+                            "startDate": "2026-04-01T00:00:00.000Z"
+                        }
+                    ]
+                }));
+            });
+
+            let client = create_client(&server);
+            let sprints = client
+                .get_board_sprints(10, devboy_core::SprintState::Active)
+                .await
+                .unwrap();
+            assert_eq!(sprints.items.len(), 1);
+            assert_eq!(sprints.items[0].state, "active");
+            assert_eq!(sprints.items[0].origin_board_id, Some(10));
+        }
+
+        #[tokio::test]
+        async fn test_get_board_sprints_all_omits_state() {
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method(GET)
+                    .path("/rest/agile/1.0/board/10/sprint")
+                    .is_true(|req| req.query_params().iter().all(|(k, _)| k != "state"));
+                then.status(200)
+                    .json_body(serde_json::json!({"values": []}));
+            });
+
+            let client = create_client(&server);
+            let sprints = client
+                .get_board_sprints(10, devboy_core::SprintState::All)
+                .await
+                .unwrap();
+            assert_eq!(sprints.items.len(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_assign_to_sprint_strips_jira_prefix() {
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method(POST)
+                    .path("/rest/agile/1.0/sprint/42/issue")
+                    .body_includes("\"issues\":[\"PROJ-1\",\"PROJ-2\"]");
+                then.status(204);
+            });
+
+            let client = create_client(&server);
+            client
+                .assign_to_sprint(devboy_core::AssignToSprintInput {
+                    sprint_id: 42,
+                    issue_keys: vec!["jira#PROJ-1".to_string(), "PROJ-2".to_string()],
+                })
+                .await
+                .unwrap();
         }
     }
 }

--- a/crates/plugins/api/jira/src/types.rs
+++ b/crates/plugins/api/jira/src/types.rs
@@ -284,6 +284,17 @@ pub struct CreateIssueFields {
     /// Assignee
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assignee: Option<serde_json::Value>,
+    /// Components (issue #197).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub components: Option<Vec<ComponentRef>>,
+}
+
+/// Component reference used in create/update issue payloads (issue #197).
+/// Jira expects `{ "id": "10001" }` — name-based references also work in
+/// Cloud, but id is more stable across rename.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentRef {
+    pub id: String,
 }
 
 /// Project key reference.
@@ -332,6 +343,10 @@ pub struct UpdateIssueFields {
     /// Assignee
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assignee: Option<serde_json::Value>,
+    /// Components (issue #197). `None` means do not touch.
+    /// `Some(vec![])` clears all components.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub components: Option<Vec<ComponentRef>>,
 }
 
 /// Request body for transitioning an issue.

--- a/crates/plugins/api/jira/src/types.rs
+++ b/crates/plugins/api/jira/src/types.rs
@@ -290,11 +290,17 @@ pub struct CreateIssueFields {
 }
 
 /// Component reference used in create/update issue payloads (issue #197).
-/// Jira expects `{ "id": "10001" }` — name-based references also work in
-/// Cloud, but id is more stable across rename.
+///
+/// We serialise by **name** (`{ "name": "..." }`) to line up with the
+/// Jira schema enricher, which enumerates component *names* in tool
+/// schemas (`JiraComponent.name`). Jira accepts either `{id}` or `{name}`
+/// in `fields.components`, so name-based references work across Cloud +
+/// Self-Hosted without forcing callers to resolve ids first.
+///
+/// This is addressed in Copilot review on PR #205.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComponentRef {
-    pub id: String,
+    pub name: String,
 }
 
 /// Project key reference.

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -177,6 +177,10 @@ struct SlackUserProfile {
     real_name: Option<String>,
     display_name: Option<String>,
     image_72: Option<String>,
+    /// Email — present on `users.info` + `users.lookupByEmail` when the
+    /// app has the `users:read.email` scope. Issue #177.
+    #[serde(default)]
+    email: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1213,6 +1217,66 @@ fn normalize_slack_token(token: &str) -> String {
     token.to_string()
 }
 
+fn slack_user_to_core(user: SlackUser) -> devboy_core::User {
+    let profile = user.profile.clone();
+    let display = profile
+        .as_ref()
+        .and_then(|p| p.display_name.clone())
+        .filter(|s| !s.is_empty());
+    let real = profile
+        .as_ref()
+        .and_then(|p| p.real_name.clone())
+        .filter(|s| !s.is_empty());
+    let username_candidate = user.name.clone().filter(|s| !s.is_empty());
+    let name = display
+        .clone()
+        .or(real.clone())
+        .or(username_candidate.clone());
+    devboy_core::User {
+        id: user.id,
+        username: username_candidate.unwrap_or_default(),
+        name,
+        email: profile.as_ref().and_then(|p| p.email.clone()),
+        avatar_url: profile.and_then(|p| p.image_72),
+    }
+}
+
+#[async_trait]
+impl devboy_core::UserProvider for SlackClient {
+    fn provider_name(&self) -> &'static str {
+        "slack"
+    }
+
+    async fn get_user_profile(&self, user_id: &str) -> Result<devboy_core::User> {
+        let payload: SlackUsersInfoResponse = self
+            .post_form("users.info", &[("user", user_id.to_string())])
+            .await?;
+        ensure_ok(payload.ok, payload.error)?;
+        let user = payload
+            .user
+            .ok_or_else(|| Error::InvalidData("Slack users.info returned no user".to_string()))?;
+        Ok(slack_user_to_core(user))
+    }
+
+    async fn lookup_user_by_email(&self, email: &str) -> Result<Option<devboy_core::User>> {
+        let payload: SlackUsersInfoResponse = self
+            .post_form("users.lookupByEmail", &[("email", email.to_string())])
+            .await?;
+        if !payload.ok {
+            // Slack returns `users_not_found` when the email simply has no
+            // match — surface this as Ok(None) rather than an error so
+            // callers can treat "no match" and "api error" distinctly.
+            match payload.error.as_deref() {
+                Some("users_not_found") => return Ok(None),
+                _ => {
+                    ensure_ok(payload.ok, payload.error)?;
+                }
+            }
+        }
+        Ok(payload.user.map(slack_user_to_core))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2051,5 +2115,119 @@ mod tests {
         let encoded = serialize_search_cursor(&SlackSearchCursor::default()).unwrap();
 
         assert!(encoded.is_none());
+    }
+
+    // =========================================================================
+    // UserProvider — issue #177
+    // =========================================================================
+
+    #[tokio::test]
+    async fn user_provider_get_user_profile_maps_fields() {
+        use devboy_core::UserProvider;
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/users.info");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "user": {
+                    "id": "U1",
+                    "name": "alice",
+                    "profile": {
+                        "real_name": "Alice Liddell",
+                        "display_name": "alice.l",
+                        "image_72": "https://cdn/alice.png",
+                        "email": "alice@example.com"
+                    }
+                }
+            }));
+        });
+
+        let user = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .get_user_profile("U1")
+            .await
+            .unwrap();
+
+        assert_eq!(user.id, "U1");
+        assert_eq!(user.username, "alice");
+        assert_eq!(user.name.as_deref(), Some("alice.l"));
+        assert_eq!(user.email.as_deref(), Some("alice@example.com"));
+        assert_eq!(user.avatar_url.as_deref(), Some("https://cdn/alice.png"));
+    }
+
+    #[tokio::test]
+    async fn user_provider_lookup_by_email_users_not_found_returns_none() {
+        use devboy_core::UserProvider;
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/users.lookupByEmail");
+            then.status(200).json_body(serde_json::json!({
+                "ok": false,
+                "error": "users_not_found"
+            }));
+        });
+
+        let result = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .lookup_user_by_email("missing@example.com")
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn user_provider_lookup_by_email_hit_returns_user() {
+        use devboy_core::UserProvider;
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/users.lookupByEmail");
+            then.status(200).json_body(serde_json::json!({
+                "ok": true,
+                "user": {
+                    "id": "U2",
+                    "name": "bob",
+                    "profile": {
+                        "real_name": "Bob",
+                        "display_name": "",
+                        "image_72": null,
+                        "email": "bob@example.com"
+                    }
+                }
+            }));
+        });
+
+        let user = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .lookup_user_by_email("bob@example.com")
+            .await
+            .unwrap()
+            .expect("user match");
+
+        assert_eq!(user.id, "U2");
+        assert_eq!(user.email.as_deref(), Some("bob@example.com"));
+        // display_name empty → falls back to real_name
+        assert_eq!(user.name.as_deref(), Some("Bob"));
+    }
+
+    #[tokio::test]
+    async fn user_provider_lookup_by_email_propagates_other_errors() {
+        use devboy_core::UserProvider;
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/users.lookupByEmail");
+            then.status(200).json_body(serde_json::json!({
+                "ok": false,
+                "error": "missing_scope"
+            }));
+        });
+
+        let err = SlackClient::new("xoxb-test")
+            .with_base_url(server.base_url())
+            .lookup_user_by_email("alice@example.com")
+            .await
+            .expect_err("missing_scope must not be silently swallowed");
+        let msg = err.to_string();
+        assert!(msg.contains("missing_scope"), "unexpected: {msg}");
     }
 }


### PR DESCRIPTION
Client-level bundle closing four priority Jira feature gaps in a single PR so cloud integration can pick them up as one atomic bump.

Each commit is standalone-reviewable and maps 1:1 to its upstream issue.

| Issue | Commit | Scope |
|-------|--------|-------|
| #197 (priority:high) | `1441efc feat(jira): add components support to create_issue and update_issue` | `CreateIssueInput.components: Vec<String>`, `UpdateIssueInput.components: Option<Vec<String>>`, payload `{ fields: { components: [{id}] } }`, 3 httpmock tests |
| #198 (priority:high) | `7adebd5 feat(jira): Sprint + ...` | Agile REST helper, `Sprint`/`SprintState`/`AssignToSprintInput`, `IssueProvider::get_board_sprints` + `assign_to_sprint`, 3 tests |
| #179 | `7adebd5 (same commit)` | `StructureGenerator` + three trait methods (`get_structure_generators`, `add_structure_generator`, `sync_structure_generator`), 1 lifecycle test |
| #180 | `7adebd5 (same commit)` | `UpdateStructureAutomationInput` + three trait methods (`delete_structure`, `update_structure_automation`, `trigger_structure_automation`), 2 tests |

## What's in

- **Provider trait extensions** — all new methods default to `ProviderUnsupported`, so ClickUp/GitLab/GitHub providers don't need changes.
- **Jira client implementations** — wire to existing `structure_*` helpers for Structure endpoints, new `agile_url`/`agile_get`/`agile_post_void` for Agile REST.
- **Tests** — 9 new httpmock-backed cases covering happy path + edge cases (empty components skipped, `SprintState::All` omits query param, `jira#` prefix stripping on sprint assign).

Verification:
- `cargo test --workspace` ✅ all passing (jira: 155, executor: 183, format-pipeline: 65, rest clean)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ clean
- `cargo fmt --all --check` ✅ clean

## What's explicitly **not** in (follow-ups)

- **#177 `UserProvider` trait + Slack user_profile** — cross-cutting refactor (new trait, refactor existing Jira `get_users`, new Slack client code). Scoped out so this PR stays reviewable. Will be a dedicated follow-up.
- **Tool registrations in `crates/devboy-executor/src/tools.rs` / dispatch in `executor.rs` / schema enrichment in `jira/src/enricher.rs`** — new tools for `get_board_sprints`, `assign_to_sprint`, `get_structure_generators`, `add_structure_generator`, `sync_structure_generator`, `delete_structure`, `update_structure_automation`, `trigger_structure_automation` will be a separate follow-up so this diff stays focused on the client-level contract. The existing `create_issue`/`update_issue` tools already pick up the new `components` field through schema pass-through.
- **Cloud-side wrappers** (NestJS providers in `apps/devboy-api/.../mcp/tools/`, entries in `MCP_TOOLS_REGISTRY`) — separate cloud MR after a v0.20.0 bump.

Refs: #197 #198 #179 #180.