### PR TITLE
Paper 2 MCP integration — wire L0 dedup + mckp_v2 + split metrics

### DIFF
--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -2998,6 +2998,33 @@ async fn handle_mcp_command(no_config: bool) -> Result<()> {
         server.set_telemetry(pipeline.buffer());
     }
 
+    // Paper 2 — enable the layered pipeline (L0 cross-turn dedup + format
+    // dispatch). Config lives at $DEVBOY_PIPELINE_CONFIG, falling back to
+    // ~/.devboy/pipeline_config.toml. A missing file resolves to defaults
+    // so the server still starts on a fresh install.
+    let pipeline_cfg_path = std::env::var_os("DEVBOY_PIPELINE_CONFIG")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            let home = std::env::var_os("HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_default();
+            home.join(".devboy").join("pipeline_config.toml")
+        });
+    let pipeline_cfg =
+        match devboy_format_pipeline::adaptive_config::AdaptiveConfig::load_or_default(
+            &pipeline_cfg_path,
+        ) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                tracing::warn!(
+                    "pipeline_config.toml at {} failed to parse: {e}; falling back to defaults",
+                    pipeline_cfg_path.display()
+                );
+                devboy_format_pipeline::adaptive_config::AdaptiveConfig::default()
+            }
+        };
+    server.enable_layered_pipeline(devboy_mcp::layered::SessionPipeline::new(pipeline_cfg));
+
     if !any_provider_added && !skip_config {
         tracing::warn!("No providers configured. MCP server will have limited functionality.");
         tracing::info!("Configure GitHub: devboy config set github.owner <owner>");

--- a/crates/devboy-executor/src/enricher.rs
+++ b/crates/devboy-executor/src/enricher.rs
@@ -78,7 +78,14 @@ impl ToolEnricher for FormatPipelineEnricher {
         safe_insert(
             schema,
             "format",
-            PropertySchema::string_enum(&["toon", "json"], "Output format (default: toon)"),
+            PropertySchema::string_enum(
+                &["toon", "json", "mckp"],
+                "Output format. \
+                 `toon` (default) is the legacy token-optimised custom format; \
+                 `json` is the pretty-printed baseline; \
+                 `mckp` is the format-adaptive encoder from Paper 2 — best for \
+                 array/object payloads on `o200k_base` tokenizers, key-lossless.",
+            ),
         );
 
         // Token budget — LLM controls response size
@@ -146,9 +153,14 @@ mod tests {
         let mut schema = ToolSchema::new();
         enricher.enrich_schema("get_issues", &mut schema);
 
-        // format
+        // format — `mckp` was added in PR for issue #203 follow-up so the
+        // LLM can pick the Paper 2 encoder explicitly when its tokenizer
+        // family makes it preferable to TOON.
         let format = schema.properties.get("format").unwrap();
-        assert_eq!(format.enum_values, Some(vec!["toon".into(), "json".into()]));
+        assert_eq!(
+            format.enum_values,
+            Some(vec!["toon".into(), "json".into(), "mckp".into()])
+        );
 
         // budget
         let budget = schema.properties.get("budget").unwrap();

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -71,6 +71,7 @@ pub fn format_output(
 ) -> Result<FormatResult> {
     let output_format = match format {
         Some("json") => OutputFormat::Json,
+        Some("mckp") => OutputFormat::Mckp,
         _ => OutputFormat::Toon,
     };
 
@@ -88,6 +89,7 @@ pub fn format_output(
     let format_name = match output_format {
         OutputFormat::Json => "json",
         OutputFormat::Toon => "toon",
+        OutputFormat::Mckp => "mckp",
     };
 
     let requested_chunk = pipeline_config.chunk.unwrap_or(1);

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -137,12 +137,18 @@ pub fn format_output(
     // different conditions. The typed-domain path always serialises
     // through `serde_json::to_string_pretty` first, so the implicit
     // baseline is `json_pretty`.
+    //
+    // Honest disclosure (Copilot review on PR #207): the typed-domain
+    // pipeline does not yet plumb the runtime `AdaptiveConfig.profiles
+    // .tokenizer` choice into this code path, so token counts are
+    // produced by the chars/3.5 heuristic regardless of what the
+    // operator configured. We label that explicitly here; BPE-accurate
+    // counts apply on the L0/L1/L2 hot path inside `LayeredPipeline`
+    // and via `tune analyze`, not on `format_output`. Tracked as a
+    // follow-up in §Implementation Status.
     let baseline = "json_pretty";
-    let tokenizer = devboy_format_pipeline::adaptive_config::AdaptiveConfig::default()
-        .effective_tokenizer_profile()
-        .bpe
-        .as_str()
-        .to_string();
+    let tokenizer = "heuristic";
+    let token_counter = devboy_format_pipeline::Tokenizer::Heuristic;
 
     let requested_chunk = pipeline_config.chunk.unwrap_or(1);
     let pipeline = Pipeline::with_config(pipeline_config);
@@ -153,7 +159,7 @@ pub fn format_output(
 
     // Helper: convert TransformOutput to FormatResult
     let baseline_for_helper = baseline.to_string();
-    let tokenizer_for_helper = tokenizer.clone();
+    let tokenizer_for_helper = tokenizer.to_string();
     let to_result = |t: devboy_format_pipeline::TransformOutput,
                      pag: Option<Pagination>,
                      sort: Option<SortInfo>|
@@ -162,7 +168,6 @@ pub fn format_output(
         // content includes hints/chunk index on top, but metrics should reflect pipeline savings
         let content_chars = t.output_chars;
         let content = t.to_string_with_hints();
-        let output_chars = content.len();
         let raw_chars = if t.raw_chars > 0 {
             t.raw_chars
         } else {
@@ -180,13 +185,27 @@ pub fn format_output(
         };
         let chunk_number = requested_chunk;
 
-        // §Savings Accounting — typed-domain path has no L0 dedup, so
-        // dedup_savings_pct is always 0 here and combined == encoder.
-        let encoder_savings_pct = if raw_chars > 0 {
-            ((raw_chars.saturating_sub(content_chars)) as f32) / (raw_chars as f32)
+        // §Savings Accounting — *token*-denominated, not byte-denominated.
+        // We can't see the raw input here so we approximate baseline
+        // tokens from `raw_chars` using the same tokenizer; the encoder
+        // savings then live in token space (which is what the LLM is
+        // billed on), independent of the chars/token ratio of either
+        // format. Fixes Copilot review on PR #207.
+        let baseline_tokens = if raw_chars > 0 {
+            // `Tokenizer::Heuristic` matches the `estimated_tokens`
+            // formula below; if a future change starts plumbing the
+            // active profile, both must move together.
+            (raw_chars as f64 / 3.5).ceil() as usize
+        } else {
+            0
+        };
+        let final_tokens = (content_chars as f64 / 3.5).ceil() as usize;
+        let encoder_savings_pct = if baseline_tokens > 0 {
+            ((baseline_tokens.saturating_sub(final_tokens)) as f32) / (baseline_tokens as f32)
         } else {
             0.0
         };
+        // Typed-domain path has no L0 dedup hop, so combined == encoder.
         let combined_savings_pct = encoder_savings_pct;
 
         FormatResult {
@@ -197,7 +216,7 @@ pub fn format_output(
                 output_chars: content_chars,
                 pre_trim_chars: pre_trim,
                 // estimated_tokens = full output including hints (what LLM actually consumes)
-                estimated_tokens: output_chars * 10 / 35, // chars / 3.5
+                estimated_tokens: token_counter.count(&content),
                 compression_ratio: if raw_chars > 0 {
                     content_chars as f32 / raw_chars as f32
                 } else {
@@ -224,7 +243,7 @@ pub fn format_output(
 
     // Helper: wrap plain text (no pipeline transform)
     let baseline_for_text = baseline.to_string();
-    let tokenizer_for_text = tokenizer.clone();
+    let tokenizer_for_text = tokenizer.to_string();
     let text_result =
         |text: String, pag: Option<Pagination>, sort: Option<SortInfo>| -> FormatResult {
             let chars = text.len();
@@ -233,7 +252,7 @@ pub fn format_output(
                     raw_chars: chars,
                     output_chars: chars,
                     pre_trim_chars: chars,
-                    estimated_tokens: chars * 10 / 35,
+                    estimated_tokens: token_counter.count(&text),
                     compression_ratio: 1.0,
                     format: "text".to_string(),
                     truncated: false,

--- a/crates/devboy-executor/src/format.rs
+++ b/crates/devboy-executor/src/format.rs
@@ -10,6 +10,18 @@ use serde::Serialize;
 use crate::output::ToolOutput;
 
 /// Metadata about formatting result — compression stats, token estimates.
+///
+/// Per Paper 2 §Savings Accounting, every quoted savings number must
+/// distinguish three orthogonal sources and name the baseline/tokenizer
+/// against which the percentages are taken. The split fields below
+/// (`dedup_savings_pct`, `encoder_savings_pct`, `combined_savings_pct`,
+/// `baseline`, `tokenizer`) encode that contract on the live response.
+///
+/// For typed-domain transforms (issues / merge_requests / …), the
+/// encoder runs without an L0 dedup hop, so `dedup_savings_pct == 0.0`
+/// and `combined == encoder`. The cross-turn dedup contribution is
+/// reported separately by `devboy-mcp::layered::SessionPipeline` via the
+/// telemetry sink.
 #[derive(Debug, Clone, Serialize)]
 pub struct FormatMetadata {
     /// Size of raw JSON input (UTF-8 bytes)
@@ -21,7 +33,7 @@ pub struct FormatMetadata {
     /// toon_saved = raw_chars - pre_trim_chars
     /// trimmed_chars = pre_trim_chars - output_chars
     pub pre_trim_chars: usize,
-    /// Estimated token count (output_chars / 3.5)
+    /// Estimated token count under the active tokenizer.
     pub estimated_tokens: usize,
     /// Compression ratio: output_chars / raw_chars (< 1.0 = savings)
     pub compression_ratio: f32,
@@ -43,6 +55,34 @@ pub struct FormatMetadata {
     pub provider_pagination: Option<Pagination>,
     /// Sort metadata from the provider (current sort, available sorts)
     pub provider_sort: Option<SortInfo>,
+    /// L0 dedup savings as a fraction of baseline tokens (0.0 = no
+    /// dedup hit on this response). Always `0.0` on the typed-domain
+    /// path; populated by the MCP-server's layered pipeline when a
+    /// hint is emitted.
+    #[serde(default)]
+    pub dedup_savings_pct: f32,
+    /// L1/L2 encoder savings as a fraction of baseline tokens, computed
+    /// over the *L0-miss* portion of the response. Equals
+    /// `1.0 - encoded_tokens / baseline_tokens` for the typed-domain
+    /// path.
+    #[serde(default)]
+    pub encoder_savings_pct: f32,
+    /// Multiplicative combination of dedup and encoder savings, per
+    /// the §Savings Accounting reporting rule: `combined = dedup +
+    /// (1 - dedup) * encoder`.
+    #[serde(default)]
+    pub combined_savings_pct: f32,
+    /// Baseline against which the percentages are taken
+    /// (e.g. `"json_pretty"`, `"json_compact"`, `"toon"`). Required by
+    /// the reporting rule — savings without a named baseline are not
+    /// comparable across systems.
+    #[serde(default)]
+    pub baseline: String,
+    /// Tokenizer used to compute `estimated_tokens` and the savings
+    /// percentages above (e.g. `"o200k_base"`, `"cl100k_base"`,
+    /// `"heuristic"`).
+    #[serde(default)]
+    pub tokenizer: String,
 }
 
 /// Result of formatting a tool output — content + metadata.
@@ -92,6 +132,18 @@ pub fn format_output(
         OutputFormat::Mckp => "mckp",
     };
 
+    // Active tokenizer + baseline are reported alongside savings numbers
+    // so downstream consumers can compare measurements taken under
+    // different conditions. The typed-domain path always serialises
+    // through `serde_json::to_string_pretty` first, so the implicit
+    // baseline is `json_pretty`.
+    let baseline = "json_pretty";
+    let tokenizer = devboy_format_pipeline::adaptive_config::AdaptiveConfig::default()
+        .effective_tokenizer_profile()
+        .bpe
+        .as_str()
+        .to_string();
+
     let requested_chunk = pipeline_config.chunk.unwrap_or(1);
     let pipeline = Pipeline::with_config(pipeline_config);
 
@@ -100,6 +152,8 @@ pub fn format_output(
     let provider_sort = output.result_meta().and_then(|m| m.sort_info.clone());
 
     // Helper: convert TransformOutput to FormatResult
+    let baseline_for_helper = baseline.to_string();
+    let tokenizer_for_helper = tokenizer.clone();
     let to_result = |t: devboy_format_pipeline::TransformOutput,
                      pag: Option<Pagination>,
                      sort: Option<SortInfo>|
@@ -126,6 +180,15 @@ pub fn format_output(
         };
         let chunk_number = requested_chunk;
 
+        // §Savings Accounting — typed-domain path has no L0 dedup, so
+        // dedup_savings_pct is always 0 here and combined == encoder.
+        let encoder_savings_pct = if raw_chars > 0 {
+            ((raw_chars.saturating_sub(content_chars)) as f32) / (raw_chars as f32)
+        } else {
+            0.0
+        };
+        let combined_savings_pct = encoder_savings_pct;
+
         FormatResult {
             metadata: FormatMetadata {
                 raw_chars,
@@ -149,12 +212,19 @@ pub fn format_output(
                 chunk_number,
                 provider_pagination: pag,
                 provider_sort: sort,
+                dedup_savings_pct: 0.0,
+                encoder_savings_pct,
+                combined_savings_pct,
+                baseline: baseline_for_helper.clone(),
+                tokenizer: tokenizer_for_helper.clone(),
             },
             content,
         }
     };
 
     // Helper: wrap plain text (no pipeline transform)
+    let baseline_for_text = baseline.to_string();
+    let tokenizer_for_text = tokenizer.clone();
     let text_result =
         |text: String, pag: Option<Pagination>, sort: Option<SortInfo>| -> FormatResult {
             let chars = text.len();
@@ -174,6 +244,11 @@ pub fn format_output(
                     chunk_number: 1,
                     provider_pagination: pag,
                     provider_sort: sort,
+                    dedup_savings_pct: 0.0,
+                    encoder_savings_pct: 0.0,
+                    combined_savings_pct: 0.0,
+                    baseline: baseline_for_text.clone(),
+                    tokenizer: tokenizer_for_text.clone(),
                 },
                 content: text,
             }
@@ -736,6 +811,48 @@ mod tests {
         assert_eq!(result.metadata.compression_ratio, 1.0);
         assert_eq!(result.metadata.format, "text");
         assert!(!result.metadata.truncated);
+    }
+
+    #[test]
+    fn test_format_metadata_savings_split() {
+        // Multi-issue payload so the encoder actually compresses below
+        // the JSON pretty baseline.
+        let issues: Vec<_> = (0..20).map(|_| sample_issue()).collect();
+        let output = ToolOutput::Issues(issues, None);
+        let result = format_output(output, Some("toon"), None, None).unwrap();
+
+        // Typed-domain path: dedup contributes nothing here.
+        assert_eq!(result.metadata.dedup_savings_pct, 0.0);
+        // Encoder savings must be in [0, 1).
+        assert!(
+            (0.0..1.0).contains(&result.metadata.encoder_savings_pct),
+            "encoder savings out of range: {}",
+            result.metadata.encoder_savings_pct
+        );
+        // Combined == encoder when dedup is zero.
+        assert_eq!(
+            result.metadata.combined_savings_pct,
+            result.metadata.encoder_savings_pct
+        );
+        // §Savings Accounting demands a named baseline + tokenizer.
+        assert_eq!(result.metadata.baseline, "json_pretty");
+        assert!(
+            !result.metadata.tokenizer.is_empty(),
+            "tokenizer must be set"
+        );
+    }
+
+    #[test]
+    fn test_format_metadata_passthrough_savings_zero() {
+        // Plain-text passthrough has no encoder hop, so all three savings
+        // must be zero — but baseline / tokenizer still populate.
+        let output = ToolOutput::Text("nothing to compress".into());
+        let result = format_output(output, None, None, None).unwrap();
+        assert_eq!(result.metadata.dedup_savings_pct, 0.0);
+        assert_eq!(result.metadata.encoder_savings_pct, 0.0);
+        assert_eq!(result.metadata.combined_savings_pct, 0.0);
+        assert_eq!(result.metadata.baseline, "json_pretty");
+        assert!(!result.metadata.tokenizer.is_empty());
     }
 
     #[test]

--- a/crates/devboy-mcp/Cargo.toml
+++ b/crates/devboy-mcp/Cargo.toml
@@ -11,6 +11,7 @@ authors.workspace = true
 devboy-core = { path = "../devboy-core" }
 devboy-assets = { path = "../devboy-assets" }
 devboy-executor = { path = "../devboy-executor" }
+devboy-format-pipeline = { path = "../plugins/format-pipeline" }
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/devboy-mcp/Cargo.toml
+++ b/crates/devboy-mcp/Cargo.toml
@@ -25,6 +25,7 @@ tokio-util = { version = "0.7", features = ["io"] }
 mockall.workspace = true
 async-trait.workspace = true
 httpmock.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [lints]

--- a/crates/devboy-mcp/src/handlers.rs
+++ b/crates/devboy-mcp/src/handlers.rs
@@ -62,6 +62,8 @@ pub const KNOWN_BUILTIN_TOOLS: &[&str] = &[
     "list_contexts",
     "use_context",
     "get_current_context",
+    // Layered-pipeline lifecycle (Paper 2 §Implementation Status)
+    "compact_pipeline_cache",
 ];
 
 #[cfg(test)]
@@ -88,7 +90,12 @@ mod tests {
     #[test]
     fn test_known_builtin_tools_matches_executor() {
         let base_tools = devboy_executor::tools::base_tool_definitions();
-        let context_tools = &["list_contexts", "use_context", "get_current_context"];
+        let context_tools = &[
+            "list_contexts",
+            "use_context",
+            "get_current_context",
+            "compact_pipeline_cache",
+        ];
 
         // Every base tool should be in KNOWN_BUILTIN_TOOLS
         for tool in &base_tools {

--- a/crates/devboy-mcp/src/layered.rs
+++ b/crates/devboy-mcp/src/layered.rs
@@ -1,0 +1,254 @@
+//! Per-session layered-pipeline state for the MCP server.
+//!
+//! Wraps a [`devboy_format_pipeline::LayeredPipeline`] in
+//! `Arc<Mutex<…>>` so it can sit in `McpServer` (which takes `&self` in
+//! handlers) and still be advanced through the L0 dedup cache. The
+//! pipeline is created once per server process and persists across all
+//! `tools/call` requests on that connection.
+//!
+//! Wiring contract:
+//!
+//! - On every successful `tools/call`, the server invokes
+//!   [`SessionPipeline::process`] with the raw response text. A hint is
+//!   returned when the L0 cache fires, otherwise the unmodified body
+//!   passes through (L1/L2 encoders are typed-domain and live in
+//!   `devboy-format-pipeline::Pipeline`; this hot path covers
+//!   *cross-turn* dedup only).
+//! - Mutating tools (`Edit` / `Write` / `MultiEdit` / `NotebookEdit`)
+//!   call [`SessionPipeline::invalidate_file`] before the cache is
+//!   consulted on the next `Read`, ensuring the agent sees fresh
+//!   contents after an edit.
+//! - On `/compact` (host-side compaction), the host calls
+//!   [`SessionPipeline::on_compaction_boundary`] to advance the
+//!   partition counter and drop entries that would otherwise outlive
+//!   the cache window.
+
+use std::sync::{Arc, Mutex};
+
+use devboy_format_pipeline::adaptive_config::AdaptiveConfig;
+use devboy_format_pipeline::layered_pipeline::{LayeredPipeline, ToolResponseInput};
+use devboy_format_pipeline::telemetry::Layer;
+
+use crate::protocol::{ToolCallParams, ToolCallResult, ToolResultContent};
+
+/// Per-session pipeline handle. Cloneable; holds an `Arc` to the inner
+/// `LayeredPipeline`.
+#[derive(Clone)]
+pub struct SessionPipeline {
+    inner: Arc<Mutex<LayeredPipeline>>,
+}
+
+impl SessionPipeline {
+    /// Create a new pipeline for the current MCP server process. The
+    /// session id is derived from the process id so multiple concurrent
+    /// `devboy mcp` instances do not collide in shared telemetry.
+    pub fn new(config: AdaptiveConfig) -> Self {
+        let session_id = format!("mcp_{}", std::process::id());
+        Self {
+            inner: Arc::new(Mutex::new(LayeredPipeline::new(session_id, config))),
+        }
+    }
+
+    /// Notify the pipeline that the host compacted its context. Drops
+    /// dedup entries from prior partitions on the next eviction sweep.
+    pub fn on_compaction_boundary(&self) {
+        if let Ok(mut p) = self.inner.lock() {
+            p.on_compaction_boundary();
+        }
+    }
+
+    /// Invalidate all cache entries pointing at `file_path`. Called by
+    /// the server before a mutating tool (`Edit`/`Write`/...) is
+    /// dispatched so that a subsequent `Read` of the same file does
+    /// not return a stale `> [ref: …]` hint.
+    pub fn invalidate_file(&self, file_path: &str) {
+        if let Ok(mut p) = self.inner.lock() {
+            p.invalidate_file(file_path);
+        }
+    }
+
+    /// Process a single tool-call response through L0 dedup. When the
+    /// L0 layer emits a reference hint (`> [ref: tc_42, byte-identical]`
+    /// or its terse / verbose variant), the input `ToolCallResult` is
+    /// rewritten to carry the hint instead of the original body. Other
+    /// layer outcomes pass the original result through unchanged —
+    /// L1/L2 encoders for typed-domain responses live in `Pipeline`.
+    pub fn process(
+        &self,
+        request_id: &str,
+        params: &ToolCallParams,
+        result: ToolCallResult,
+        ts_ms: i64,
+    ) -> ToolCallResult {
+        // Errors must never be deduped — a stale hint instead of a real
+        // error message would silently break the agent's recovery loop.
+        if result.is_error == Some(true) {
+            return result;
+        }
+
+        let file_path = extract_file_path(params.arguments.as_ref());
+
+        let mut new_content: Vec<ToolResultContent> = Vec::with_capacity(result.content.len());
+        let mut p = match self.inner.lock() {
+            Ok(g) => g,
+            // A poisoned mutex means an earlier panic — best-effort fall
+            // back to passing the response through unmodified.
+            Err(_) => return result,
+        };
+
+        for c in result.content {
+            match c {
+                ToolResultContent::Text { text } => {
+                    let input = ToolResponseInput {
+                        tool_call_id: request_id,
+                        tool_name: &params.name,
+                        file_path: file_path.as_deref(),
+                        content: &text,
+                        is_sidechain: false,
+                        ts_ms,
+                    };
+                    let out = p.process(input);
+                    // Only rewrite when L0 fired — other layers do not
+                    // operate on opaque text content from arbitrary
+                    // upstream tools (the typed-domain L1/L2 path goes
+                    // through `Pipeline::transform_*`).
+                    let body = if matches!(out.layer, Layer::L0) {
+                        out.output
+                    } else {
+                        text
+                    };
+                    new_content.push(ToolResultContent::Text { text: body });
+                }
+            }
+        }
+
+        ToolCallResult {
+            content: new_content,
+            is_error: result.is_error,
+        }
+    }
+}
+
+/// Pull `file_path` / `path` / `notebook_path` out of a tool call's
+/// arguments. Tools not in the file-operating family produce `None`.
+pub fn extract_file_path(args: Option<&serde_json::Value>) -> Option<String> {
+    let obj = args?.as_object()?;
+    for k in ["file_path", "path", "notebook_path"] {
+        if let Some(v) = obj.get(k).and_then(|v| v.as_str()) {
+            return Some(v.to_string());
+        }
+    }
+    None
+}
+
+/// True iff `name` is a mutating file-operating tool. Server uses this
+/// to fire a cache invalidation before the tool is dispatched.
+pub fn is_mutating_tool(name: &str) -> bool {
+    matches!(name, "Edit" | "Write" | "MultiEdit" | "NotebookEdit")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{ToolCallParams, ToolCallResult, ToolResultContent};
+    use serde_json::json;
+
+    fn read_params(path: &str) -> ToolCallParams {
+        ToolCallParams {
+            name: "Read".to_string(),
+            arguments: Some(json!({"file_path": path})),
+        }
+    }
+
+    fn long_text(seed: &str) -> String {
+        // Body must clear the 200-byte min_body_chars default to be
+        // eligible for dedup.
+        format!("{}{}", seed, "x".repeat(400))
+    }
+
+    #[test]
+    fn second_identical_read_emits_reference_hint() {
+        let pipeline = SessionPipeline::new(AdaptiveConfig::default());
+        let body = long_text("file-A:");
+        let r1 = pipeline.process(
+            "req_1",
+            &read_params("/tmp/a.rs"),
+            ToolCallResult::text(body.clone()),
+            0,
+        );
+        let r2 = pipeline.process(
+            "req_2",
+            &read_params("/tmp/a.rs"),
+            ToolCallResult::text(body.clone()),
+            10,
+        );
+        // First call returns the body unchanged.
+        let ToolResultContent::Text { text: t1 } = &r1.content[0];
+        assert_eq!(t1, &body);
+        // Second call returns a hint (much shorter, contains `[ref:`).
+        let ToolResultContent::Text { text: t2 } = &r2.content[0];
+        assert!(t2.len() < body.len() / 2, "expected hint, got `{t2}`");
+        assert!(
+            t2.contains("[ref:") || t2.contains("[ref "),
+            "expected reference hint, got `{t2}`"
+        );
+    }
+
+    #[test]
+    fn edit_invalidation_busts_cache() {
+        let pipeline = SessionPipeline::new(AdaptiveConfig::default());
+        let body = long_text("file-B:");
+        let _ = pipeline.process(
+            "req_1",
+            &read_params("/tmp/b.rs"),
+            ToolCallResult::text(body.clone()),
+            0,
+        );
+        // Mutating tool fires its invalidation hook.
+        pipeline.invalidate_file("/tmp/b.rs");
+        // A subsequent identical read must come back fresh, not as a hint.
+        let r3 = pipeline.process(
+            "req_3",
+            &read_params("/tmp/b.rs"),
+            ToolCallResult::text(body.clone()),
+            10,
+        );
+        let ToolResultContent::Text { text: t3 } = &r3.content[0];
+        assert_eq!(t3, &body, "expected fresh body after invalidation");
+    }
+
+    #[test]
+    fn errors_are_never_deduped() {
+        let pipeline = SessionPipeline::new(AdaptiveConfig::default());
+        let body = long_text("err:");
+        let _ = pipeline.process(
+            "req_1",
+            &read_params("/tmp/c.rs"),
+            ToolCallResult::text(body.clone()),
+            0,
+        );
+        let mut err = ToolCallResult::text(body.clone());
+        err.is_error = Some(true);
+        let r2 = pipeline.process("req_2", &read_params("/tmp/c.rs"), err, 10);
+        let ToolResultContent::Text { text: t2 } = &r2.content[0];
+        assert_eq!(t2, &body, "errors must pass through untouched");
+    }
+
+    #[test]
+    fn extract_file_path_handles_three_argument_names() {
+        assert_eq!(
+            extract_file_path(Some(&json!({"file_path": "/x"}))),
+            Some("/x".into())
+        );
+        assert_eq!(
+            extract_file_path(Some(&json!({"path": "/y"}))),
+            Some("/y".into())
+        );
+        assert_eq!(
+            extract_file_path(Some(&json!({"notebook_path": "/z"}))),
+            Some("/z".into())
+        );
+        assert_eq!(extract_file_path(Some(&json!({"unrelated": "x"}))), None);
+        assert_eq!(extract_file_path(None), None);
+    }
+}

--- a/crates/devboy-mcp/src/layered.rs
+++ b/crates/devboy-mcp/src/layered.rs
@@ -23,11 +23,12 @@
 //!   partition counter and drop entries that would otherwise outlive
 //!   the cache window.
 
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use devboy_format_pipeline::adaptive_config::AdaptiveConfig;
 use devboy_format_pipeline::layered_pipeline::{LayeredPipeline, ToolResponseInput};
-use devboy_format_pipeline::telemetry::Layer;
+use devboy_format_pipeline::telemetry::{JsonlSink, Layer, TelemetrySink};
 
 use crate::protocol::{ToolCallParams, ToolCallResult, ToolResultContent};
 
@@ -42,10 +43,37 @@ impl SessionPipeline {
     /// Create a new pipeline for the current MCP server process. The
     /// session id is derived from the process id so multiple concurrent
     /// `devboy mcp` instances do not collide in shared telemetry.
+    ///
+    /// When `config.telemetry.enabled` is `true`, a [`JsonlSink`] is
+    /// opened at `<config.telemetry.path | ~/.devboy/telemetry>/<session>.jsonl`
+    /// and attached to the pipeline. Failures to open the sink (missing
+    /// permissions, etc.) are logged at WARN level and degrade to a
+    /// no-op telemetry — they never fail the server start-up.
     pub fn new(config: AdaptiveConfig) -> Self {
         let session_id = format!("mcp_{}", std::process::id());
+        let mut pipeline = LayeredPipeline::new(session_id.clone(), config.clone());
+
+        if config.telemetry.enabled
+            && let Some(path) = resolve_telemetry_path(&config, &session_id)
+        {
+            match JsonlSink::open(&path) {
+                Ok(sink) => {
+                    let arc: Arc<dyn TelemetrySink> = Arc::new(sink);
+                    pipeline = pipeline.with_telemetry(arc);
+                    tracing::info!(target: "devboy_mcp::telemetry", "telemetry sink opened at {}", path.display());
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "devboy_mcp::telemetry",
+                        "telemetry sink at {} failed to open: {e} — running without telemetry",
+                        path.display()
+                    );
+                }
+            }
+        }
+
         Self {
-            inner: Arc::new(Mutex::new(LayeredPipeline::new(session_id, config))),
+            inner: Arc::new(Mutex::new(pipeline)),
         }
     }
 
@@ -147,6 +175,22 @@ pub fn is_mutating_tool(name: &str) -> bool {
     matches!(name, "Edit" | "Write" | "MultiEdit" | "NotebookEdit")
 }
 
+/// Resolve the JSONL sink target for a session. Honours
+/// `telemetry.path`, then `$DEVBOY_TELEMETRY_DIR`, then
+/// `$HOME/.devboy/telemetry/`, then `$TMPDIR/.devboy-telemetry/`.
+fn resolve_telemetry_path(config: &AdaptiveConfig, session_id: &str) -> Option<PathBuf> {
+    let dir: PathBuf = if let Some(p) = config.telemetry.path.as_deref() {
+        Path::new(p).to_path_buf()
+    } else if let Ok(env_dir) = std::env::var("DEVBOY_TELEMETRY_DIR") {
+        PathBuf::from(env_dir)
+    } else if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        home.join(".devboy").join("telemetry")
+    } else {
+        std::env::temp_dir().join(".devboy-telemetry")
+    };
+    Some(dir.join(format!("{session_id}.jsonl")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -232,6 +276,67 @@ mod tests {
         let r2 = pipeline.process("req_2", &read_params("/tmp/c.rs"), err, 10);
         let ToolResultContent::Text { text: t2 } = &r2.content[0];
         assert_eq!(t2, &body, "errors must pass through untouched");
+    }
+
+    #[test]
+    fn telemetry_disabled_by_default_writes_no_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg = AdaptiveConfig::default();
+        cfg.telemetry.path = Some(tmp.path().to_string_lossy().into_owned());
+        // enabled stays false (the default)
+        let pipeline = SessionPipeline::new(cfg);
+        let body = long_text("file-T:");
+        let _ = pipeline.process(
+            "req_1",
+            &read_params("/tmp/t.rs"),
+            ToolCallResult::text(body),
+            0,
+        );
+        // Default is `enabled = false` → directory must remain empty.
+        let entries: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "telemetry must be silent until explicitly enabled, found {entries:?}"
+        );
+    }
+
+    #[test]
+    fn telemetry_enabled_creates_jsonl_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg = AdaptiveConfig::default();
+        cfg.telemetry.enabled = true;
+        cfg.telemetry.path = Some(tmp.path().to_string_lossy().into_owned());
+        // Flush after every event so the file is non-empty when we read it.
+        cfg.telemetry.flush_every_n = 1;
+        let pipeline = SessionPipeline::new(cfg);
+        let body = long_text("file-U:");
+        let _ = pipeline.process(
+            "req_1",
+            &read_params("/tmp/u.rs"),
+            ToolCallResult::text(body),
+            0,
+        );
+        let mut found = false;
+        for entry in std::fs::read_dir(tmp.path()).unwrap() {
+            let entry = entry.unwrap();
+            if entry.path().extension().and_then(|s| s.to_str()) == Some("jsonl") {
+                let contents = std::fs::read_to_string(entry.path()).unwrap();
+                assert!(
+                    contents.contains("\"endpoint_class\":\"Read\""),
+                    "expected Read event in JSONL, got {contents}"
+                );
+                found = true;
+                break;
+            }
+        }
+        assert!(
+            found,
+            "expected at least one .jsonl file in {:?}",
+            tmp.path()
+        );
     }
 
     #[test]

--- a/crates/devboy-mcp/src/lib.rs
+++ b/crates/devboy-mcp/src/lib.rs
@@ -22,6 +22,7 @@
 //! ```
 
 pub mod handlers;
+pub mod layered;
 pub mod protocol;
 pub mod proxy;
 pub mod routing;

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -343,6 +343,15 @@ impl McpServer {
             "notifications/cancelled" => {
                 tracing::debug!("Request cancelled by client");
             }
+            // devboy-specific extension — host signals that it just
+            // compacted its conversation context. The L0 dedup cache
+            // advances its partition counter so any earlier-turn
+            // entries are dropped on the next eviction sweep, matching
+            // the agent's *visible* context.
+            "notifications/devboy/compact" => {
+                tracing::info!("Host compaction signal received — advancing dedup partition");
+                self.on_compaction_boundary();
+            }
             _ => {
                 tracing::debug!("Ignoring notification: {}", method);
             }
@@ -613,6 +622,15 @@ impl McpServer {
                 Some(ToolCallResult::text(content))
             }
             "get_current_context" => Some(ToolCallResult::text(self.active_context_name())),
+            "compact_pipeline_cache" => {
+                // Tool-call entry point for hosts that can't emit
+                // `notifications/devboy/compact`. Same effect: advance
+                // the dedup partition.
+                self.on_compaction_boundary();
+                Some(ToolCallResult::text(
+                    "pipeline cache partition advanced".to_string(),
+                ))
+            }
             "use_context" => {
                 #[derive(Deserialize)]
                 struct UseContextParams {
@@ -2076,6 +2094,40 @@ mod tests {
         // on_compaction_boundary must be a no-op on the disabled path and
         // a no-panic on the enabled path.
         server.on_compaction_boundary();
+    }
+
+    #[tokio::test]
+    async fn test_compaction_notification_advances_partition() {
+        use devboy_format_pipeline::adaptive_config::AdaptiveConfig;
+
+        let mut server = McpServer::new();
+        server.enable_layered_pipeline(SessionPipeline::new(AdaptiveConfig::default()));
+        // Notification path — must not panic and must not error.
+        server.handle_notification("notifications/devboy/compact");
+        // Unknown notifications are still ignored.
+        server.handle_notification("notifications/totally/unrelated");
+    }
+
+    #[tokio::test]
+    async fn test_compact_pipeline_cache_internal_tool() {
+        use devboy_format_pipeline::adaptive_config::AdaptiveConfig;
+
+        let mut server = McpServer::new();
+        server.enable_layered_pipeline(SessionPipeline::new(AdaptiveConfig::default()));
+
+        let req = JsonRpcRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: RequestId::Number(1),
+            method: "tools/call".to_string(),
+            params: Some(serde_json::json!({
+                "name": "compact_pipeline_cache",
+                "arguments": {}
+            })),
+        };
+        let resp = server.handle_request(req).await;
+        assert!(resp.error.is_none());
+        let result: ToolCallResult = serde_json::from_value(resp.result.unwrap()).unwrap();
+        assert_eq!(result.is_error, None);
     }
 
     #[tokio::test]

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use tokio::sync::oneshot;
 
+use crate::layered::{SessionPipeline, extract_file_path as file_path_from_args, is_mutating_tool};
 use crate::protocol::{
     InitializeParams, InitializeResult, JsonRpcError, JsonRpcRequest, JsonRpcResponse, MCP_VERSION,
     RequestId, ServerCapabilities, ServerInfo, ToolCallParams, ToolCallResult, ToolsCapability,
@@ -52,6 +53,10 @@ pub struct McpServer {
     /// Deferred background initialization — resolved on first `tools/list` or `tools/call`.
     /// Returns proxy manager and optional builtin_tools override from remote config.
     deferred_init: Option<oneshot::Receiver<DeferredInit>>,
+    /// Layered pipeline — when configured, every successful `tools/call`
+    /// response passes through L0 dedup before being returned to the client
+    /// (Paper 2 §Implementation Status).
+    layered_pipeline: Option<SessionPipeline>,
 }
 
 impl McpServer {
@@ -72,6 +77,21 @@ impl McpServer {
             routing_engine: None,
             telemetry: None,
             deferred_init: None,
+            layered_pipeline: None,
+        }
+    }
+
+    /// Enable the Paper 2 layered pipeline (L0 cross-turn dedup) for the
+    /// lifetime of this server. Once set, every `tools/call` response is
+    /// passed through `SessionPipeline::process` before being returned.
+    pub fn enable_layered_pipeline(&mut self, pipeline: SessionPipeline) {
+        self.layered_pipeline = Some(pipeline);
+    }
+
+    /// Drop the layered-pipeline cache partition on host compaction.
+    pub fn on_compaction_boundary(&self) {
+        if let Some(p) = &self.layered_pipeline {
+            p.on_compaction_boundary();
         }
     }
 
@@ -520,9 +540,35 @@ impl McpServer {
             return JsonRpcResponse::success(id, serde_json::to_value(result).unwrap());
         }
 
+        // Mutation-aware cache invalidation must fire *before* dispatch:
+        // the tool is about to change the file, so any cached body for
+        // that path is stale starting from this turn.
+        if let Some(pipeline) = &self.layered_pipeline
+            && is_mutating_tool(&params.name)
+            && let Some(path) = file_path_from_args(params.arguments.as_ref())
+        {
+            pipeline.invalidate_file(&path);
+        }
+
         let started = Instant::now();
         let (result, was_fallback, emitted_reason, emitted_detail, upstream_label, resolved_name) =
             self.dispatch_with_routing(&params).await;
+
+        // Apply Paper 2 L0 dedup on the way back to the client.
+        let result = if let Some(pipeline) = &self.layered_pipeline {
+            let req_id = match &id {
+                RequestId::Number(n) => format!("req_{n}"),
+                RequestId::String(s) => s.clone(),
+                RequestId::Null => "req_null".to_string(),
+            };
+            let ts_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0);
+            pipeline.process(&req_id, &params, result, ts_ms)
+        } else {
+            result
+        };
 
         // Best-effort telemetry — never block response path on this.
         if let Some(buffer) = &self.telemetry {
@@ -2017,5 +2063,50 @@ mod tests {
         assert!(!result.tools.iter().any(|t| t.name == "get_issues"));
         // Other tools should still be present
         assert!(result.tools.iter().any(|t| t.name == "get_issue"));
+    }
+
+    #[test]
+    fn test_enable_layered_pipeline_sets_field() {
+        use devboy_format_pipeline::adaptive_config::AdaptiveConfig;
+
+        let mut server = McpServer::new();
+        assert!(server.layered_pipeline.is_none());
+        server.enable_layered_pipeline(SessionPipeline::new(AdaptiveConfig::default()));
+        assert!(server.layered_pipeline.is_some());
+        // on_compaction_boundary must be a no-op on the disabled path and
+        // a no-panic on the enabled path.
+        server.on_compaction_boundary();
+    }
+
+    #[tokio::test]
+    async fn test_layered_pipeline_dedups_repeated_internal_tool_response() {
+        use devboy_format_pipeline::adaptive_config::AdaptiveConfig;
+
+        let mut server = McpServer::new();
+        server.contexts.insert("workspace".to_string(), vec![]);
+        server.set_active_context("workspace").unwrap();
+        server.enable_layered_pipeline(SessionPipeline::new(AdaptiveConfig::default()));
+
+        // `get_current_context` is an internal tool whose response is a
+        // short fixed string — too small to clear the L0 min_body_chars
+        // threshold (default 200). The layered pipeline should pass it
+        // through unchanged on both calls.
+        let make_req = |id: i64| JsonRpcRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: RequestId::Number(id),
+            method: "tools/call".to_string(),
+            params: Some(serde_json::json!({
+                "name": "get_current_context",
+                "arguments": {}
+            })),
+        };
+
+        let r1 = server.handle_request(make_req(1)).await;
+        let r2 = server.handle_request(make_req(2)).await;
+        assert!(r1.error.is_none());
+        assert!(r2.error.is_none());
+        // Both calls return the same body (identity below the dedup
+        // threshold means no rewrite, not a hint).
+        assert_eq!(r1.result, r2.result);
     }
 }

--- a/crates/devboy-mcp/src/server.rs
+++ b/crates/devboy-mcp/src/server.rs
@@ -86,6 +86,11 @@ impl McpServer {
     /// passed through `SessionPipeline::process` before being returned.
     pub fn enable_layered_pipeline(&mut self, pipeline: SessionPipeline) {
         self.layered_pipeline = Some(pipeline);
+        tracing::info!(
+            "Paper 2 layered pipeline enabled — L0 dedup active. \
+             Edit ~/.devboy/pipeline_config.toml (or set DEVBOY_PIPELINE_CONFIG) \
+             to tune knobs. See `devboy tune analyze` for split-savings metrics."
+        );
     }
 
     /// Drop the layered-pipeline cache partition on host compaction.
@@ -2128,6 +2133,59 @@ mod tests {
         assert!(resp.error.is_none());
         let result: ToolCallResult = serde_json::from_value(resp.result.unwrap()).unwrap();
         assert_eq!(result.is_error, None);
+    }
+
+    #[tokio::test]
+    async fn test_e2e_read_edit_read_busts_cache_via_server() {
+        // P-203-09 acceptance gate: the server's full request-handling
+        // path must invalidate the cache when a mutating tool is
+        // dispatched, so a re-read of the same file returns a fresh body
+        // (not a stale `> [ref: …]` hint).
+        //
+        // We exercise this through the public `extract_file_path` /
+        // `is_mutating_tool` helpers + `SessionPipeline::process` so the
+        // assertion is the same path the server's `handle_tools_call`
+        // takes — minus the dispatch step (which would need real
+        // providers).
+        use devboy_format_pipeline::adaptive_config::AdaptiveConfig;
+
+        let pipeline = SessionPipeline::new(AdaptiveConfig::default());
+        let body = "x".repeat(600);
+
+        let read_params = crate::protocol::ToolCallParams {
+            name: "Read".to_string(),
+            arguments: Some(serde_json::json!({"file_path": "/tmp/e2e.rs"})),
+        };
+
+        // Turn 1 — fresh body.
+        let r1 = pipeline.process("req_1", &read_params, ToolCallResult::text(body.clone()), 0);
+        let crate::protocol::ToolResultContent::Text { text: t1 } = &r1.content[0];
+        assert_eq!(t1, &body);
+
+        // Turn 2 — server's mutation hook fires before dispatch. We
+        // simulate the same call sequence directly.
+        let edit_params = crate::protocol::ToolCallParams {
+            name: "Edit".to_string(),
+            arguments: Some(serde_json::json!({"file_path": "/tmp/e2e.rs"})),
+        };
+        if crate::layered::is_mutating_tool(&edit_params.name)
+            && let Some(p) = crate::layered::extract_file_path(edit_params.arguments.as_ref())
+        {
+            pipeline.invalidate_file(&p);
+        }
+
+        // Turn 3 — same Read after invalidation must come back fresh.
+        let r3 = pipeline.process(
+            "req_3",
+            &read_params,
+            ToolCallResult::text(body.clone()),
+            10,
+        );
+        let crate::protocol::ToolResultContent::Text { text: t3 } = &r3.content[0];
+        assert_eq!(
+            t3, &body,
+            "Edit must bust the dedup cache so subsequent Read is fresh"
+        );
     }
 
     #[tokio::test]

--- a/crates/plugins/format-pipeline/Cargo.toml
+++ b/crates/plugins/format-pipeline/Cargo.toml
@@ -15,6 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+tiktoken-rs = "0.11"
 toml.workspace = true
 tracing.workspace = true
 

--- a/crates/plugins/format-pipeline/src/adaptive_config.rs
+++ b/crates/plugins/format-pipeline/src/adaptive_config.rs
@@ -480,6 +480,20 @@ impl Default for ShapeThresholds {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TelemetryConfig {
+    /// Master switch — when `false`, no sink is opened on the host even
+    /// if `path` is set. Default: `false` so a fresh install does not
+    /// silently start writing files to the user's `$HOME`.
+    #[serde(default = "default_telemetry_enabled")]
+    pub enabled: bool,
+    /// Optional override for the JSONL sink directory. When `None`, the
+    /// host falls back to `~/.devboy/telemetry/`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Soft size cap per JSONL file (MiB). When the active sink crosses
+    /// this size, the host opens a new file with a numeric suffix
+    /// (`<session>.<n>.jsonl`). 0 disables rotation.
+    #[serde(default = "default_rotate_mib")]
+    pub rotate_mib: u32,
     /// Fraction of events to record (1.0 = all).
     #[serde(default = "default_sample_rate")]
     pub sample_rate: f32,
@@ -488,6 +502,12 @@ pub struct TelemetryConfig {
     pub flush_every_n: usize,
 }
 
+fn default_telemetry_enabled() -> bool {
+    false
+}
+fn default_rotate_mib() -> u32 {
+    100
+}
 fn default_sample_rate() -> f32 {
     1.0
 }
@@ -498,6 +518,9 @@ fn default_flush_every() -> usize {
 impl Default for TelemetryConfig {
     fn default() -> Self {
         Self {
+            enabled: default_telemetry_enabled(),
+            path: None,
+            rotate_mib: default_rotate_mib(),
             sample_rate: default_sample_rate(),
             flush_every_n: default_flush_every(),
         }

--- a/crates/plugins/format-pipeline/src/adaptive_config.rs
+++ b/crates/plugins/format-pipeline/src/adaptive_config.rs
@@ -489,9 +489,12 @@ pub struct TelemetryConfig {
     /// host falls back to `~/.devboy/telemetry/`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
-    /// Soft size cap per JSONL file (MiB). When the active sink crosses
-    /// this size, the host opens a new file with a numeric suffix
-    /// (`<session>.<n>.jsonl`). 0 disables rotation.
+    /// Soft size cap per JSONL file (MiB). **Reserved for future use —
+    /// the v1 sink does not rotate yet.** Persisted so a later
+    /// implementation can pick it up without a config migration; today
+    /// the value is read but not acted on. Operators with long-running
+    /// sessions should keep `enabled = false` or rotate externally
+    /// (logrotate / `find -mtime`).
     #[serde(default = "default_rotate_mib")]
     pub rotate_mib: u32,
     /// Fraction of events to record (1.0 = all).

--- a/crates/plugins/format-pipeline/src/adaptive_config.rs
+++ b/crates/plugins/format-pipeline/src/adaptive_config.rs
@@ -47,6 +47,8 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::token_counter::Tokenizer;
+
 #[derive(Error, Debug)]
 pub enum ConfigError {
     #[error("adaptive-config I/O: {0}")]
@@ -211,6 +213,40 @@ impl AdaptiveConfig {
             }
         }
         n.max(1)
+    }
+
+    /// Effective tokenizer profile resolved from `profiles.tokenizer.active`
+    /// (or `auto` → `anthropic_class`). Always returns *some* profile —
+    /// falls back to the default `anthropic_class` if the active id is
+    /// missing from `variants`.
+    pub fn effective_tokenizer_profile(&self) -> &TokenizerProfile {
+        let active = self.profiles.tokenizer.active.as_str();
+        let id = if active == "auto" || active.is_empty() {
+            "anthropic_class"
+        } else {
+            active
+        };
+        self.profiles
+            .tokenizer
+            .variants
+            .get(id)
+            .or_else(|| self.profiles.tokenizer.variants.get("anthropic_class"))
+            .unwrap_or_else(|| {
+                // Last resort: a static default kept for the lifetime of the
+                // process. We never expect to hit this branch — `Default`
+                // populates `anthropic_class` — but safe-guard against a
+                // hand-edited config that wiped variants.
+                static FALLBACK: std::sync::OnceLock<TokenizerProfile> = std::sync::OnceLock::new();
+                FALLBACK.get_or_init(TokenizerProfile::default)
+            })
+    }
+
+    /// Token count for `text` under the active tokenizer profile. Hot path:
+    /// when the profile selects `Tokenizer::Heuristic`, this is a single
+    /// integer division on `text.len()`. When BPE is selected, it pays one
+    /// `tiktoken-rs` encode call (typically 1–10 µs).
+    pub fn effective_token_count(&self, text: &str) -> usize {
+        self.effective_tokenizer_profile().count_tokens(text)
     }
 
     /// Effective L1 template id for `endpoint`. Per-endpoint override wins;
@@ -519,10 +555,20 @@ pub struct ProfilesConfig {
 /// different token counts depending on the receiving model's tokenizer (e.g.,
 /// `inline_json_cost` is 2.2x on Anthropic-class but 1.0x on Ollama BPE).
 /// See Paper 2 §Encoder Bug Postmortem (2026-04-25).
+///
+/// `bpe` selects the actual byte-pair encoder used to count tokens. When set
+/// to [`Tokenizer::Heuristic`] (default for backward compat), `chars_per_token`
+/// drives the estimate. When set to a real BPE variant, that BPE is used and
+/// `chars_per_token` is informational only.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenizerProfile {
     /// Average characters per token observed for this tokenizer.
+    /// Only used when `bpe == Heuristic`.
     pub chars_per_token: f32,
+    /// Real BPE tokenizer to use for accurate counts. Falls back to the
+    /// `chars_per_token` heuristic when set to `heuristic`.
+    #[serde(default)]
+    pub bpe: Tokenizer,
     /// Penalty multiplier for inline-JSON cells inside markdown tables.
     /// Use to decide between inline-JSON nested cells vs. recursive sections.
     #[serde(default = "default_inline_json_cost")]
@@ -547,9 +593,33 @@ impl Default for TokenizerProfile {
     fn default() -> Self {
         Self {
             chars_per_token: 4.0,
+            bpe: Tokenizer::Heuristic,
             inline_json_cost: default_inline_json_cost(),
             toon_overhead: default_toon_overhead(),
             format_factors: BTreeMap::new(),
+        }
+    }
+}
+
+impl TokenizerProfile {
+    /// Count tokens in `text` using this profile's resolved tokenizer.
+    ///
+    /// - If `bpe == Heuristic`, applies `text.len() / chars_per_token` (ceiled).
+    /// - Otherwise delegates to the real BPE encoder.
+    pub fn count_tokens(&self, text: &str) -> usize {
+        if text.is_empty() {
+            return 0;
+        }
+        match self.bpe {
+            Tokenizer::Heuristic => {
+                let cpt = if self.chars_per_token > 0.0 {
+                    self.chars_per_token as f64
+                } else {
+                    3.5
+                };
+                (text.len() as f64 / cpt).ceil() as usize
+            }
+            tk => tk.count(text),
         }
     }
 }
@@ -573,6 +643,7 @@ fn default_tokenizer_variants() -> BTreeMap<String, TokenizerProfile> {
         "anthropic_class".into(),
         TokenizerProfile {
             chars_per_token: 3.5,
+            bpe: Tokenizer::O200kBase,
             inline_json_cost: 2.2,
             toon_overhead: 1.13,
             format_factors: BTreeMap::new(),
@@ -582,6 +653,17 @@ fn default_tokenizer_variants() -> BTreeMap<String, TokenizerProfile> {
         "openai_o200k".into(),
         TokenizerProfile {
             chars_per_token: 4.0,
+            bpe: Tokenizer::O200kBase,
+            inline_json_cost: 1.0,
+            toon_overhead: 0.60,
+            format_factors: BTreeMap::new(),
+        },
+    );
+    m.insert(
+        "openai_cl100k".into(),
+        TokenizerProfile {
+            chars_per_token: 3.7,
+            bpe: Tokenizer::Cl100kBase,
             inline_json_cost: 1.0,
             toon_overhead: 0.60,
             format_factors: BTreeMap::new(),
@@ -591,6 +673,7 @@ fn default_tokenizer_variants() -> BTreeMap<String, TokenizerProfile> {
         "ollama_bpe".into(),
         TokenizerProfile {
             chars_per_token: 3.8,
+            bpe: Tokenizer::Heuristic,
             inline_json_cost: 1.0,
             toon_overhead: 1.00,
             format_factors: BTreeMap::new(),
@@ -1634,5 +1717,53 @@ recursion_depth = 6
         let t = TemplatesConfig::default();
         assert!(!t.is_template_active("not_a_real_template"));
         assert!(t.is_template_active("csv_from_md"));
+    }
+
+    #[test]
+    fn tokenizer_profile_heuristic_uses_chars_per_token() {
+        let p = TokenizerProfile {
+            chars_per_token: 4.0,
+            bpe: Tokenizer::Heuristic,
+            ..Default::default()
+        };
+        // 8 chars / 4.0 = 2 tokens
+        assert_eq!(p.count_tokens("abcdefgh"), 2);
+        // empty stays zero regardless of chars_per_token
+        assert_eq!(p.count_tokens(""), 0);
+    }
+
+    #[test]
+    fn tokenizer_profile_bpe_overrides_heuristic() {
+        let p = TokenizerProfile {
+            // Deliberately wrong cpt — should be ignored when bpe is set.
+            chars_per_token: 1.0,
+            bpe: Tokenizer::O200kBase,
+            ..Default::default()
+        };
+        // BPE count is small for "hello world", definitely not 11 (= 11 chars / 1.0).
+        let n = p.count_tokens("hello world");
+        assert!(n > 0 && n < 5, "BPE should win, got {n}");
+    }
+
+    #[test]
+    fn default_tokenizer_variants_have_real_bpe_for_modern_models() {
+        let variants = default_tokenizer_variants();
+        assert_eq!(
+            variants.get("anthropic_class").unwrap().bpe,
+            Tokenizer::O200kBase
+        );
+        assert_eq!(
+            variants.get("openai_o200k").unwrap().bpe,
+            Tokenizer::O200kBase
+        );
+        assert_eq!(
+            variants.get("openai_cl100k").unwrap().bpe,
+            Tokenizer::Cl100kBase
+        );
+        // Ollama-class models keep the heuristic until we ship a per-model BPE.
+        assert_eq!(
+            variants.get("ollama_bpe").unwrap().bpe,
+            Tokenizer::Heuristic
+        );
     }
 }

--- a/crates/plugins/format-pipeline/src/dedup.rs
+++ b/crates/plugins/format-pipeline/src/dedup.rs
@@ -44,8 +44,11 @@
 //! ```
 
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
+
+use crate::near_ref::{DeltaField, NearRefConfig, extract_delta};
 
 /// 128-bit content fingerprint (first 16 bytes of SHA-256).
 pub type ContentHash = [u8; 16];
@@ -103,6 +106,11 @@ struct CacheEntry {
     /// Anonymized hash of the primary file-path argument (None for non-file
     /// tools). Used as the invalidation key.
     file_path_hash: Option<String>,
+    /// Optional cached body for Type-2 (near-duplicate) reference hints.
+    /// Populated only when the caller used `insert_with_body` (i.e. when
+    /// `dedup.near_ref_enabled` is on). `Arc<String>` keeps cloning
+    /// cheap when the cache holds multiple references to the same body.
+    body_snapshot: Option<Arc<String>>,
 }
 
 /// Session-scoped deduplication cache.
@@ -177,15 +185,74 @@ impl DedupCache {
         tool_kind: ToolKind,
         file_path_hash: Option<String>,
     ) {
+        self.insert_inner(hash, tool_call_id.into(), tool_kind, file_path_hash, None);
+    }
+
+    /// Insert a fresh response and retain its body for Type-2
+    /// (near-duplicate) hint extraction. Used when
+    /// `dedup.near_ref_enabled` is on; otherwise prefer [`Self::insert`]
+    /// to avoid the extra allocation.
+    pub fn insert_with_body(
+        &mut self,
+        hash: ContentHash,
+        tool_call_id: impl Into<String>,
+        tool_kind: ToolKind,
+        file_path_hash: Option<String>,
+        body: Arc<String>,
+    ) {
+        self.insert_inner(
+            hash,
+            tool_call_id.into(),
+            tool_kind,
+            file_path_hash,
+            Some(body),
+        );
+    }
+
+    fn insert_inner(
+        &mut self,
+        hash: ContentHash,
+        tool_call_id: String,
+        tool_kind: ToolKind,
+        file_path_hash: Option<String>,
+        body_snapshot: Option<Arc<String>>,
+    ) {
         if self.entries.len() >= self.capacity {
             self.entries.pop_front();
         }
         self.entries.push_back(CacheEntry {
             hash,
-            tool_call_id: tool_call_id.into(),
+            tool_call_id,
             tool_kind,
             file_path_hash,
+            body_snapshot,
         });
+    }
+
+    /// Look for a Type-2 near-duplicate match in the cache. Walks entries
+    /// from newest to oldest; the first one whose retained body produces
+    /// a valid delta against `new_body` (per [`extract_delta`]) wins.
+    /// Returns the matched `tool_call_id` plus the field-level deltas.
+    ///
+    /// Returns `None` when:
+    /// - no entry has a body snapshot,
+    /// - no entry's delta against `new_body` clears the eligibility
+    ///   gate (size, scalar-only, key-set match),
+    /// - or `new_body` itself is too short to bother.
+    pub fn find_near_ref(
+        &self,
+        new_body: &str,
+        config: &NearRefConfig,
+    ) -> Option<(String, Vec<DeltaField>)> {
+        for entry in self.entries.iter().rev() {
+            let Some(body) = entry.body_snapshot.as_ref() else {
+                continue;
+            };
+            if let Some(deltas) = extract_delta(body.as_str(), new_body, config) {
+                return Some((entry.tool_call_id.clone(), deltas));
+            }
+        }
+        None
     }
 
     /// Invalidate all cached `FileRead` entries whose path hash matches.

--- a/crates/plugins/format-pipeline/src/layered_pipeline.rs
+++ b/crates/plugins/format-pipeline/src/layered_pipeline.rs
@@ -240,14 +240,67 @@ impl LayeredPipeline {
             return out;
         }
 
-        // Not a duplicate — insert into cache for future reference.
+        // Not byte-identical — try Type-2 (near-duplicate) hint when
+        // enabled. The cache must hold a body snapshot for at least one
+        // matching prior entry; otherwise this is a no-op fall-through
+        // to L1.
+        if endpoint_ok && self.config.dedup.near_ref_enabled {
+            let near_cfg = crate::near_ref::NearRefConfig::default();
+            if let Some((reference_tool_call_id, deltas)) =
+                self.dedup.find_near_ref(input.content, &near_cfg)
+            {
+                let hint = crate::near_ref::render_near_ref_hint(&reference_tool_call_id, &deltas);
+                let tokens_final = self.tokens(&hint);
+                let out = ProcessedResponse {
+                    output: hint,
+                    layer: Layer::L0,
+                    format_or_template: Some("hint_near".into()),
+                    tokens_saved: baseline_tokens as i64 - tokens_final as i64,
+                    tokens_final,
+                };
+                self.emit_event(
+                    &input,
+                    &out,
+                    None,
+                    Some(&content_sha_hex),
+                    file_path_hash.as_deref(),
+                    None,
+                );
+                // Even on a near-ref hit, still cache the *new* body so
+                // a later turn that drifts further can build a delta off
+                // the most recent state.
+                let tc_hash = short_hash(input.tool_call_id);
+                self.dedup.insert_with_body(
+                    content_hash_value,
+                    tc_hash,
+                    tool_kind,
+                    file_path_hash.clone(),
+                    std::sync::Arc::new(input.content.to_string()),
+                );
+                return out;
+            }
+        }
+
+        // Not a duplicate — insert into cache for future reference. When
+        // near-ref is enabled, also retain the body so future turns can
+        // diff against it; otherwise stick to the cheaper hash-only entry.
         let tc_hash = short_hash(input.tool_call_id);
-        self.dedup.insert(
-            content_hash_value,
-            tc_hash.clone(),
-            tool_kind,
-            file_path_hash.clone(),
-        );
+        if self.config.dedup.near_ref_enabled {
+            self.dedup.insert_with_body(
+                content_hash_value,
+                tc_hash.clone(),
+                tool_kind,
+                file_path_hash.clone(),
+                std::sync::Arc::new(input.content.to_string()),
+            );
+        } else {
+            self.dedup.insert(
+                content_hash_value,
+                tc_hash.clone(),
+                tool_kind,
+                file_path_hash.clone(),
+            );
+        }
 
         // === Shape classification (used by L1/L2) ===
         let classified = classify(input.content);
@@ -711,6 +764,65 @@ mod tests {
             bpe_count < heuristic,
             "expected BPE count {bpe_count} < heuristic {heuristic} on a degenerate input"
         );
+    }
+
+    #[test]
+    fn near_ref_enabled_emits_delta_hint_for_pipeline_polling() {
+        // Two responses to the same MCP endpoint differing only in
+        // `status` and `duration` — the canonical Type-2 case.
+        let body_a = format!(
+            r#"{{"id":42,"name":"deploy","status":"pending","duration":10,"url":"https://example.com/p/42","commit_sha":"abcd","triggered_by":"webhook","preview":"{}"}}"#,
+            "x".repeat(500)
+        );
+        let body_b = format!(
+            r#"{{"id":42,"name":"deploy","status":"success","duration":42,"url":"https://example.com/p/42","commit_sha":"abcd","triggered_by":"webhook","preview":"{}"}}"#,
+            "x".repeat(500)
+        );
+
+        let mut cfg = AdaptiveConfig::default();
+        cfg.dedup.near_ref_enabled = true;
+        let mut p = LayeredPipeline::new("s_near".into(), cfg);
+
+        let r1 = p.process(input("tc_pipeline_1", "Bash", None, &body_a));
+        assert_eq!(r1.layer, Layer::L3, "first call must be fresh");
+
+        let r2 = p.process(input("tc_pipeline_2", "Bash", None, &body_b));
+        assert_eq!(r2.layer, Layer::L0, "second call must hit L0 via near-ref");
+        assert_eq!(r2.format_or_template.as_deref(), Some("hint_near"));
+        assert!(
+            r2.output.contains("near-ref"),
+            "expected near-ref hint, got `{}`",
+            r2.output
+        );
+        // Both differing scalar fields must show in the hint.
+        assert!(r2.output.contains("status"));
+        assert!(r2.output.contains("duration"));
+        // Compaction-friendly bound — the rendered hint must be tiny.
+        assert!(
+            r2.output.len() < body_b.len() / 5,
+            "near-ref hint should be far smaller than the body"
+        );
+    }
+
+    #[test]
+    fn near_ref_disabled_falls_through_when_bodies_drift() {
+        let body_a = format!(
+            r#"{{"id":42,"status":"pending","preview":"{}"}}"#,
+            "x".repeat(500)
+        );
+        let body_b = format!(
+            r#"{{"id":42,"status":"success","preview":"{}"}}"#,
+            "x".repeat(500)
+        );
+
+        let mut cfg = AdaptiveConfig::default();
+        cfg.dedup.near_ref_enabled = false; // explicit
+        let mut p = LayeredPipeline::new("s_no_near".into(), cfg);
+        let _ = p.process(input("tc_a", "Bash", None, &body_a));
+        let r2 = p.process(input("tc_b", "Bash", None, &body_b));
+        // Without near-ref, the second call goes to L3 (or L2 if shape
+        // happens to match) — but never to L0/hint_near.
+        assert_ne!(r2.format_or_template.as_deref(), Some("hint_near"));
     }
 
     #[test]

--- a/crates/plugins/format-pipeline/src/layered_pipeline.rs
+++ b/crates/plugins/format-pipeline/src/layered_pipeline.rs
@@ -52,7 +52,6 @@ use crate::adaptive_config::AdaptiveConfig;
 use crate::dedup::{DedupCache, DedupDecision, ToolKind, content_hash, render_reference_hint_with};
 use crate::shape::{ClassifiedResponse, classify};
 use crate::telemetry::{Layer, PipelineEvent, Shape, TelemetrySink};
-use crate::token_counter::Tokenizer;
 
 /// Input to [`LayeredPipeline::process`].
 #[derive(Debug, Clone, Copy)]
@@ -87,16 +86,6 @@ pub struct ProcessedResponse {
     pub tokens_saved: i64,
     /// Token count of the `output` we're returning.
     pub tokens_final: u32,
-}
-
-/// Legacy `chars/4` token approximation matching the Python research
-/// extractor. Used as a hot-path fallback when the pipeline's adaptive
-/// config selects `Tokenizer::Heuristic` (i.e. has not been pointed at a
-/// real BPE table). Pipeline-internal callers go through
-/// [`LayeredPipeline::tokens`], which honours the config.
-#[inline]
-fn est_tokens(chars: usize) -> u32 {
-    (chars.max(4) / 4) as u32
 }
 
 /// Session-scoped layered pipeline.
@@ -160,17 +149,14 @@ impl LayeredPipeline {
 
     /// Token count for `text` under the active tokenizer profile.
     ///
-    /// Honours `profiles.tokenizer.active`: when the resolved profile uses
-    /// `Tokenizer::Heuristic`, falls back to the legacy `chars/4` approximation
-    /// (kept in sync with the Python extractor) so existing telemetry stays
-    /// stable. When a real BPE profile is selected, returns the exact count.
+    /// Always routed through [`TokenizerProfile::count_tokens`] so a
+    /// custom `chars_per_token` set in `[profiles.tokenizer.variants]`
+    /// actually takes effect — earlier versions hard-coded `chars/4`
+    /// for the heuristic branch and silently ignored the config knob.
+    /// For Python-extractor parity, the matching variant ships
+    /// `chars_per_token = 4.0`.
     fn tokens(&self, text: &str) -> u32 {
-        let profile = self.config.effective_tokenizer_profile();
-        if profile.bpe == Tokenizer::Heuristic {
-            est_tokens(text.len())
-        } else {
-            profile.count_tokens(text) as u32
-        }
+        self.config.effective_tokenizer_profile().count_tokens(text) as u32
     }
 
     /// Dispatch a tool response through the 4-layer pipeline.
@@ -826,15 +812,16 @@ mod tests {
     }
 
     #[test]
-    fn tokens_method_uses_heuristic_when_profile_is_heuristic() {
+    fn tokens_method_honours_profile_chars_per_token() {
         let mut cfg = AdaptiveConfig::default();
-        // Force the active tokenizer to ollama_bpe, which is configured with
-        // Tokenizer::Heuristic — that path must hit the legacy chars/4 fallback.
+        // Force the active tokenizer to `ollama_bpe`, which ships
+        // `chars_per_token = 3.8` and `bpe = Heuristic`. The pipeline
+        // must respect the configured ratio (8 / 3.8 ≈ 2.1 → 3 tokens
+        // after ceil); earlier versions silently hard-coded chars/4
+        // and produced 2 instead — Copilot review on PR #207.
         cfg.profiles.tokenizer.active = "ollama_bpe".into();
         let p = LayeredPipeline::new("s_h".into(), cfg);
         let body = "abcdefgh"; // 8 chars
-        // chars/4 → 2 tokens. Confirm the legacy formula is preserved so that
-        // existing telemetry/snapshot tests downstream don't shift.
-        assert_eq!(p.tokens(body), 2);
+        assert_eq!(p.tokens(body), 3);
     }
 }

--- a/crates/plugins/format-pipeline/src/layered_pipeline.rs
+++ b/crates/plugins/format-pipeline/src/layered_pipeline.rs
@@ -150,6 +150,14 @@ impl LayeredPipeline {
         self.dedup.partition()
     }
 
+    /// Drop every cache entry tagged with `file_path`. Called by the host
+    /// after a mutating tool (`Edit` / `Write` / `MultiEdit` / …) so the
+    /// next `Read` of the same file returns the fresh body, not a hint.
+    pub fn invalidate_file(&mut self, file_path: &str) -> usize {
+        let hash = crate::dedup_util::file_path_hash(file_path);
+        self.dedup.invalidate_file(&hash)
+    }
+
     /// Token count for `text` under the active tokenizer profile.
     ///
     /// Honours `profiles.tokenizer.active`: when the resolved profile uses

--- a/crates/plugins/format-pipeline/src/layered_pipeline.rs
+++ b/crates/plugins/format-pipeline/src/layered_pipeline.rs
@@ -52,6 +52,7 @@ use crate::adaptive_config::AdaptiveConfig;
 use crate::dedup::{DedupCache, DedupDecision, ToolKind, content_hash, render_reference_hint_with};
 use crate::shape::{ClassifiedResponse, classify};
 use crate::telemetry::{Layer, PipelineEvent, Shape, TelemetrySink};
+use crate::token_counter::Tokenizer;
 
 /// Input to [`LayeredPipeline::process`].
 #[derive(Debug, Clone, Copy)]
@@ -88,8 +89,11 @@ pub struct ProcessedResponse {
     pub tokens_final: u32,
 }
 
-/// Convert char count to a token estimate.
-/// Matches the Python extractor's `chars/4` approximation — keep in sync.
+/// Legacy `chars/4` token approximation matching the Python research
+/// extractor. Used as a hot-path fallback when the pipeline's adaptive
+/// config selects `Tokenizer::Heuristic` (i.e. has not been pointed at a
+/// real BPE table). Pipeline-internal callers go through
+/// [`LayeredPipeline::tokens`], which honours the config.
 #[inline]
 fn est_tokens(chars: usize) -> u32 {
     (chars.max(4) / 4) as u32
@@ -146,10 +150,25 @@ impl LayeredPipeline {
         self.dedup.partition()
     }
 
+    /// Token count for `text` under the active tokenizer profile.
+    ///
+    /// Honours `profiles.tokenizer.active`: when the resolved profile uses
+    /// `Tokenizer::Heuristic`, falls back to the legacy `chars/4` approximation
+    /// (kept in sync with the Python extractor) so existing telemetry stays
+    /// stable. When a real BPE profile is selected, returns the exact count.
+    fn tokens(&self, text: &str) -> u32 {
+        let profile = self.config.effective_tokenizer_profile();
+        if profile.bpe == Tokenizer::Heuristic {
+            est_tokens(text.len())
+        } else {
+            profile.count_tokens(text) as u32
+        }
+    }
+
     /// Dispatch a tool response through the 4-layer pipeline.
     pub fn process(&mut self, input: ToolResponseInput<'_>) -> ProcessedResponse {
         self.event_counter += 1;
-        let baseline_tokens = est_tokens(input.content.len());
+        let baseline_tokens = self.tokens(input.content);
 
         // Mutation-aware invalidation must fire even for tiny Edit responses —
         // the invalidation itself is correctness-critical, not an optimization.
@@ -194,7 +213,7 @@ impl LayeredPipeline {
                 self.config.dedup.hint_verbosity.to_runtime(),
                 Some(tool_kind),
             );
-            let tokens_final = est_tokens(hint.len());
+            let tokens_final = self.tokens(&hint);
             let out = ProcessedResponse {
                 output: hint,
                 layer: Layer::L0,
@@ -233,7 +252,7 @@ impl LayeredPipeline {
             && self.config.templates.is_template_active(&t_id)
             && let Some(body) = crate::templates::apply_by_id(&t_id, input.content, &classified)
         {
-            let tokens_final = est_tokens(body.len());
+            let tokens_final = self.tokens(&body);
             if tokens_final < baseline_tokens {
                 let out = ProcessedResponse {
                     output: body,
@@ -258,7 +277,7 @@ impl LayeredPipeline {
         if let Some((fmt_id, body)) =
             crate::mckp_router::route(&self.config.mckp, input.content, &classified)
         {
-            let tokens_final = est_tokens(body.len());
+            let tokens_final = self.tokens(&body);
             if tokens_final < baseline_tokens {
                 let out = ProcessedResponse {
                     output: body,
@@ -352,7 +371,7 @@ impl LayeredPipeline {
             is_dedup_hit: matches!(out.layer, Layer::L0),
             layer_used: out.layer,
             template_id: template_id.map(String::from),
-            tokens_baseline: est_tokens(input.content.len()),
+            tokens_baseline: self.tokens(input.content),
             tokens_final: out.tokens_final,
             context_partition: self.dedup.partition() as u32,
             is_sidechain: input.is_sidechain,
@@ -665,5 +684,37 @@ mod tests {
         // First entry now evicted (capacity 12), so recalling it should be Fresh.
         let o = p.process(input("tc_recheck", "Bash", None, &distinct[0]));
         assert_eq!(o.layer, Layer::L3);
+    }
+
+    #[test]
+    fn tokens_method_falls_back_to_heuristic_by_default() {
+        let cfg = AdaptiveConfig::default();
+        // Default profile is "auto" → resolves to anthropic_class which now
+        // selects O200kBase BPE. Pipeline.tokens should therefore *not* match
+        // the legacy chars/4 estimate on a sufficiently long body.
+        let p = LayeredPipeline::new("s_tk".into(), cfg);
+        let body = "a".repeat(2_000);
+        let bpe_count = p.tokens(&body);
+        let heuristic = (body.len() / 4) as u32;
+        // BPE on a long run of a single character compresses much better than
+        // chars/4 — assert they differ (and BPE is smaller, the whole point of
+        // bringing in tiktoken-rs).
+        assert!(
+            bpe_count < heuristic,
+            "expected BPE count {bpe_count} < heuristic {heuristic} on a degenerate input"
+        );
+    }
+
+    #[test]
+    fn tokens_method_uses_heuristic_when_profile_is_heuristic() {
+        let mut cfg = AdaptiveConfig::default();
+        // Force the active tokenizer to ollama_bpe, which is configured with
+        // Tokenizer::Heuristic — that path must hit the legacy chars/4 fallback.
+        cfg.profiles.tokenizer.active = "ollama_bpe".into();
+        let p = LayeredPipeline::new("s_h".into(), cfg);
+        let body = "abcdefgh"; // 8 chars
+        // chars/4 → 2 tokens. Confirm the legacy formula is preserved so that
+        // existing telemetry/snapshot tests downstream don't shift.
+        assert_eq!(p.tokens(body), 2);
     }
 }

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -40,6 +40,7 @@ pub mod tree;
 pub mod trim;
 pub mod truncation;
 
+pub use token_counter::{Tokenizer, estimate_tokens, tokens_to_chars};
 pub use truncation::TruncationPlugin;
 
 use devboy_core::{Comment, Discussion, FileDiff, Issue, MergeRequest, Result};

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -30,6 +30,7 @@ pub mod layered_pipeline;
 pub mod mckp_router;
 pub mod page_index;
 pub mod pagination;
+pub mod round_trip;
 pub mod shape;
 pub mod strategy;
 pub mod telemetry;

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -28,6 +28,7 @@ pub mod dedup;
 pub(crate) mod dedup_util;
 pub mod layered_pipeline;
 pub mod mckp_router;
+pub mod near_ref;
 pub mod page_index;
 pub mod pagination;
 pub mod round_trip;

--- a/crates/plugins/format-pipeline/src/lib.rs
+++ b/crates/plugins/format-pipeline/src/lib.rs
@@ -54,6 +54,21 @@ fn estimate_tokens_from_chars(chars: usize) -> usize {
     (chars as f64 / 3.5).ceil() as usize
 }
 
+/// Serialize a `Serialize` slice to JSON pretty, then route the JSON
+/// through the L2 MCKP shape dispatcher. Falls back to the pretty-printed
+/// JSON when no shape applies. The L0 dedup layer is host-side (per
+/// session) and is wired separately in P-203-04.
+fn encode_mckp<T: serde::Serialize>(items: &[T]) -> Result<String> {
+    let json = serde_json::to_string_pretty(items)?;
+    let cls = shape::classify(&json);
+    let cfg = adaptive_config::MckpConfig::default();
+    if let Some((_id, body)) = mckp_router::route(&cfg, &json, &cls) {
+        Ok(body)
+    } else {
+        Ok(json)
+    }
+}
+
 /// Output from a pipeline transformation.
 ///
 /// Contains the transformed data and metadata about truncation/pagination.
@@ -183,10 +198,19 @@ impl Default for PipelineConfig {
 /// Output format for transformations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputFormat {
-    /// TOON format (default) -- token-optimized, saves 39-90% vs JSON
+    /// TOON format -- token-optimized custom format. Wins on `cl100k_base`
+    /// tokenizers but *loses* ~26% on `o200k_base` (the modern Anthropic /
+    /// OpenAI family). Kept as a baseline; not the recommended default.
+    /// See Paper 2 §Savings Accounting.
     Toon,
-    /// JSON format -- for programmatic processing
+    /// JSON pretty-printed -- for programmatic processing.
     Json,
+    /// MCKP v2 -- format-adaptive encoder dispatched by structural shape.
+    /// Routes object-wrapping-array shapes through the union-of-keys table
+    /// renderer (`deep_mckp_with_inner_table`) and falls back to compact
+    /// JSON when no shape applies. Tokenizer-agnostic — see Paper 2
+    /// §Encoder Bug Postmortem and §Savings Accounting.
+    Mckp,
 }
 
 /// Pipeline for chaining output transformations.
@@ -217,6 +241,7 @@ impl Pipeline {
         let full_content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&issues)?,
             OutputFormat::Toon => toon::encode_issues(&issues, toon::TrimLevel::Full)?,
+            OutputFormat::Mckp => encode_mckp(&issues)?,
         };
 
         if self.config.max_chars == 0 || full_content.len() <= self.config.max_chars {
@@ -237,6 +262,7 @@ impl Pipeline {
             let content = match self.config.format {
                 OutputFormat::Json => serde_json::to_string_pretty(chunk_items)?,
                 OutputFormat::Toon => toon::encode_issues(chunk_items, toon::TrimLevel::Full)?,
+                OutputFormat::Mckp => encode_mckp(chunk_items)?,
             };
             let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
             output.included_count = chunk_items.len();
@@ -266,6 +292,7 @@ impl Pipeline {
         let full_content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&mrs)?,
             OutputFormat::Toon => toon::encode_merge_requests(&mrs, toon::TrimLevel::Full)?,
+            OutputFormat::Mckp => encode_mckp(&mrs)?,
         };
 
         if self.config.max_chars == 0 || full_content.len() <= self.config.max_chars {
@@ -286,6 +313,7 @@ impl Pipeline {
                 OutputFormat::Toon => {
                     toon::encode_merge_requests(chunk_items, toon::TrimLevel::Full)?
                 }
+                OutputFormat::Mckp => encode_mckp(chunk_items)?,
             };
             let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
             output.included_count = chunk_items.len();
@@ -327,6 +355,7 @@ impl Pipeline {
         let full_content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&diffs)?,
             OutputFormat::Toon => toon::encode_diffs(&diffs)?,
+            OutputFormat::Mckp => encode_mckp(&diffs)?,
         };
 
         if self.config.max_chars == 0 || full_content.len() <= self.config.max_chars {
@@ -345,6 +374,7 @@ impl Pipeline {
             let content = match self.config.format {
                 OutputFormat::Json => serde_json::to_string_pretty(chunk_items)?,
                 OutputFormat::Toon => toon::encode_diffs(chunk_items)?,
+                OutputFormat::Mckp => encode_mckp(chunk_items)?,
             };
             let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
             output.included_count = chunk_items.len();
@@ -373,6 +403,7 @@ impl Pipeline {
         let full_content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&comments)?,
             OutputFormat::Toon => toon::encode_comments(&comments)?,
+            OutputFormat::Mckp => encode_mckp(&comments)?,
         };
 
         if self.config.max_chars == 0 || full_content.len() <= self.config.max_chars {
@@ -391,6 +422,7 @@ impl Pipeline {
             let content = match self.config.format {
                 OutputFormat::Json => serde_json::to_string_pretty(chunk_items)?,
                 OutputFormat::Toon => toon::encode_comments(chunk_items)?,
+                OutputFormat::Mckp => encode_mckp(chunk_items)?,
             };
             let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
             output.included_count = chunk_items.len();
@@ -419,6 +451,7 @@ impl Pipeline {
         let full_content = match self.config.format {
             OutputFormat::Json => serde_json::to_string_pretty(&discussions)?,
             OutputFormat::Toon => toon::encode_discussions(&discussions)?,
+            OutputFormat::Mckp => encode_mckp(&discussions)?,
         };
 
         if self.config.max_chars == 0 || full_content.len() <= self.config.max_chars {
@@ -437,6 +470,7 @@ impl Pipeline {
             let content = match self.config.format {
                 OutputFormat::Json => serde_json::to_string_pretty(chunk_items)?,
                 OutputFormat::Toon => toon::encode_discussions(chunk_items)?,
+                OutputFormat::Mckp => encode_mckp(chunk_items)?,
             };
             let mut output = TransformOutput::new(content).with_raw_chars(raw_chars);
             output.included_count = chunk_items.len();
@@ -1200,5 +1234,57 @@ mod tests {
             toon_output.content.len(),
             json_output.content.len()
         );
+    }
+
+    #[test]
+    fn test_mckp_routes_issues_through_inner_table() {
+        let issues: Vec<Issue> = sample_issues().into_iter().take(10).collect();
+
+        let mckp_pipeline = Pipeline::with_config(PipelineConfig {
+            format: OutputFormat::Mckp,
+            max_chars: 1_000_000,
+            ..Default::default()
+        });
+        let json_pipeline = Pipeline::with_config(PipelineConfig {
+            format: OutputFormat::Json,
+            max_chars: 1_000_000,
+            ..Default::default()
+        });
+
+        let mckp_out = mckp_pipeline.transform_issues(issues.clone()).unwrap();
+        let json_out = json_pipeline.transform_issues(issues).unwrap();
+
+        // MCKP must beat the pretty-printed JSON baseline on this shape
+        // (array of objects → routes to `csv` via try_array_csv).
+        assert!(
+            mckp_out.content.len() < json_out.content.len(),
+            "MCKP ({}) should be smaller than JSON ({})",
+            mckp_out.content.len(),
+            json_out.content.len(),
+        );
+        // Round-trip key parity: every Issue field still appears in the
+        // output (the encoder bug regression).
+        for k in ["key", "title", "state", "source"] {
+            assert!(
+                mckp_out.content.contains(k),
+                "MCKP output is missing field `{k}`: {}",
+                &mckp_out.content[..mckp_out.content.len().min(200)]
+            );
+        }
+    }
+
+    #[test]
+    fn test_mckp_falls_back_to_pretty_json_on_unstable_keys() {
+        // Single issue → array length 1, below the min_items threshold for
+        // try_array_csv. encode_mckp must not crash; it should fall back
+        // to the pretty JSON.
+        let issues: Vec<Issue> = sample_issues().into_iter().take(1).collect();
+        let mckp_pipeline = Pipeline::with_config(PipelineConfig {
+            format: OutputFormat::Mckp,
+            max_chars: 1_000_000,
+            ..Default::default()
+        });
+        let out = mckp_pipeline.transform_issues(issues).unwrap();
+        assert!(out.content.contains("gh#1"));
     }
 }

--- a/crates/plugins/format-pipeline/src/near_ref.rs
+++ b/crates/plugins/format-pipeline/src/near_ref.rs
@@ -83,7 +83,6 @@ pub fn extract_delta(
     }
 
     let mut deltas = Vec::new();
-    let mut delta_bytes = 0usize;
     for (k, new_val) in new_obj {
         let old_val = match old_obj.get(k) {
             Some(v) => v,
@@ -98,19 +97,19 @@ pub fn extract_delta(
         if !is_scalar(old_val) || !is_scalar(new_val) {
             return None;
         }
-        let old_s = scalar_to_string(old_val);
-        let new_s = scalar_to_string(new_val);
-        // Approximate the on-wire size: `key: old→new, ` (plus separators
-        // amortised). The exact framing overhead is added by the caller.
-        delta_bytes += k.len() + old_s.len() + new_s.len() + 4; // ": ", "→"
-        if delta_bytes > config.max_delta_bytes {
-            return None;
-        }
         deltas.push(DeltaField {
             key: k.clone(),
-            old: old_s,
-            new: new_s,
+            old: scalar_to_string(old_val),
+            new: scalar_to_string(new_val),
         });
+    }
+
+    // Size the eligibility gate against the *actually rendered* delta
+    // payload — the previous +4 approximation under-counted the UTF-8
+    // arrow (`→` is 3 bytes) and the `", "`/`": "` separators, which
+    // could let near-ref hints exceed `max_delta_bytes`.
+    if rendered_delta_bytes(&deltas) > config.max_delta_bytes {
+        return None;
     }
 
     // No diff at all → caller should emit a full byte-identical hint
@@ -120,6 +119,23 @@ pub fn extract_delta(
         return None;
     }
     Some(deltas)
+}
+
+/// Size in bytes of the delta payload as it appears in the rendered hint
+/// (i.e. the part after `> [near-ref: <id>` and before the closing `]`).
+/// Mirrors [`render_near_ref_hint`] precisely so `max_delta_bytes` gates
+/// what actually goes on the wire, not an approximation.
+fn rendered_delta_bytes(deltas: &[DeltaField]) -> usize {
+    let mut frag = String::new();
+    for d in deltas {
+        frag.push_str(", ");
+        frag.push_str(&d.key);
+        frag.push_str(": ");
+        frag.push_str(&d.old);
+        frag.push('→');
+        frag.push_str(&d.new);
+    }
+    frag.len()
 }
 
 fn is_scalar(v: &serde_json::Value) -> bool {

--- a/crates/plugins/format-pipeline/src/near_ref.rs
+++ b/crates/plugins/format-pipeline/src/near_ref.rs
@@ -1,0 +1,281 @@
+//! Type-2 (near-duplicate) reference hints — Paper 2 §Near-reference.
+//!
+//! When the L0 cache holds a body that is *not* byte-identical to the
+//! current response but differs only in a few enumerated fields, we
+//! emit a compact delta hint instead of the full body or a full
+//! reference hint. The canonical case is pipeline polling: two calls
+//! to `get_pipeline(id=42)` differing only in `status` and `duration`.
+//!
+//! ```text
+//! > [near-ref: tc_42, status: pending→success, duration: +22s]
+//! ```
+//!
+//! Eligibility (per the paper):
+//!
+//! - Both inputs must be valid JSON objects.
+//! - Their top-level key sets must match (no fields added or removed).
+//! - The **delta payload** (rendered hint minus framing) must be
+//!   ≤ 30 bytes.
+//! - The full response must be ≥ 500 bytes — savings on shorter
+//!   bodies do not justify the delta-extraction cost.
+//!
+//! The eligibility predicate is conservative: when in doubt, this
+//! module returns `None` and the caller falls back to either a full
+//! reference hint or fresh body.
+
+use std::collections::BTreeSet;
+
+/// One scalar field that differs between two JSON objects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeltaField {
+    pub key: String,
+    pub old: String,
+    pub new: String,
+}
+
+/// Configuration knobs for delta extraction.
+#[derive(Debug, Clone, Copy)]
+pub struct NearRefConfig {
+    /// Maximum total bytes in the rendered delta payload (`status: a→b, …`).
+    pub max_delta_bytes: usize,
+    /// Minimum input body length (bytes) for which a near-ref hint is
+    /// worth emitting. Below this, the full body is cheaper than the
+    /// extraction work.
+    pub min_body_bytes: usize,
+}
+
+impl Default for NearRefConfig {
+    fn default() -> Self {
+        Self {
+            // 50-byte ceiling fits the canonical pipeline-polling case
+            // (status: pending→success, duration: 12→34 ≈ 34 bytes
+            // including framing) while still rejecting cases where
+            // half a dozen fields drifted. Paper text uses 30 as the
+            // payload-only bound, but the runtime sums framing in too.
+            max_delta_bytes: 50,
+            min_body_bytes: 500,
+        }
+    }
+}
+
+/// Try to extract a delta between `old_body` and `new_body`. Returns the
+/// list of differing fields when *all* eligibility checks pass; otherwise
+/// `None` so the caller can fall back to a full ref / fresh body.
+pub fn extract_delta(
+    old_body: &str,
+    new_body: &str,
+    config: &NearRefConfig,
+) -> Option<Vec<DeltaField>> {
+    if new_body.len() < config.min_body_bytes {
+        return None;
+    }
+    let old: serde_json::Value = serde_json::from_str(old_body.trim_start()).ok()?;
+    let new: serde_json::Value = serde_json::from_str(new_body.trim_start()).ok()?;
+    let old_obj = old.as_object()?;
+    let new_obj = new.as_object()?;
+
+    // Top-level key sets must match. A new field appearing means the
+    // shape shifted and a delta hint would be misleading.
+    let old_keys: BTreeSet<&str> = old_obj.keys().map(|s| s.as_str()).collect();
+    let new_keys: BTreeSet<&str> = new_obj.keys().map(|s| s.as_str()).collect();
+    if old_keys != new_keys {
+        return None;
+    }
+
+    let mut deltas = Vec::new();
+    let mut delta_bytes = 0usize;
+    for (k, new_val) in new_obj {
+        let old_val = match old_obj.get(k) {
+            Some(v) => v,
+            None => unreachable!("key sets are equal"),
+        };
+        if old_val == new_val {
+            continue;
+        }
+        // Only scalar diffs round-trip cleanly into a hint. A nested
+        // object difference would balloon the hint and obscure the
+        // delta — refuse the hint and let the caller pass the full body.
+        if !is_scalar(old_val) || !is_scalar(new_val) {
+            return None;
+        }
+        let old_s = scalar_to_string(old_val);
+        let new_s = scalar_to_string(new_val);
+        // Approximate the on-wire size: `key: old→new, ` (plus separators
+        // amortised). The exact framing overhead is added by the caller.
+        delta_bytes += k.len() + old_s.len() + new_s.len() + 4; // ": ", "→"
+        if delta_bytes > config.max_delta_bytes {
+            return None;
+        }
+        deltas.push(DeltaField {
+            key: k.clone(),
+            old: old_s,
+            new: new_s,
+        });
+    }
+
+    // No diff at all → caller should emit a full byte-identical hint
+    // via the regular L0 path, not a near-ref. Returning `None` here
+    // lets the caller distinguish.
+    if deltas.is_empty() {
+        return None;
+    }
+    Some(deltas)
+}
+
+fn is_scalar(v: &serde_json::Value) -> bool {
+    matches!(
+        v,
+        serde_json::Value::Null
+            | serde_json::Value::Bool(_)
+            | serde_json::Value::Number(_)
+            | serde_json::Value::String(_)
+    )
+}
+
+fn scalar_to_string(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => s.clone(),
+        _ => v.to_string(),
+    }
+}
+
+/// Render the near-ref hint for the agent. Single line, matches the
+/// `> [near-ref: <id>, <field>: <old>→<new>, …]` format documented in
+/// Paper 2 §Near-reference.
+pub fn render_near_ref_hint(reference_id: &str, deltas: &[DeltaField]) -> String {
+    let mut out = String::new();
+    out.push_str("> [near-ref: ");
+    out.push_str(reference_id);
+    for d in deltas {
+        out.push_str(", ");
+        out.push_str(&d.key);
+        out.push_str(": ");
+        out.push_str(&d.old);
+        out.push('→');
+        out.push_str(&d.new);
+    }
+    out.push(']');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> NearRefConfig {
+        NearRefConfig::default()
+    }
+
+    fn long_pipeline_body(status: &str, duration: u64) -> String {
+        // Pad with a generic field so the body clears `min_body_bytes`.
+        format!(
+            r#"{{"id":42,"name":"{}","status":"{}","duration":{},"url":"https://example.com/pipelines/42","commit_sha":"deadbeefdeadbeefdeadbeefdeadbeef","ref":"refs/heads/main","author":"alice","triggered_by":"webhook","preview":"{}"}}"#,
+            "p".repeat(20),
+            status,
+            duration,
+            "x".repeat(400)
+        )
+    }
+
+    #[test]
+    fn extracts_status_and_duration_delta_for_pipeline_polling() {
+        let a = long_pipeline_body("pending", 12);
+        let b = long_pipeline_body("success", 34);
+        let deltas = extract_delta(&a, &b, &cfg()).unwrap();
+        assert_eq!(deltas.len(), 2);
+        let keys: BTreeSet<_> = deltas.iter().map(|d| d.key.as_str()).collect();
+        assert!(keys.contains("status"));
+        assert!(keys.contains("duration"));
+    }
+
+    #[test]
+    fn refuses_when_too_short() {
+        // Both bodies are well under min_body_bytes (500).
+        let a = r#"{"a":1,"b":2}"#;
+        let b = r#"{"a":1,"b":3}"#;
+        assert!(extract_delta(a, b, &cfg()).is_none());
+    }
+
+    #[test]
+    fn refuses_when_keys_differ() {
+        let a = format!(r#"{{"a":1,"long":"{}"}}"#, "x".repeat(600));
+        let b = format!(r#"{{"a":1,"different":"{}"}}"#, "x".repeat(600));
+        assert!(extract_delta(&a, &b, &cfg()).is_none());
+    }
+
+    #[test]
+    fn refuses_when_nested_value_changes() {
+        let a = format!(r#"{{"meta":{{"k":1}},"pad":"{}"}}"#, "x".repeat(600));
+        let b = format!(r#"{{"meta":{{"k":2}},"pad":"{}"}}"#, "x".repeat(600));
+        assert!(extract_delta(&a, &b, &cfg()).is_none());
+    }
+
+    #[test]
+    fn refuses_when_delta_blob_too_large() {
+        // Two very long string fields differ — easily exceeds 50 bytes.
+        let a = format!(
+            r#"{{"x":"{}","pad":"{}"}}"#,
+            "a".repeat(80),
+            "p".repeat(600)
+        );
+        let b = format!(
+            r#"{{"x":"{}","pad":"{}"}}"#,
+            "b".repeat(80),
+            "p".repeat(600)
+        );
+        assert!(extract_delta(&a, &b, &cfg()).is_none());
+    }
+
+    #[test]
+    fn returns_none_for_byte_identical_inputs() {
+        // Caller should fall back to the regular byte-identical hint
+        // path rather than treat a zero-delta change as a near-ref.
+        let a = long_pipeline_body("ok", 10);
+        assert!(extract_delta(&a, &a, &cfg()).is_none());
+    }
+
+    #[test]
+    fn render_format_matches_paper_spec() {
+        let deltas = vec![
+            DeltaField {
+                key: "status".into(),
+                old: "pending".into(),
+                new: "success".into(),
+            },
+            DeltaField {
+                key: "duration".into(),
+                old: "12".into(),
+                new: "34".into(),
+            },
+        ];
+        let s = render_near_ref_hint("tc_42", &deltas);
+        assert_eq!(
+            s,
+            "> [near-ref: tc_42, status: pending→success, duration: 12→34]"
+        );
+    }
+
+    #[test]
+    fn hint_size_under_paper_budget() {
+        // Paper 2 §Hint Cost Model targets ≤ 18 cl100k_base tokens for
+        // a typical near-ref hint. We assert byte length as a proxy
+        // (≤ 70 bytes ≈ 18 tokens on average for ASCII).
+        let deltas = vec![
+            DeltaField {
+                key: "status".into(),
+                old: "pending".into(),
+                new: "success".into(),
+            },
+            DeltaField {
+                key: "duration".into(),
+                old: "12".into(),
+                new: "34".into(),
+            },
+        ];
+        let s = render_near_ref_hint("tc_42", &deltas);
+        assert!(s.len() <= 70, "near-ref hint too long: {} bytes", s.len());
+    }
+}

--- a/crates/plugins/format-pipeline/src/round_trip.rs
+++ b/crates/plugins/format-pipeline/src/round_trip.rs
@@ -1,0 +1,496 @@
+//! Round-trip correctness gate for L1 / L2 encoders.
+//!
+//! Paper 2 §Encoder Bug Postmortem (2026-04-25) describes a class of
+//! silent data-loss bugs where the chosen encoder produced shorter output
+//! at the cost of dropping wrapping fields or nested-object cells. The
+//! `mckp_v2` encoder (`deep_mckp_with_inner_table`) was the fix; this
+//! module is the regression test that ensures no future change re-introduces
+//! the bug.
+//!
+//! Each registered encoder declares its [`DataLoss`] guarantee:
+//!
+//! - [`DataLoss::None`] — every top-level and nested key in the input must
+//!   appear (textually) in the output. `mckp_v2` and `json_compact` must
+//!   meet this bar.
+//! - [`DataLoss::TopLevel`] — wrapping object's top-level fields are
+//!   intentionally dropped. Naive `csv` / `markdown_table` are in this
+//!   category and **may not be selected as the production default** (see
+//!   §Implementation Status migration warning).
+//! - [`DataLoss::Nested`] — nested values inside otherwise-preserved
+//!   wrappers may be flattened or dropped.
+//!
+//! The `round_trip_keys` API parses the encoded form back to a textual key
+//! set and compares it against the input. The shape of "decoder" is
+//! deliberately tolerant — we only check membership of key strings, not
+//! type fidelity, since the encoders are explicitly token-saving and not
+//! always type-lossless.
+
+use std::collections::BTreeSet;
+
+/// Whether an encoder is allowed to drop input keys, and where.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataLoss {
+    /// Encoder must preserve every input key (top-level and nested).
+    /// Failing this is a bug.
+    None,
+    /// Encoder may drop the wrapping object's top-level keys (sibling
+    /// fields of the chosen array). It must still preserve all keys
+    /// inside the array elements.
+    TopLevel,
+    /// Encoder may drop nested-object keys inside array elements
+    /// (e.g. older naive CSV that only kept primitive columns).
+    Nested,
+}
+
+/// Result of a round-trip key comparison.
+#[derive(Debug, Clone)]
+pub struct KeyComparison {
+    pub encoder_id: String,
+    pub input_keys: BTreeSet<String>,
+    pub output_keys: BTreeSet<String>,
+    pub dropped: Vec<String>,
+    pub added: Vec<String>,
+    pub allowed_loss: DataLoss,
+}
+
+impl KeyComparison {
+    /// True iff the comparison meets the encoder's declared guarantee.
+    pub fn is_within_contract(&self) -> bool {
+        match self.allowed_loss {
+            DataLoss::None => self.dropped.is_empty(),
+            // Tolerate any drop: encoder is documented as lossy. Production
+            // code paths must already gate on this (refusing to set a
+            // lossy encoder as the default).
+            DataLoss::TopLevel | DataLoss::Nested => true,
+        }
+    }
+
+    /// Compact summary for assertions / paper tables.
+    pub fn report(&self) -> String {
+        format!(
+            "encoder={} input_keys={} output_keys={} dropped={:?} added={:?} loss={:?}",
+            self.encoder_id,
+            self.input_keys.len(),
+            self.output_keys.len(),
+            self.dropped,
+            self.added,
+            self.allowed_loss,
+        )
+    }
+}
+
+/// Loss profile declared by each encoder.
+///
+/// The list is the source of truth — adding a new encoder requires adding
+/// a row here, which forces the author to think about which guarantee it
+/// holds (and forces the test below to cover it).
+pub fn declared_loss(encoder_id: &str) -> Option<DataLoss> {
+    Some(match encoder_id {
+        "json_compact" | "deep_mckp" | "deep_mckp_inner_table" | "mckp_v2" => DataLoss::None,
+        // `kv` and `mr_diff_fence` flatten / serialise structured values
+        // into a single line — we still expect every key to be visible
+        // textually, so they are `None` for *key* preservation.
+        "kv" | "mr_diff_fence" => DataLoss::None,
+        // `csv` (try_array_csv) and `csv_from_md` discard wrapping object
+        // context (see §Encoder Bug Postmortem). Keys *inside* array
+        // elements are preserved (union of keys), but a top-level
+        // wrapper's siblings are dropped.
+        "csv" | "csv_from_md" => DataLoss::TopLevel,
+        _ => return None,
+    })
+}
+
+/// Run a round-trip key comparison for a known encoder id and the body it
+/// produced from `raw_input`. Returns `None` if the encoder id is unknown.
+pub fn round_trip_keys(
+    encoder_id: &str,
+    raw_input: &str,
+    encoded_output: &str,
+) -> Option<KeyComparison> {
+    let allowed_loss = declared_loss(encoder_id)?;
+    let input_keys = collect_json_keys(raw_input).unwrap_or_default();
+    let output_keys = decode_keys(encoder_id, encoded_output);
+    let dropped: Vec<String> = input_keys.difference(&output_keys).cloned().collect();
+    let added: Vec<String> = output_keys.difference(&input_keys).cloned().collect();
+    Some(KeyComparison {
+        encoder_id: encoder_id.to_string(),
+        input_keys,
+        output_keys,
+        dropped,
+        added,
+        allowed_loss,
+    })
+}
+
+/// Walk a JSON value and return every `key` seen at any depth — including
+/// keys nested inside arrays and inside string-valued cells that happen to
+/// parse back as JSON. Free-form text and primitives contribute no keys.
+fn collect_json_keys(raw: &str) -> Option<BTreeSet<String>> {
+    let val: serde_json::Value = serde_json::from_str(raw.trim_start()).ok()?;
+    let mut out = BTreeSet::new();
+    walk_value(&val, &mut out);
+    Some(out)
+}
+
+fn walk_value(v: &serde_json::Value, out: &mut BTreeSet<String>) {
+    match v {
+        serde_json::Value::Object(map) => {
+            for (k, child) in map {
+                out.insert(k.clone());
+                walk_value(child, out);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for child in arr {
+                walk_value(child, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Decode the textual key set out of an encoder's output. The decoders are
+/// permissive — they look for any token that *could* be a key, since the
+/// goal is to detect *missing* keys, not validate full syntactic recovery.
+fn decode_keys(encoder_id: &str, encoded: &str) -> BTreeSet<String> {
+    match encoder_id {
+        "json_compact" | "deep_mckp" => {
+            // Compact JSON parses cleanly back to a Value.
+            collect_json_keys(encoded).unwrap_or_default()
+        }
+        "deep_mckp_inner_table" | "mckp_v2" => decode_inner_table_keys(encoded),
+        "csv" | "csv_from_md" => decode_csv_header_keys(encoded),
+        "kv" => decode_kv_keys(encoded),
+        "mr_diff_fence" => decode_diff_fence_keys(encoded),
+        _ => BTreeSet::new(),
+    }
+}
+
+/// Parse the deep_mckp_with_inner_table output: top-level `key: value`
+/// lines (until the first blank line), then a `## <main_array_name>`
+/// section heading, then a markdown table. Returns the union of pre-table
+/// kv keys, the heading, the table headers, and any keys recovered from
+/// inline-JSON cells.
+fn decode_inner_table_keys(encoded: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let mut lines = encoded.lines().peekable();
+
+    // Phase 1: top-level kv lines.
+    while let Some(line) = lines.peek() {
+        if line.trim().is_empty() {
+            lines.next();
+            break;
+        }
+        if line.starts_with("## ") || line.starts_with("| ") || line.starts_with("|---") {
+            // Reached the section heading or table without a separating
+            // blank line — stop kv parsing.
+            break;
+        }
+        let line = lines.next().unwrap();
+        if let Some((k, v)) = line.split_once(": ") {
+            out.insert(k.trim().to_string());
+            // The value may itself be inline JSON — recover its keys too.
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(v.trim()) {
+                walk_value(&val, &mut out);
+            }
+        }
+    }
+
+    // Phase 2 (optional): `## <main_array_name>` section heading carries
+    // the wrapping object's array key.
+    while let Some(line) = lines.peek() {
+        if line.trim().is_empty() {
+            lines.next();
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("## ") {
+            out.insert(rest.trim().to_string());
+            lines.next();
+            // Consume the blank line between heading and table.
+            if matches!(lines.peek(), Some(l) if l.trim().is_empty()) {
+                lines.next();
+            }
+        }
+        break;
+    }
+
+    // Phase 3: markdown table header.
+    if let Some(header) = lines.next() {
+        for cell in split_md_row(header) {
+            if !cell.is_empty() {
+                out.insert(cell);
+            }
+        }
+        // Skip the `| --- | --- |` separator.
+        let _ = lines.next();
+    }
+
+    // Phase 3: inline-JSON cells inside data rows.
+    for row in lines {
+        for cell in split_md_row(row) {
+            if (cell.starts_with('{') && cell.ends_with('}'))
+                || (cell.starts_with('[') && cell.ends_with(']'))
+            {
+                let unescaped = cell.replace("\\|", "|");
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(&unescaped) {
+                    walk_value(&val, &mut out);
+                }
+            }
+        }
+    }
+
+    out
+}
+
+fn split_md_row(line: &str) -> Vec<String> {
+    let trimmed = line.trim().trim_start_matches('|').trim_end_matches('|');
+    trimmed
+        .split(" | ")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// CSV (or csv_from_md) output — keys are the comma-separated header row.
+/// Wrapping object's top-level keys are *not* recoverable from this
+/// representation; that drop is the documented `DataLoss::TopLevel`.
+fn decode_csv_header_keys(encoded: &str) -> BTreeSet<String> {
+    let header = encoded.lines().next().unwrap_or("");
+    header
+        .split(',')
+        .map(|s| s.trim().trim_matches('"').to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// `key: value` lines, one per pair.
+fn decode_kv_keys(encoded: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for line in encoded.lines() {
+        if let Some((k, v)) = line.split_once(": ") {
+            out.insert(k.trim().to_string());
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(v.trim()) {
+                walk_value(&val, &mut out);
+            }
+        }
+    }
+    out
+}
+
+/// `mr_diff_fence` output is a sequence of fenced blocks with a path
+/// header. We recover `path` (and `diff` / `content` if recognisable as
+/// the section labels) so that the input's matching keys round-trip.
+fn decode_diff_fence_keys(encoded: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    // The encoder writes `path: <p>\n` lines and ```diff fences. The
+    // top-level JSON had `diffs`, `path`, and `content` / `diff` keys —
+    // we approximate by saying any of those words appearing in the
+    // output counts.
+    let lower = encoded.to_ascii_lowercase();
+    for k in ["diffs", "path", "diff", "content"] {
+        if lower.contains(k) {
+            out.insert(k.to_string());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shape::classify;
+    use crate::templates;
+
+    fn keys_of(raw: &str) -> BTreeSet<String> {
+        collect_json_keys(raw).unwrap_or_default()
+    }
+
+    // ─── mckp_v2 / deep_mckp_inner_table — must preserve EVERY key ─────
+
+    #[test]
+    fn mckp_v2_preserves_top_level_and_nested_keys() {
+        let raw = r#"{
+            "company": "Acme",
+            "year": 2026,
+            "employees": [
+                {"id": 1, "name": "Ada", "address": {"city": "Boston"}},
+                {"id": 2, "name": "Lin", "address": {"city": "Tokyo"}, "phone": "555"}
+            ]
+        }"#;
+        let cls = classify(raw);
+        let body = templates::deep_mckp_with_inner_table(raw, &cls)
+            .expect("mckp_v2 should engage on object-wrapping-array shape");
+        let cmp = round_trip_keys("mckp_v2", raw, &body).expect("encoder is registered");
+        assert!(
+            cmp.is_within_contract(),
+            "mckp_v2 dropped keys: {}",
+            cmp.report()
+        );
+        // Spot-check the specific keys called out in the postmortem.
+        for k in [
+            "company",
+            "year",
+            "employees",
+            "id",
+            "name",
+            "address",
+            "city",
+        ] {
+            assert!(
+                cmp.output_keys.contains(k),
+                "expected key `{k}` in mckp_v2 output, got {:?}",
+                cmp.output_keys
+            );
+        }
+    }
+
+    #[test]
+    fn mckp_v2_preserves_keys_when_inner_objects_are_heterogeneous() {
+        // Last record has an extra `phone` field — union-of-keys must
+        // include it.
+        let raw = r#"{
+            "scope": "ops",
+            "items": [
+                {"id": 1, "ok": true},
+                {"id": 2, "ok": false, "phone": "x"}
+            ]
+        }"#;
+        let cls = classify(raw);
+        let body = templates::deep_mckp_with_inner_table(raw, &cls).unwrap();
+        let cmp = round_trip_keys("mckp_v2", raw, &body).unwrap();
+        assert!(cmp.is_within_contract(), "{}", cmp.report());
+        assert!(cmp.output_keys.contains("phone"));
+        assert!(cmp.output_keys.contains("scope"));
+    }
+
+    #[test]
+    fn mckp_v2_returns_none_when_no_inner_array() {
+        // Without a homogeneous inner array, the encoder declines. The
+        // gate doesn't apply (no encoded output to compare).
+        let raw = r#"{"a": 1, "b": 2}"#;
+        let cls = classify(raw);
+        assert!(templates::deep_mckp_with_inner_table(raw, &cls).is_none());
+    }
+
+    // ─── pipeline_deep_mckp / json_compact — fully lossless ───────────
+
+    #[test]
+    fn pipeline_deep_mckp_is_lossless() {
+        let raw = r#"{
+            "url_a": "https://example.com",
+            "log": "line1\nline2",
+            "hash": "deadbeef",
+            "nested": {"k": "v"}
+        }"#;
+        let cls = classify(raw);
+        let body = templates::pipeline_deep_mckp(raw, &cls).unwrap_or_else(|| {
+            // If the template doesn't engage on this shape, fall back to
+            // serde_json compaction which is the L2 last resort.
+            serde_json::to_string(&serde_json::from_str::<serde_json::Value>(raw).unwrap()).unwrap()
+        });
+        let cmp = round_trip_keys("deep_mckp", raw, &body).unwrap();
+        assert!(cmp.is_within_contract(), "{}", cmp.report());
+        assert_eq!(cmp.dropped.len(), 0);
+    }
+
+    #[test]
+    fn json_compact_is_lossless() {
+        let raw = r#"{"id":1,"items":[{"a":2},{"b":3}]}"#;
+        let body = serde_json::to_string(&serde_json::from_str::<serde_json::Value>(raw).unwrap())
+            .unwrap();
+        let cmp = round_trip_keys("json_compact", raw, &body).unwrap();
+        assert!(cmp.is_within_contract());
+        assert_eq!(cmp.dropped.len(), 0);
+    }
+
+    // ─── csv / csv_from_md — declared lossy (TopLevel) ─────────────────
+
+    #[test]
+    fn naive_csv_drops_top_level_wrapper_as_documented() {
+        // Input has a wrapping object with `meta` and `rows`. Naive CSV
+        // would emit only the rows table — `meta` *will* be dropped.
+        // We assert the gate flags this as expected loss, not a regression.
+        let raw = r#"{
+            "meta": "report-2026-04-25",
+            "rows": [
+                {"id": 1, "v": "a"},
+                {"id": 2, "v": "b"}
+            ]
+        }"#;
+        // Hand-build the naive CSV that the bug used to emit (the lossy
+        // historical path, kept here as the regression target).
+        let body = "id,v\n1,a\n2,b\n";
+        let cmp = round_trip_keys("csv", raw, body).unwrap();
+        assert_eq!(cmp.allowed_loss, DataLoss::TopLevel);
+        // Documented loss: `meta` and `rows` (the wrapper) are gone.
+        assert!(cmp.dropped.iter().any(|k| k == "meta"));
+        assert!(cmp.dropped.iter().any(|k| k == "rows"));
+        // But keys inside the array are recoverable from the CSV header.
+        assert!(cmp.output_keys.contains("id"));
+        assert!(cmp.output_keys.contains("v"));
+        // `is_within_contract` tolerates the documented loss — failing it
+        // would mean we tightened the contract.
+        assert!(cmp.is_within_contract());
+    }
+
+    #[test]
+    fn csv_from_md_documents_the_same_loss() {
+        // markdown_table → csv only carries the table itself; any
+        // surrounding section/heading text is lost on this path.
+        let md = "# Report 2026-04-25\n\n| id | v |\n|---|---|\n| 1 | a |\n| 2 | b |\n";
+        let cls = classify(md);
+        let body = templates::csv_from_md(md, &cls).unwrap();
+        // No native JSON input here, so we synthesise the "logical" input
+        // (what the markdown represents) for the comparison.
+        let logical =
+            r#"{"heading":"Report 2026-04-25","rows":[{"id":"1","v":"a"},{"id":"2","v":"b"}]}"#;
+        let cmp = round_trip_keys("csv_from_md", logical, &body).unwrap();
+        assert_eq!(cmp.allowed_loss, DataLoss::TopLevel);
+        assert!(cmp.is_within_contract());
+        assert!(cmp.output_keys.contains("id"));
+    }
+
+    // ─── kv format — keys preserved, values flattened ─────────────────
+
+    #[test]
+    fn kv_format_preserves_all_top_level_keys() {
+        let raw = r#"{"alpha":1,"beta":"two","gamma":true,"delta":null,"epsilon":3.14}"#;
+        let body = "alpha: 1\nbeta: two\ngamma: true\ndelta: \nepsilon: 3.14\n";
+        let cmp = round_trip_keys("kv", raw, body).unwrap();
+        assert!(cmp.is_within_contract(), "{}", cmp.report());
+        for k in ["alpha", "beta", "gamma", "delta", "epsilon"] {
+            assert!(cmp.output_keys.contains(k));
+        }
+    }
+
+    // ─── meta-test: every encoder id used by the pipeline has a row ───
+
+    #[test]
+    fn declared_loss_table_covers_known_encoders() {
+        for id in [
+            "json_compact",
+            "deep_mckp",
+            "deep_mckp_inner_table",
+            "mckp_v2",
+            "csv",
+            "csv_from_md",
+            "kv",
+            "mr_diff_fence",
+        ] {
+            assert!(
+                declared_loss(id).is_some(),
+                "encoder id `{id}` missing from declared_loss table"
+            );
+        }
+        // Defensive: an unknown id should still return None so the test
+        // does not silently flag a typo as `None` loss.
+        assert!(declared_loss("totally_made_up").is_none());
+    }
+
+    #[test]
+    fn empty_input_collects_no_keys() {
+        assert!(keys_of("").is_empty());
+        assert!(keys_of("not json").is_empty());
+        assert!(keys_of("[1,2,3]").is_empty());
+    }
+}

--- a/crates/plugins/format-pipeline/src/templates.rs
+++ b/crates/plugins/format-pipeline/src/templates.rs
@@ -196,6 +196,13 @@ pub fn deep_mckp_with_inner_table(raw: &str, _cls: &ClassifiedResponse) -> Optio
         out.push('\n');
     }
 
+    // Section heading carrying the wrapping object's array key — preserves
+    // round-trip key parity (the inner-table form would otherwise drop it)
+    // and gives the LLM the contextual signal "this table is `<name>`".
+    out.push_str("## ");
+    out.push_str(&main_key);
+    out.push_str("\n\n");
+
     // Union of keys across elements, preserving first-occurrence order.
     let mut headers: Vec<String> = Vec::new();
     let mut seen: BTreeSet<String> = BTreeSet::new();

--- a/crates/plugins/format-pipeline/src/token_counter.rs
+++ b/crates/plugins/format-pipeline/src/token_counter.rs
@@ -69,14 +69,25 @@ pub enum Tokenizer {
 
 impl Tokenizer {
     /// Count tokens in `text` using the selected tokenizer.
+    ///
+    /// On failure to load a BPE table at first use, the variant
+    /// degrades to [`Self::Heuristic`] silently (with a one-time
+    /// `WARN` log). Better an over-conservative estimate than a panic
+    /// in the MCP hot path.
     pub fn count(&self, text: &str) -> usize {
         if text.is_empty() {
             return 0;
         }
         match self {
             Self::Heuristic => (text.len() as f64 / CHARS_PER_TOKEN).ceil() as usize,
-            Self::Cl100kBase => cl100k_bpe().encode_with_special_tokens(text).len(),
-            Self::O200kBase => o200k_bpe().encode_with_special_tokens(text).len(),
+            Self::Cl100kBase => match cl100k_bpe() {
+                Some(bpe) => bpe.encode_with_special_tokens(text).len(),
+                None => Self::Heuristic.count(text),
+            },
+            Self::O200kBase => match o200k_bpe() {
+                Some(bpe) => bpe.encode_with_special_tokens(text).len(),
+                None => Self::Heuristic.count(text),
+            },
         }
     }
 
@@ -100,14 +111,40 @@ impl Tokenizer {
     }
 }
 
-fn cl100k_bpe() -> &'static CoreBPE {
-    static BPE: OnceLock<CoreBPE> = OnceLock::new();
-    BPE.get_or_init(|| tiktoken_rs::cl100k_base().expect("cl100k_base BPE table must load"))
+/// Lazily-loaded BPE tables. Returning `Option` (instead of expecting
+/// the load to succeed) means a tiktoken-rs build/feature regression
+/// degrades token counting to the heuristic instead of panicking the
+/// MCP server. Logs a single WARN per BPE family on first failure.
+fn cl100k_bpe() -> Option<&'static CoreBPE> {
+    static BPE: OnceLock<Option<CoreBPE>> = OnceLock::new();
+    BPE.get_or_init(|| match tiktoken_rs::cl100k_base() {
+        Ok(b) => Some(b),
+        Err(e) => {
+            tracing::warn!(
+                target: "devboy_format_pipeline::tokenizer",
+                "cl100k_base BPE table failed to load: {e} — \
+                 falling back to chars/3.5 heuristic"
+            );
+            None
+        }
+    })
+    .as_ref()
 }
 
-fn o200k_bpe() -> &'static CoreBPE {
-    static BPE: OnceLock<CoreBPE> = OnceLock::new();
-    BPE.get_or_init(|| tiktoken_rs::o200k_base().expect("o200k_base BPE table must load"))
+fn o200k_bpe() -> Option<&'static CoreBPE> {
+    static BPE: OnceLock<Option<CoreBPE>> = OnceLock::new();
+    BPE.get_or_init(|| match tiktoken_rs::o200k_base() {
+        Ok(b) => Some(b),
+        Err(e) => {
+            tracing::warn!(
+                target: "devboy_format_pipeline::tokenizer",
+                "o200k_base BPE table failed to load: {e} — \
+                 falling back to chars/3.5 heuristic"
+            );
+            None
+        }
+    })
+    .as_ref()
 }
 
 #[cfg(test)]
@@ -151,15 +188,32 @@ mod tests {
     }
 
     #[test]
-    fn cl100k_counts_hello_world() {
-        // "hello world" tokenizes to 2 tokens in cl100k_base.
-        assert_eq!(Tokenizer::Cl100kBase.count("hello world"), 2);
+    fn cl100k_and_o200k_produce_positive_counts_on_simple_input() {
+        // Stable invariants only — exact token counts can shift across
+        // tiktoken-rs upgrades even when the BPE family name does not.
+        // We assert (a) the counter returns a positive value and (b) it
+        // is at least as compact as the chars/3.5 heuristic on this
+        // English phrase. Both are properties any sensible BPE shares.
+        let phrase = "hello world";
+        let heuristic = Tokenizer::Heuristic.count(phrase);
+        for tk in [Tokenizer::Cl100kBase, Tokenizer::O200kBase] {
+            let n = tk.count(phrase);
+            assert!(n > 0, "{tk:?} returned zero on `{phrase}`");
+            assert!(
+                n <= heuristic,
+                "{tk:?} reported {n} tokens, worse than the {heuristic}-token heuristic prior"
+            );
+        }
     }
 
     #[test]
-    fn o200k_counts_hello_world() {
-        // "hello world" tokenizes to 2 tokens in o200k_base.
-        assert_eq!(Tokenizer::O200kBase.count("hello world"), 2);
+    fn cl100k_and_o200k_agree_on_hello_world() {
+        // Common-English short phrases tokenize identically across the
+        // two BPE families. This is a tighter — but still vocabulary-
+        // version-tolerant — invariant than pinning the exact count.
+        let cl = Tokenizer::Cl100kBase.count("hello world");
+        let o2 = Tokenizer::O200kBase.count("hello world");
+        assert_eq!(cl, o2, "cl100k and o200k should agree on `hello world`");
     }
 
     #[test]

--- a/crates/plugins/format-pipeline/src/token_counter.rs
+++ b/crates/plugins/format-pipeline/src/token_counter.rs
@@ -1,7 +1,26 @@
-//! Approximation of token count in text.
+//! Token counting for budget pipeline and savings telemetry.
 //!
-//! Uses char-based estimation instead of tiktoken-rs to save ~2MB binary size.
-//! A 20% margin in the budget pipeline compensates for estimation inaccuracy.
+//! Two modes are supported:
+//!
+//! - [`Tokenizer::Heuristic`] — fast `chars / 3.5` approximation, ±20%
+//!   accuracy. Used for budget enforcement, where over-/under-shoot of a
+//!   few percent is absorbed by the 20% budget margin.
+//!
+//! - [`Tokenizer::Cl100kBase`] / [`Tokenizer::O200kBase`] — exact BPE
+//!   counts via `tiktoken-rs`. Slower (1–10 µs per call after warm-up,
+//!   plus ~5 ms one-time table load) but reproducible across host and
+//!   eval scripts. Required for the §Savings Accounting reporting rule
+//!   in Paper 2 — quoted savings numbers are tokenizer-dependent and
+//!   must be computed against a named tokenizer.
+//!
+//! The default tokenizer for new code is [`Tokenizer::Heuristic`] so that
+//! existing callers (budget pipeline, doc examples) keep their fast path.
+//! Telemetry / `tune` should explicitly pick a BPE variant.
+
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+use tiktoken_rs::CoreBPE;
 
 /// Average chars/token ratio for structured data.
 ///
@@ -13,22 +32,82 @@
 /// We use 3.5 for a conservative estimate (better to overestimate than underestimate).
 const CHARS_PER_TOKEN: f64 = 3.5;
 
-/// Estimate the number of tokens in text.
+/// Estimate the number of tokens in text via the heuristic.
 ///
 /// Returns an approximate token count.
 /// Accuracy: +/-20%, which is covered by the margin in the budget pipeline.
+///
+/// Equivalent to `Tokenizer::Heuristic.count(text)`.
 pub fn estimate_tokens(text: &str) -> usize {
-    if text.is_empty() {
-        return 0;
-    }
-    (text.len() as f64 / CHARS_PER_TOKEN).ceil() as usize
+    Tokenizer::Heuristic.count(text)
 }
 
 /// Estimate the number of characters for a given token budget.
 ///
-/// Inverse operation of `estimate_tokens`.
+/// Inverse operation of `estimate_tokens` for the heuristic only.
 pub fn tokens_to_chars(tokens: usize) -> usize {
     (tokens as f64 * CHARS_PER_TOKEN).floor() as usize
+}
+
+/// Tokenizer choice for token counting.
+///
+/// `Heuristic` is the fast char-based approximation. The `*Base` variants
+/// load a real BPE table once and produce exact counts that match the
+/// model provider's billing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Tokenizer {
+    /// `chars / 3.5` approximation. ±20% accuracy.
+    #[default]
+    Heuristic,
+    /// `cl100k_base`: GPT-3.5-turbo / GPT-4 / Claude (older).
+    Cl100kBase,
+    /// `o200k_base`: GPT-4o / GPT-4o-mini / Claude (current Anthropic
+    /// models reportedly share this family on the o200k axis).
+    O200kBase,
+}
+
+impl Tokenizer {
+    /// Count tokens in `text` using the selected tokenizer.
+    pub fn count(&self, text: &str) -> usize {
+        if text.is_empty() {
+            return 0;
+        }
+        match self {
+            Self::Heuristic => (text.len() as f64 / CHARS_PER_TOKEN).ceil() as usize,
+            Self::Cl100kBase => cl100k_bpe().encode_with_special_tokens(text).len(),
+            Self::O200kBase => o200k_bpe().encode_with_special_tokens(text).len(),
+        }
+    }
+
+    /// Stable identifier for telemetry / config serialization.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Heuristic => "heuristic",
+            Self::Cl100kBase => "cl100k_base",
+            Self::O200kBase => "o200k_base",
+        }
+    }
+
+    /// Parse from telemetry / config string. Unknown values fall back to
+    /// `Heuristic` to keep startup non-fatal on typos.
+    pub fn from_str_lossy(s: &str) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "cl100k_base" | "cl100k" => Self::Cl100kBase,
+            "o200k_base" | "o200k" => Self::O200kBase,
+            _ => Self::Heuristic,
+        }
+    }
+}
+
+fn cl100k_bpe() -> &'static CoreBPE {
+    static BPE: OnceLock<CoreBPE> = OnceLock::new();
+    BPE.get_or_init(|| tiktoken_rs::cl100k_base().expect("cl100k_base BPE table must load"))
+}
+
+fn o200k_bpe() -> &'static CoreBPE {
+    static BPE: OnceLock<CoreBPE> = OnceLock::new();
+    BPE.get_or_init(|| tiktoken_rs::o200k_base().expect("o200k_base BPE table must load"))
 }
 
 #[cfg(test)]
@@ -38,6 +117,8 @@ mod tests {
     #[test]
     fn test_empty_string() {
         assert_eq!(estimate_tokens(""), 0);
+        assert_eq!(Tokenizer::Cl100kBase.count(""), 0);
+        assert_eq!(Tokenizer::O200kBase.count(""), 0);
     }
 
     #[test]
@@ -67,5 +148,67 @@ mod tests {
     fn test_tokens_to_chars() {
         // 8000 tokens × 3.5 = 28000 chars
         assert_eq!(tokens_to_chars(8000), 28000);
+    }
+
+    #[test]
+    fn cl100k_counts_hello_world() {
+        // "hello world" tokenizes to 2 tokens in cl100k_base.
+        assert_eq!(Tokenizer::Cl100kBase.count("hello world"), 2);
+    }
+
+    #[test]
+    fn o200k_counts_hello_world() {
+        // "hello world" tokenizes to 2 tokens in o200k_base.
+        assert_eq!(Tokenizer::O200kBase.count("hello world"), 2);
+    }
+
+    #[test]
+    fn cl100k_and_o200k_disagree_on_jsonish() {
+        // The two tokenizers diverge on JSON-shaped input — the headline
+        // observation behind §Savings Accounting. We don't pin exact
+        // numbers here (they may shift with tiktoken-rs upgrades), only
+        // the inequality.
+        let json = "{\"id\":42,\"name\":\"alpha\",\"tags\":[\"x\",\"y\",\"z\"]}";
+        let cl = Tokenizer::Cl100kBase.count(json);
+        let o2 = Tokenizer::O200kBase.count(json);
+        assert!(cl > 0 && o2 > 0);
+        assert_ne!(cl, o2);
+    }
+
+    #[test]
+    fn heuristic_default_is_heuristic() {
+        assert_eq!(Tokenizer::default(), Tokenizer::Heuristic);
+        assert_eq!(Tokenizer::default().as_str(), "heuristic");
+    }
+
+    #[test]
+    fn from_str_lossy_known_and_unknown() {
+        assert_eq!(
+            Tokenizer::from_str_lossy("cl100k_base"),
+            Tokenizer::Cl100kBase
+        );
+        assert_eq!(Tokenizer::from_str_lossy("CL100K"), Tokenizer::Cl100kBase);
+        assert_eq!(
+            Tokenizer::from_str_lossy("o200k_base"),
+            Tokenizer::O200kBase
+        );
+        assert_eq!(Tokenizer::from_str_lossy("o200k"), Tokenizer::O200kBase);
+        assert_eq!(Tokenizer::from_str_lossy("nonsense"), Tokenizer::Heuristic);
+        assert_eq!(Tokenizer::from_str_lossy(""), Tokenizer::Heuristic);
+    }
+
+    #[test]
+    fn round_trip_serde() {
+        for tk in [
+            Tokenizer::Heuristic,
+            Tokenizer::Cl100kBase,
+            Tokenizer::O200kBase,
+        ] {
+            let json = serde_json::to_string(&tk).unwrap();
+            let back: Tokenizer = serde_json::from_str(&json).unwrap();
+            assert_eq!(tk, back);
+            // Round-trip via stable string id used by config / telemetry.
+            assert_eq!(Tokenizer::from_str_lossy(tk.as_str()), tk);
+        }
     }
 }

--- a/docs/research/paper-2-mckp-format-adaptive.md
+++ b/docs/research/paper-2-mckp-format-adaptive.md
@@ -913,11 +913,12 @@ Total: **242 tests** (233 lib + 6 bin + 3 doctests) passing; `cargo clippy --all
 
 ### Deferred to follow-up work
 
-- [ ] **MCP middleware integration** — wire `LayeredPipeline` + `DedupCache` per-session state into `devboy-mcp` request path (hook after tool call returns, before response streams to client).
-- [ ] **LLM comprehension eval** — run 100 real conversations × {Sonnet 4.6 / Haiku 4.5 / GLM-4.6 / gpt-oss:20b / gemma4:26b} on the GPU server, measure accuracy delta vs full-response baseline (tracked separately — GPU-bound).
-- [ ] **Near-dup (Type-2) hints** — `> [near-ref: tc_42, status: pending→success]`. Requires delta extraction and `delta_match` primitive. Projected extra yield: +3-5 pp on pipeline-polling endpoints.
+- [x] **MCP middleware integration** — `crates/devboy-mcp/src/layered.rs` (`SessionPipeline`) wraps `LayeredPipeline` per-session state and is consulted from `handle_tools_call` for every successful response. Mutating tools (`Edit` / `Write` / `MultiEdit` / `NotebookEdit`) fire `invalidate_file` before dispatch; the host advances the partition counter on `notifications/devboy/compact` or the `compact_pipeline_cache` internal tool. Wired in PR for issue #203 follow-up (2026-04-25).
+- [x] **Near-dup (Type-2) hints** — `crates/plugins/format-pipeline/src/near_ref.rs` plus `DedupCache::insert_with_body` / `find_near_ref`. Emits `> [near-ref: tc_X, status: a→b, …]` for pipeline-polling endpoints when `dedup.near_ref_enabled = true`. Eligibility: scalar-only diffs, matched key sets, ≤ 50 bytes of delta payload, ≥ 500 bytes body.
+- [x] **Format round-trip correctness tests** — `crates/plugins/format-pipeline/src/round_trip.rs` declares a `DataLoss` profile per encoder and asserts every input key reappears in the encoded output (textually). `mckp_v2` and `json_compact` are gated at `DataLoss::None`; naive `csv` / `csv_from_md` are documented `DataLoss::TopLevel` and therefore cannot be made the production default.
+- [ ] **LLM comprehension eval (5-model batch)** — partial: 109-question evaluation across {`glm-5.1`, `gpt-oss:20b`, `gemma4:26b`} shipped in §Encoder Bug Postmortem. Outstanding: same fixtures × {`claude-sonnet-4-6`, `claude-haiku-4-5`} on the GPU server.
 - [ ] **Team- and provider-shared fingerprints** (§Deployment Patterns B/C). Requires shared-bucket protocol and k-anonymity enforcement.
-- [ ] **Format round-trip correctness tests** — sample 50 L1/L2-encoded responses, verify that a downstream decoder recovers full information vs the raw baseline.
+- [ ] **TOON → MCKP default switch** — `OutputFormat::Mckp` exists and is wired into all typed-domain transforms; switching the default needs a major-version bump and a one-shot migration warning surfaced in `format_output`.
 
 ## Savings Accounting
 

--- a/skills/00-self-bootstrap/devboy-pipeline-tune/SKILL.md
+++ b/skills/00-self-bootstrap/devboy-pipeline-tune/SKILL.md
@@ -29,12 +29,22 @@ Adapt the layered-pipeline (Paper 2 / `crates/plugins/format-pipeline`) to **thi
 
 ## What the user gets
 
-After running this skill the user has a `~/.config/devboy/pipeline_config.toml` with:
+After running this skill the user has a `~/.config/devboy/pipeline_config.toml` (or `~/.devboy/pipeline_config.toml` for the MCP-server hot path) with:
 
 - **`profiles.llm.active`** pinned to their dominant model (if ≥80% share);
 - **`profiles.agent.active`** pinned to one of `default` / `file_search_heavy` / `marathon_refactor` based on session length, read-share, and compaction count;
 - **`profiles.data.variants`** extended with placeholder entries for every observed `mcp__*` endpoint, ready for them to set `preferred_format`;
 - **`hints`** policy left at safe defaults: `schema_explainer` is **off** (confirmed 0 lift in the 2026-04-25 evaluation), `inline_format_hint` is on **only** for local Ollama models.
+
+Once telemetry is on (`[telemetry] enabled = true`), live `FormatMetadata` from the MCP path reports the **split savings**:
+
+- `dedup_savings_pct` — fraction of tokens reclaimed by L0 cross-turn hints;
+- `encoder_savings_pct` — fraction reclaimed by L1/L2 encoders, computed *only over the L0-miss share* of responses;
+- `combined_savings_pct` — multiplicative composition (`dedup + (1 − dedup) × encoder`);
+- `baseline` — the fixed baseline against which the percentages are taken (`json_pretty` for typed-domain transforms, `json_compact` for the offline `tune analyze` path);
+- `tokenizer` — the BPE family driving the count (`o200k_base` / `cl100k_base` / `heuristic`).
+
+Quote those four numbers (plus the baseline + tokenizer) — *not* a single "saved X%" — when reporting back to the user. Per Paper 2 §Savings Accounting, savings without a named baseline and tokenizer are not comparable across systems.
 
 ## Procedure
 


### PR DESCRIPTION
## Summary

Closes the gap from issue #203 follow-up: the Paper 2 layered pipeline now
runs in the live MCP server's request path, not just in the offline
research crate. Includes the Type-2 (near-dup) hints implementation
that the user explicitly asked to land in this PR rather than defer.

## What changes

10 tasks (P-203-01 → P-203-10), one commit each:

- **01 — Tokenizer-aware token counting.** `tiktoken-rs` BPEs replace
  the `chars/3.5` heuristic. `TokenizerProfile.bpe` resolves
  per-profile; default schema-v2 profiles point at `O200kBase` for
  Anthropic / OpenAI families.
- **02 — Round-trip correctness gate.** New `round_trip` module
  declares `DataLoss` per encoder. `mckp_v2` and `json_compact` are
  gated at `DataLoss::None`; naive `csv` / `csv_from_md` documented as
  `DataLoss::TopLevel` and forbidden as production defaults.
  `deep_mckp_with_inner_table` now emits `## <main_array_name>` so the
  encoder is strictly key-lossless.
- **03 — `OutputFormat::Mckp`.** New variant routed through
  `mckp_router` for issues / merge_requests / diffs / comments /
  discussions; CLI accepts `--format mckp`. Default stays `Toon` until
  a major-version bump.
- **04 — MCP middleware integration.** New `crates/devboy-mcp/src/layered.rs`
  (`SessionPipeline`); `McpServer::handle_tools_call` invalidates on
  mutating tools and runs every successful response through L0 dedup.
- **05 — Compaction-boundary hook.** Two entry points: notification
  `notifications/devboy/compact` and internal tool
  `compact_pipeline_cache` for clients without notification support.
- **06 — JsonlSink wired to live telemetry.** New `[telemetry]` knobs
  (`enabled`, `path`, `rotate_mib`) — silent by default, opt-in via
  config. Sink writes `<dir>/<session>.jsonl`, readable by
  `tune analyze`.
- **07 — AdaptiveConfig loader on hot path.** `devboy mcp` reads
  `~/.devboy/pipeline_config.toml` (or `$DEVBOY_PIPELINE_CONFIG`) at
  start-up; missing/malformed → defaults + WARN, never fails start-up.
- **08 — Split-savings accounting on `FormatMetadata`.** New fields
  `dedup_savings_pct`, `encoder_savings_pct`, `combined_savings_pct`,
  `baseline`, `tokenizer`. Computed multiplicatively per Paper 2
  §Savings Accounting.
- **09 — End-to-end gate + migration UX.** Full `read → edit → read`
  test asserts mutation invalidation works through the server.
  `enable_layered_pipeline` logs an INFO pointing at `devboy tune analyze`.
  Skill `devboy-pipeline-tune` updated to require quoting the five
  split-savings fields, not a single number.
- **10 — Type-2 near-dup hints.** New `near_ref` module +
  `DedupCache::insert_with_body` / `find_near_ref`. Pipeline polling
  with `status: pending→success, duration: 12→34` now collapses to
  `> [near-ref: tc_X, status: pending→success, duration: 12→34]`
  when `dedup.near_ref_enabled = true`. Lands here by user request.

## Validation

| Crate | Tests before | Tests after |
|-------|--------------|-------------|
| `devboy-format-pipeline` | 318 | **345** (+27) |
| `devboy-mcp` | 139 | **150** (+11) |
| `devboy-executor` | 177 | **179** (+2) |

Workspace `cargo test --workspace` is green; `cargo clippy --all-targets
--all-features` clean at the default warning level.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo fmt --all -- --check`
- [ ] Run `devboy mcp` against Claude Code locally with
      `[telemetry] enabled = true` and verify `~/.devboy/telemetry/<sess>.jsonl`
      receives events; then run `devboy tune analyze` and check the
      printed dedup / encoder / combined columns are non-zero.
- [ ] Toggle `dedup.near_ref_enabled = true` in `pipeline_config.toml`,
      hit a polling MCP endpoint twice, confirm second response carries
      `> [near-ref: …]`.
- [ ] Trigger `notifications/devboy/compact` (or call
      `compact_pipeline_cache`), verify a fresh body is returned on the
      next identical Read.

## Out of scope (deferred to follow-up issues)

- TOON → MCKP default switch (needs a major-version bump + one-shot
  migration warning surfaced in `format_output`).
- LLM comprehension eval on `claude-sonnet-4-6` and `claude-haiku-4-5`
  (3 of 5 models already shipped in §Encoder Bug Postmortem).
- Team-shared / provider-shared fingerprints (§Deployment Patterns B/C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)