### PR TITLE
feat(analyze-usage): full Tier-1 + Tier-2 skill (AU-02..AU-18)

### DIFF
--- a/.claude/skills/analyze-usage/.gitignore
+++ b/.claude/skills/analyze-usage/.gitignore
@@ -1,0 +1,7 @@
+# Generated artefacts — never commit
+outputs/
+
+# Python caches
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/.claude/skills/analyze-usage/GLOSSARY.md
+++ b/.claude/skills/analyze-usage/GLOSSARY.md
@@ -1,0 +1,290 @@
+# Glossary — analyze-usage concepts
+
+Each concept links to the source file where it's computed. If a definition
+disagrees with the code, the code wins — open an issue.
+
+---
+
+## 🌊 Biome — session size class
+
+A session's size class derived from its real-human prompt count.
+
+| Biome | Real prompts | Emoji |
+|-------|-------------:|:-----:|
+| Plankton | 0–2 | 🦠 |
+| Shrimp | 3–9 | 🦐 |
+| Fish | 10–29 | 🐟 |
+| Dolphin | 30–99 | 🐬 |
+| Shark | 100–499 | 🦈 |
+| Whale | ≥ 500 | 🐋 |
+
+Real-human prompt = a `type=user` event whose first text block is **not**
+prefixed by a system marker (`<command-name>`, `<system-reminder>`,
+`<user-prompt-submit-hook>`, `<task-notification>`, `Caveat:`,
+`<local-command-stdout>`, `[Request interrupted by user`, or
+`This session is being continued from a previous conversation`).
+
+**Code:**
+- [`lib/classifiers.py:biome_of`](lib/classifiers.py)
+- [`lib/parsers.py:_classify_user_kind`](lib/parsers.py)
+- [`scripts/extract_biome.py`](scripts/extract_biome.py)
+
+---
+
+## 🎭 Archetype — what the session does
+
+8-class classification (Variant B 45/25 thresholds) based on Edit / Bash /
+Read tool-call shares.
+
+| Archetype | Rule | Emoji |
+|-----------|------|:-----:|
+| Constructor | Edit ≥ 45% | 🏗 |
+| Operator    | Bash ≥ 45% | ⚙️ |
+| Researcher  | Read ≥ 45% | 🔬 |
+| Polymath    | All three ≥ 25% | 🌐 |
+| Builder     | Edit ≥ 25% AND Bash ≥ 25% (and not Polymath) | 🛠 |
+| Scholar     | Edit ≥ 25% AND Read ≥ 25% (and not Polymath) | 📝 |
+| Inspector   | Bash ≥ 25% AND Read ≥ 25% (and not Polymath) | 🔍 |
+| Discusser   | Total tools < 5, or no rule matches | 💬 |
+
+**Code:**
+- [`lib/classifiers.py:archetype_of`](lib/classifiers.py)
+- [`scripts/extract_archetype.py`](scripts/extract_archetype.py)
+
+History: started with Constructor / Operator / Researcher; expanded after
+Cycle 7 of the hypothesis loop revealed `Mixed` archetype was a catch-all.
+
+---
+
+## 🎵 Rhythm — temporal tool-mix shape
+
+Classification of the dominant-tool sequence over 10 windows.
+
+| Rhythm | Rule | Emoji |
+|--------|------|:-----:|
+| Mono   | Top tool dominates ≥ 80% of windows | 🎼 |
+| Phased | ≤ 4 transitions AND ≤ 3 unique tops | 📊 |
+| Mixed  | Anything else | 🎲 |
+| Chaos  | ≥ 6 transitions AND ≥ 4 unique tops | 🌪 |
+| —      | Fewer than 10 events total | · |
+
+The "tool" label uses extended palette: `Edit`, `Read`, `Bash:git`,
+`Bash:test`, `Bash:build`, `Bash:run`, `Bash:device`, `Bash:deploy`,
+`Bash:format`, `Bash:net`, `Bash:playwright_cli`, `Bash:shell`,
+`Bash:other`. Without sub-categories Chaos is impossible to reach with
+only 3 distinct tool families — see Cycle 20 → Cycle 21 fix.
+
+**Code:**
+- [`lib/classifiers.py:rhythm_of`](lib/classifiers.py)
+- [`lib/classifiers.py:bash_sub_of`](lib/classifiers.py)
+
+---
+
+## 🎨 Stack — code-base layer
+
+File-path classification into:
+
+| Stack | Examples |
+|-------|----------|
+| frontend  | `*.tsx`, `*.css`, `apps/dashboard-ui/`, `*-web/` |
+| backend   | `*.rs`, `*.py`, `*.go`, `*.sql`, `apps/*-api/`, `services/*` |
+| infra     | `*.tf`, `Dockerfile`, `*.sh`, `/k8s/`, `/charts/`, `deckhouse` |
+| docs      | `*.md`, `*.mdx`, `*.rst` |
+| config    | `*.yaml` (non-K8s), `*.json`, `*.toml` |
+| other     | lockfiles, binaries, unknown |
+
+**Code:** [`lib/classifiers.py:stack_of`](lib/classifiers.py)
+
+---
+
+## 🔧 Bash subcategory — what the shell command does
+
+Single-command classification:
+
+| Sub | Examples |
+|-----|----------|
+| git    | `git ...`, `gh ...`, `glab ...` |
+| test   | `cargo test`, `pytest`, `jest`, `playwright` |
+| build  | `cargo build`, `cargo check`, `tsc`, `webpack` |
+| run    | `cargo run`, `npm run`, `pnpm dev`, `python ...`, `node ...` |
+| device | `adb`, `simctl`, `fastboot` |
+| deploy | `kubectl`, `helm`, `terraform`, `werf`, `docker run/build/compose` |
+| format | `prettier`, `rustfmt`, `eslint`, `ruff`, `clippy` |
+| net    | `curl`, `wget`, `ping`, `nc` |
+| playwright_cli | `playwright-cli ...` (manual UI testing tool) |
+| shell  | `cd`, `ls`, `cat`, `mv`, `cp`, `find`, `grep`, … |
+| other  | everything else |
+
+**Code:** [`lib/classifiers.py:bash_sub_of`](lib/classifiers.py)
+
+---
+
+## 🚀 DORA — DevOps Research and Assessment metrics
+
+Adapted from Forsgren et al. *Accelerate*. Computed from git commit
+messages parsed out of bash command logs.
+
+### Conventional commit types
+
+`feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`, `perf`, `style`,
+`build`, `revert`. Anything else → `uncategorized`.
+
+### True CFR (Change Failure Rate)
+
+```
+true_CFR = prod_fix / feat
+prod_fix = total_fix − review_fix
+review_fix = fix-commit whose message contains "review", "комментар",
+             "copilot", "artslob", "cr ", "nitpick", "address review",
+             "по ревью", "after review"
+```
+
+Levels (DORA 2024):
+- 🟢 Elite: < 0.30
+- 🟡 High: 0.30–1.0
+- 🟠 Medium: 1.0–3.0
+- 🔴 Low: > 3.0
+
+### Lead time (proxy)
+
+Time from `git checkout -b feat/...` to first `git push` of that branch.
+
+### Deploy frequency (proxy)
+
+Count of `git push` events per day.
+
+**Code:**
+- [`lib/classifiers.py:commit_type_of`, `is_review_fix`](lib/classifiers.py)
+- [`scripts/extract_outputs.py`](scripts/extract_outputs.py)
+- [`scripts/period_report.py`](scripts/period_report.py) (header `🚀 DORA`)
+
+---
+
+## ⚡ Friction — context cost markers
+
+| Concept | Definition | Source |
+|---------|-----------|--------|
+| **Compact** | `isCompactSummary: true` event in jsonl. Indicates Claude condensed context to fit the window. | [`lib/parsers.py:_is_compact`](lib/parsers.py), [`extract_compacts.py`](scripts/extract_compacts.py) |
+| **Pivot** | A user message starting with `[Request interrupted by user`. User killed the agent mid-action. | [`scripts/period_report.py:parse_all`](scripts/period_report.py) |
+| **Subagent spawn** | A `Task` or `Agent` tool_use call. | [`extract_subagents.py`](scripts/extract_subagents.py) |
+| **Idle gap** | Wallclock gap > 8h between consecutive bursts. Suggested split point. | [`extract_gaps.py`](scripts/extract_gaps.py) |
+
+---
+
+## ⏱️ Wallclock vs Active duration
+
+```
+wallclock = last_ts − first_ts
+active    = sum of intervals ≤ 30 min between consecutive events
+ratio     = active / wallclock  (typically 7–23%)
+```
+
+**Code:** [`scripts/period_report.py:active_minutes`](scripts/period_report.py)
+
+---
+
+## 🌱 Burst classes — per-prompt work shape
+
+Each burst (one human prompt + the agent's response) is classified into:
+
+| Class | Rule |
+|-------|------|
+| pure_qa | 0 tool calls |
+| read_only | only Read/Grep/Glob/ToolSearch |
+| write_only | only Edit/MultiEdit/Write |
+| bash_only | only Bash |
+| chain_run | Bash with chained commands (≥3 split parts) |
+| write_heavy | ≥ 50% Edit/Write of all tools |
+| mixed | everything else |
+
+**Code:** [`scripts/extract_burst_classes.py`](scripts/extract_burst_classes.py)
+
+---
+
+## 📈 Growth, milestones, distribution stats
+
+| Concept | Definition |
+|---------|-----------|
+| `cv` | Coefficient of variation = std/mean |
+| `gini` | Gini coefficient (0 = uniform, 1 = max concentration) |
+| `shannon_entropy` | Diversity in bits (`log₂`) |
+| `milestone_at(thr)` | Burst index where cumulative R first reaches `thr` |
+| `acceleration` | Slope(2nd half) − slope(1st half) of daily series |
+| `power_law_fit` | Log-log linear fit `y ≈ a · xᵏ`. Returns `slope`, `intercept_log`, `scale=a`, `r`, `n` |
+
+**Code:** [`lib/stats.py`](lib/stats.py)
+
+Empirical findings from the hypothesis loop (Cycle 16, 34, 35):
+- `R ∝ rank^3.4` across biomes (r = 0.969)
+- `+LOC ∝ rank^5.7` (r = 0.982)
+- `compacts ≈ 0.23 × R^0.71` (r = 0.984, sublinear)
+- `pivots ≈ 0.031 × R^1.21` (r = 0.999, slightly superlinear)
+
+---
+
+## 🔐 Anonymization
+
+Anonymized parquet under `outputs/anon/` follows this contract:
+
+| Raw field | Anon replacement |
+|-----------|-----------------|
+| session_id (UUID) | `s0001` (main) / `a0001` (subagent) — sequential |
+| project_path | `p<6hex>` SHA-1 truncation |
+| file_path | dropped, only `file_ext` + stack class kept |
+| bash_command | dropped, only `bash_sub` + structural flags kept |
+| prompt_text | dropped, only `chars` + `intent_flags` + `token_hash` BoW |
+| branch_name | dropped, only `b<6hex>` kept |
+| tool_use_id | dropped |
+| MCP slug `mcp__<server>__<verb>` | `mcp__<6hex>__<verb>` (server hashed, verb intact) |
+| Aggregate with N < 5 sessions | suppressed (K=5 threshold) |
+
+The reverse-lookup dictionary lives in `outputs/raw/_token_dict.json` and
+never gets copied to `anon/`. Audit with `analyze-usage audit`.
+
+**Code:**
+- [`lib/anonymize.py`](lib/anonymize.py)
+- [`scripts/pattern_detector.py:audit_anon`](scripts/pattern_detector.py)
+
+---
+
+## 📊 Three-tier output
+
+```
+outputs/
+├── raw/      Tier 1: pure-stat parquet, original identifiers
+├── anon/     Tier 1 anonymized: same schema, hashed identifiers
+└── llm/      Tier 2: LLM-augmented features (session names, narratives)
+```
+
+| Tier | Reproducible offline? | Anonymizable? | Code path |
+|------|----------------------|---------------|-----------|
+| 1 (stats) | ✓ | ✓ → `anon/` | `scripts/extract_*.py` |
+| 2 (LLM)   | ✗ | partial      | `scripts/extract_llm_*.py` (queues; agent fills) |
+
+**Code:**
+- [`lib/io.py:outputs_dirs_v2`](lib/io.py)
+- [`scripts/extract_llm_session_names.py`](scripts/extract_llm_session_names.py) — Tier 2 example
+
+---
+
+## Patterns detected
+
+Heuristic flags from `pattern_detector.py`:
+
+| Flag | Rule |
+|------|------|
+| `needs_split` | ≥ 2 idle gaps in the session |
+| `pure_constructor` | archetype = Constructor AND rhythm = Phased |
+| `feature_with_debug` | archetype = Inspector AND compacts ≥ 2 |
+| `pipeline_rescue` | compacts ≥ 3 AND lines_added < 500 AND commits > 0 |
+| `ghost_session` | biome = Plankton AND total_tools = 0 |
+
+**Code:** [`scripts/pattern_detector.py`](scripts/pattern_detector.py)
+
+---
+
+## See also
+
+- **[SKILL.md](SKILL.md)** — full architecture, extractor table, extension guide
+- **[README.md](README.md)** — quick-start for users (standalone CLI + agent flow)
+- **Test suite** — [`tests/run_all.sh`](tests/run_all.sh) — 28 unit + smoke tests

--- a/.claude/skills/analyze-usage/README.md
+++ b/.claude/skills/analyze-usage/README.md
@@ -1,0 +1,149 @@
+# analyze-usage
+
+Higher-level analytics on top of Claude Code session logs.
+Generates **graphic monthly/weekly digests** with metaphors (aquarium of
+biomes, archetype bars, DORA radar) and **per-session parquet bundles** for
+deeper analysis.
+
+Two ways to use it:
+
+1. **Standalone CLI** — run `bin/analyze-usage` directly from your terminal,
+   no agent needed.
+2. **Through an agent** — Claude (or any agent that loads `.claude/skills/`)
+   triggers it on phrases like *"weekly digest"*, *"DORA"*, *"когда сессия
+   стала китом"*, *"drill into session 2c052d83"*.
+
+---
+
+## Install (without cloning the whole repo)
+
+```bash
+# Sparse-checkout just this skill into ~/.claude/skills/analyze-usage/:
+curl -sSL https://raw.githubusercontent.com/meteora-pro/devboy-tools/main/.claude/skills/analyze-usage/scripts/install.sh | bash
+
+# …then add to PATH:
+echo 'export PATH="$HOME/.claude/skills/analyze-usage/bin:$PATH"' >> ~/.zshrc
+exec zsh
+analyze-usage --help
+```
+
+If you already cloned `devboy-tools`, the skill is already at
+`.claude/skills/analyze-usage/` — skip the install step.
+
+Requirements: `uv` (https://docs.astral.sh/uv/) for running Python scripts,
+`git` for the install.
+
+## Quick start (standalone)
+
+```bash
+# Add to PATH (once):
+export PATH="$PWD/.claude/skills/analyze-usage/bin:$PATH"
+
+# Last week, html, auto-open in browser:
+analyze-usage period --from 2026-04-23 --to 2026-04-30 --format html --open
+
+# Whole quarter, all 3 formats (text + markdown + html) into a directory:
+analyze-usage period --from 2026-02-01 --to 2026-04-30 --period both \
+    --format all --out-dir /tmp/q1_2026
+
+# Drill into one session:
+analyze-usage session 2c052d83
+
+# Help:
+analyze-usage --help
+```
+
+---
+
+## Output formats
+
+| Format     | When to use                                            |
+|------------|--------------------------------------------------------|
+| `text`     | Quick glance in terminal (default if `--out` omitted)  |
+| `markdown` | Paste into Slack / GitHub / docs                       |
+| `html`     | Pretty page with biome colors, progress bars, tables   |
+| `all`      | Generates `report.{txt,md,html}` in `--out-dir`        |
+
+`--open` auto-opens the HTML in your default browser (only with
+`--format html` or `--format all`).
+
+---
+
+## Output directories
+
+```
+.claude/skills/analyze-usage/outputs/
+├── raw/      ← Tier 1 stat extraction with original UUIDs/paths/branches.
+│              Owner-only. Keeps reverse dictionaries (_token_dict.json,
+│              _sid_main.json, _sid_sub.json).
+├── anon/     ← Tier 1 anonymized version. Sharable. Audit with
+│              `analyze-usage audit` after every regeneration.
+└── llm/      ← Tier 2 LLM-augmented features (session names, narratives).
+              Generated when the agent runs the skill. Empty until then.
+```
+
+Run `analyze-usage pipeline` to populate `raw/` + `anon/`. ~4–5 min for a
+full corpus, sequential.
+
+---
+
+## Three-tier model
+
+| Tier | What                                | Reproducible offline? | Anonymizable? |
+|------|-------------------------------------|----------------------|---------------|
+| **0**| `tests/` — unit + smoke tests        | ✓ (deterministic)    | n/a           |
+| **1**| `scripts/extract_*.py` — pure stat   | ✓                    | ✓ → `anon/`   |
+| **2**| LLM-augmented features (narratives) | ✗ (needs agent)      | partial       |
+
+Tier 1 must remain deterministic — same input → same parquet.
+Tier 2 is enriched by the agent (Claude reads `outputs/llm/_queue.jsonl`,
+summarizes each session, writes narrative back to `outputs/llm/*.parquet`).
+
+---
+
+## Subcommands
+
+```
+analyze-usage period      Graphic digest (monthly/weekly, text/md/html/all)
+analyze-usage pipeline    Run all 10 extractors → parquet
+analyze-usage session SID Drill-down on one session
+analyze-usage audit       Verify outputs/anon/ has no leaks
+analyze-usage patterns    Heuristic flags from raw parquet
+analyze-usage report      Markdown report from existing parquet
+analyze-usage test        Run all tests
+```
+
+---
+
+## Environment
+
+| Variable                | Default                  | Purpose                            |
+|-------------------------|--------------------------|------------------------------------|
+| `CLAUDE_PROJECTS_ROOT`  | `~/.claude/projects`     | Where session jsonls live          |
+
+Set `CLAUDE_PROJECTS_ROOT` to point at a different folder (sandbox testing,
+analyzing someone else's logs after they share with you, etc).
+
+---
+
+## Through the agent
+
+When you ask Claude things like:
+
+- "сделай отчёт за последний месяц"
+- "weekly digest with html"
+- "drill into session 2c052d83"
+- "какие у меня DORA метрики?"
+- "посмотри на наши биомы"
+
+…the skill loads automatically. Claude will run `period_report.py` with
+the right args, parse the parquet, and produce a narrative. For long-form
+analysis (Tier 2) Claude consumes `outputs/llm/_queue.jsonl`, reads the
+relevant jsonls, and appends narrative summaries to `outputs/llm/*.parquet`.
+
+---
+
+## Architecture
+
+See [SKILL.md](./SKILL.md) for the full table of extractors, library API,
+anonymization contract, and extension guide.

--- a/.claude/skills/analyze-usage/SKILL.md
+++ b/.claude/skills/analyze-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze-usage
-description: Analyze higher-level patterns in Claude Code usage — biome (whale/shark/.../plankton), archetype (constructor/operator/researcher), growth curves, milestones, idle gaps, subagent pyramids, compact patterns, parallelism. Builds on research-pipeline. Use when the user asks about session biomes, productivity profiles, "what kind of work" was done, when a session became a whale, what shaped a long-running project, or wants to see drill-down view of a specific session.
+description: Analyze higher-level patterns in Claude Code usage. Outputs (a) graphic monthly/weekly digest with metaphors — aquarium of biomes (🐋🦈🐬🐟🦐🦠), archetypes (⚙️🔬🌐🛠📝🔍🏗💬), rhythm, stack palette, DORA radar (CFR + lead time + pushes), friction (compacts/pivots/subagents); (b) per-session parquet bundles for further analysis (biome, archetype, rhythm, growth, milestones, idle gaps, subagent pyramids, compact patterns, parallelism, burst classes, topics). Use when the user asks about weekly/monthly reports, session biomes, productivity profiles, "what kind of work was done", when a session became a whale, DORA metrics, or wants drill-down view of a specific session.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
@@ -23,32 +23,44 @@ Trigger on any of:
 - "compact pattern", "context window over time", "автокомпакты"
 - "idle gaps", "should I split this session", "split point"
 - "drill into session", "view session timeline" + a session id
+- "weekly digest", "monthly report", "отчёт за неделю/месяц/квартал", "графический отчёт", "DORA", "CFR", "lead time" → use `scripts/period_report.py --from --to --period monthly|weekly|both`
+- "rhythm", "Mono / Phased / Mixed / Chaos", "ритм сессии", "stack palette", "self-feedback", "TDD ratio", "motivated read" — these come from `lib/classifiers.py` and the corresponding extractors
 
 If the user only wants the base research dataset (sessions, turns, tool_calls,
 loops, correlations), use `research-pipeline` instead. This skill **extends**
 that dataset.
 
-## Two-layer output
+## Three-tier output
 
 ```
 outputs/
-  raw/        non-anonymized parquet — owner only
-  anon/       anonymized parquet — shareable bundle
-  reports/    markdown reports written by the agent
+  raw/        Tier 1 stat parquet, original UUIDs/paths/branches — owner only
+  anon/       Tier 1 anonymized — shareable bundle (audit with `--audit-anon`)
+  llm/        Tier 2 LLM-augmented features (session names, narratives) — owner only
+  reports/    markdown reports written by the agent (Tier 2)
 ```
 
 - `raw/` keeps original session UUIDs, project paths, file paths, branch
   names, and prompt token frequencies. Owner-only; never share without
   re-running the anonymizer.
-- `anon/` follows the same anonymity contract as Papers 1-3: hashed session
-  ids (s0001 / a0001), hashed project slugs (p7d8fb1), file ext only, no raw
-  paths or branch names, prompt tokens replaced by 6-char hashes (sidecar
-  dictionary stays in `raw/`).
-- `reports/` is markdown the agent generates from the parquet tables. Reports
-  may include real session names and quotes if the user owns the data.
+- `anon/` follows the anonymization contract below. Hashed session ids
+  (`s0001` / `a0001`), hashed project slugs (`p<6hex>`), file ext only,
+  no raw paths or branch names, prompt tokens replaced by 6-char hashes
+  (reverse dictionary stays in `raw/_token_dict.json`). Auditable via
+  `pattern_detector.py --audit-anon`.
+- `llm/` holds Tier 2 outputs that depend on the agent (Claude). Tier 1
+  extractors stay deterministic; LLM enrichment is layered on top via
+  `extract_llm_*.py` extractors that build a queue (`_queue.jsonl`) the
+  agent consumes and writes back as parquet. Owner-only by default.
+- `reports/` is markdown the agent generates from the parquet tables.
+  Reports may include real session names and quotes if the user owns the
+  data.
 
 ## Tier model
 
+- **Tier 0 — tests**: `tests/run_all.sh` runs 22 unit + smoke tests
+  (classifiers, stats, full extractor pipeline on a synthetic fixture).
+  Run before shipping a new extractor.
 - **Tier 1 — always-on (no API key)**: pure Python extractors using regex
   and statistics. Lives in `scripts/extract_*.py`. Reuses `lib/` helpers.
 - **Tier 2 — agent-side LLM**: when the skill is active, the agent itself
@@ -57,12 +69,25 @@ outputs/
   LLM API call required.
 
 If you (the agent) need a metric that doesn't exist yet, **write a new
-`extract_<name>.py`**, wire it into `pipeline.py`, run it. The pipeline is
-designed to extend without rewrite.
+`extract_<name>.py`**, wire it into `pipeline.py`, add a test in
+`tests/test_extractors_smoke.py`, run it. The pipeline is designed to
+extend without rewrite.
 
 ## Run
 
 ```bash
+# Graphic period digest (monthly + weekly, with метафоры — aquarium, palette, DORA radar)
+uv run .claude/skills/analyze-usage/scripts/period_report.py \
+  --from 2026-02-01 --to 2026-04-30 --period both
+
+# Just one month at a time
+uv run .claude/skills/analyze-usage/scripts/period_report.py \
+  --from 2026-04-01 --to 2026-04-30 --period monthly
+
+# Just last week (auto-saves a copy)
+uv run .claude/skills/analyze-usage/scripts/period_report.py \
+  --from 2026-04-23 --to 2026-04-30 --period weekly --out /tmp/last_week.txt
+
 # Full pipeline (assumes research-pipeline has populated /tmp/claude_analysis/)
 uv run .claude/skills/analyze-usage/scripts/pipeline.py \
   --since 2026-04-01 \
@@ -76,31 +101,38 @@ uv run .claude/skills/analyze-usage/scripts/extract_growth.py
 uv run .claude/skills/analyze-usage/scripts/view_session.py 2c052d83
 ```
 
-The pipeline expects `~/.claude/projects/*.jsonl` to be present. If
-`/tmp/claude_analysis/sessions.parquet` already exists from `research-pipeline`,
-the skill reuses it; otherwise it parses jsonl directly.
+The pipeline expects `~/.claude/projects/*.jsonl` to be present. Override
+the location by setting `CLAUDE_PROJECTS_ROOT=/some/dir/projects` (used by
+the smoke tests; useful for sandboxed runs on someone else's logs).
+
+If `/tmp/claude_analysis/sessions.parquet` already exists from
+`research-pipeline`, the skill reuses it; otherwise it parses jsonl
+directly.
 
 ## Available extractors
 
 | Script                          | Output (raw + anon)              | What it computes |
 |---------------------------------|----------------------------------|------------------|
-| `extract_biome.py`              | `biome.parquet`                  | Whale/Shark/Dolphin/Fish/Shrimp/Plankton class per session |
-| `extract_archetype.py`          | `archetype.parquet`              | Constructor/Operator/Researcher classification |
-| `extract_growth.py`             | `growth.parquet`, `milestones.parquet` | Daily rates, CV, Gini, acceleration; burst-index when each milestone was reached |
-| `extract_outputs.py`            | `outputs.parquet`                | Commits, pushes, PR/MR, issues, files, branches, TODOs |
-| `extract_subagents.py`          | `subagent_pyramid.parquet`       | Per-parent distribution of subagent sizes |
-| `extract_compacts.py`           | `compact_pattern.parquet`        | Per-session compact frequency, context size before each |
-| `extract_gaps.py`               | `idle_gaps.parquet`              | Gaps >8h with suggested split points |
-| `extract_topics.py`             | `topic_signatures.parquet`       | BoW per session, hashed for anon bundle |
-| `extract_burst_classes.py`      | `burst_classes.parquet`          | pure_qa / read_only / bash_only / mixed / write_heavy / write_only counts per session |
-| `extract_parallelism.py`        | `parallelism.parquet`            | Per-minute concurrent session counts, hour-of-day map |
+| `extract_biome.py`              | `biome.parquet`                  | Whale / Shark / Dolphin / Fish / Shrimp / Plankton per session (main + subagents) |
+| `extract_archetype.py`          | `archetype.parquet`              | 8-class archetype (Variant B 45/25): Constructor / Operator / Researcher / Builder / Scholar / Inspector / Polymath / Discusser, plus rhythm class (Mono / Phased / Mixed / Chaos) |
+| `extract_growth.py`             | `growth.parquet`, `milestones.parquet` | Per-session: n_bursts, daily R/LOC, CV, Gini, acceleration_R; milestone burst-index for thresholds 10/30/100/500 |
+| `extract_outputs.py`            | `outputs.parquet`                | Commits by type (feat/fix/refactor/chore/docs/test/ci) with review-fix vs prod-fix split, pushes, PR/MR/issue creation, comments, files edited/written, lines added/removed, unique branches/issues |
+| `extract_subagents.py`          | `subagent_pyramid.parquet`       | Per-parent distribution of subagent sizes (whale/shark/.../plankton bins) |
+| `extract_compacts.py`           | `compact_pattern.parquet`        | Per-session compact frequency, real_prompts before first compact, max context size, compact_per_asst |
+| `extract_gaps.py`               | `idle_gaps.parquet`              | Gaps >8h with suggested split points (long-form: one row per gap) |
+| `extract_topics.py`             | `topic_signatures.parquet`       | BoW per session (top-20 tokens). raw keeps tokens, anon hashes them; reverse dictionary in `raw/_token_dict.json` |
+| `extract_burst_classes.py`      | `burst_classes.parquet`          | Per-session counts: pure_qa / read_only / bash_only / write_only / write_heavy / chain_run / mixed |
+| `extract_parallelism.py`        | `parallelism.parquet`            | Hour-bin concurrent session counts (date+hour → cnt) |
 
 | Other tool                      | Purpose |
 |---------------------------------|---------|
-| `pipeline.py`                   | Orchestrator — runs all extractors, parallel where safe |
-| `view_session.py SID`           | Drill-down view of one session (raw jsonl required) |
-| `pattern_detector.py`           | Heuristic auto-detection (needs-split, concentrated, constructor) |
-| `report_generator.py`           | Markdown report skeleton from parquet tables |
+| `period_report.py`              | Graphic monthly/weekly digest with metaphors (aquarium, palette, DORA radar, friction). Reads jsonl directly, no parquet needed. Args: `--from --to --period monthly\|weekly\|both --format text\|markdown\|html\|all [--out FILE \| --out-dir DIR] [--open]`. With `--open` auto-opens HTML in browser. |
+| `extract_llm_session_names.py`  | Tier 2 stub: enqueues Whale/Shark/Dolphin sessions for narrative summarization by the agent. Writes `outputs/llm/_queue.jsonl` (and an empty `session_names.parquet` stub). Agent consumes the queue and appends rows. |
+| `bin/analyze-usage`             | Standalone CLI wrapper. Subcommands: `period`, `pipeline`, `session SID`, `audit`, `patterns`, `report`, `test`. Add to PATH for non-agent usage. |
+| `pipeline.py`                   | Orchestrator — runs all 10 extractors **sequentially** (~4–5 min on a full corpus). Args: `--since --outputs --only <names>` |
+| `view_session.py SID`           | Drill-down view of one session by sid prefix (raw jsonl required). Prints biome/archetype/rhythm + first 5 prompts + bash subcategory mix |
+| `pattern_detector.py`           | Default: heuristic flags from `raw/` parquets: `needs_split` (≥2 idle gaps), `pure_constructor` (Constructor+Phased), `feature_with_debug` (Inspector+compacts≥2), `pipeline_rescue` (compacts≥3 + LOC<500), `ghost_session` (Plankton+0 tools). With `--audit-anon`: walks `anon/` parquets and asserts no raw UUIDs / abs paths / bash commands / branches / mcp slugs leak — exits 1 on any leak. |
+| `report_generator.py`           | Markdown report skeleton from parquet tables → `outputs/reports/<date>.md` |
 
 ## Library helpers
 
@@ -109,10 +141,30 @@ rather than duplicate logic.
 
 | Module             | Provides |
 |--------------------|----------|
-| `lib/parsers.py`   | `parse_session(jsonl_path)`, `find_session_files(root)`, `find_subagents(parent_dir, sid)`, `build_bursts(events)`, `split_chain(cmd)` |
-| `lib/classifiers.py` | `classify_bash_part(cmd)` → read/write/build/test/env/neutral; `classify_burst(b)` → 7 burst classes; `biome_of(real_prompts)` → emoji + name; `archetype_of(stats)` → constructor/operator/researcher |
-| `lib/stats.py`     | `cv(xs)`, `gini(xs)`, `shannon_entropy(counter)`, `milestone_at(cum_R)`, `acceleration(daily_xs)` |
-| `lib/anonymize.py` | `hash_path(p)`, `hash_token(w)`, `anonymize_df(df, schema)`, `write_token_sidecar(dict, raw_dir)` |
+| `lib/parsers.py`   | `find_session_files(root=None)`, `find_subagents(jsonl)`, `parse_session(jsonl, since, until)` → Iterator[Event], `build_bursts(events, sid, project)` → list[Burst], `load_session(jsonl) → ParsedSession`, `split_chain(cmd)`. Honors `CLAUDE_PROJECTS_ROOT` env var. |
+| `lib/classifiers.py` | Pure-function classifiers: `biome_of(real_prompts)`, `archetype_of(edit, bash, read)` (Variant B 45/25), `rhythm_of(event_seq)` (Mono / Phased / Mixed / Chaos / "—"), `stack_of(file_path)` (frontend / backend / infra / docs / config / other), `bash_sub_of(cmd)` (git / test / build / run / device / deploy / format / net / playwright_cli / shell / other), `commit_type_of(first_line)`, `is_review_fix(body)`. Plus emoji dicts: `BIOME_EMOJI`, `ARCHETYPE_EMOJI`, `RHYTHM_EMOJI`. |
+| `lib/stats.py`     | `cv(xs)`, `gini(xs)`, `shannon_entropy(counter)`, `milestone_at(cum, threshold)`, `acceleration(daily_xs)`, `pearson(xs, ys)`, `percentile(xs, p)`, `median(xs)`, `power_law_fit(xs, ys)` (returns slope/intercept/r/n). |
+| `lib/anonymize.py` | `hash_path(s)` → `p<6hex>`, `hash_token(w)`, `hash_branch(name)`, `hash_mcp_slug(name)`, `SidProjector(prefix)` (sequential `s0001` / `a0001` mapping), `file_ext(path)`, `k_anon_filter(rows, group_key)` (drops groups with N<5), `write_token_sidecar(dict, raw_dir)`. |
+| `lib/io.py`        | `outputs_dirs(base=None)` → `(raw, anon)`, `outputs_dirs_v2(base=None)` → `(raw, anon, llm)` (auto-mkdir), `write_parquet(rows, path)` (snappy, returns row count, empty marker if no rows). |
+| `lib/render.py`    | Period-report renderers in three formats: `render_period_terminal/markdown/html_section(label, agg)`, `render_html_doc(title, sections)`, `render_weekly_table_*`, `render_trends_*`. Pure data → string. Used by `period_report.py`. |
+
+## Tests
+
+`tests/run_all.sh` runs four test suites (~15 seconds total, 28 tests):
+
+| Suite | Coverage | Count |
+|-------|----------|-------|
+| `tests/test_classifiers.py` | biome thresholds, archetype Variant B (pure / hybrid / too-few-tools), rhythm Mono / Chaos / too-short, stack classification (all extensions), bash sub regex coverage, conventional commit type, review-fix detection | 11 |
+| `tests/test_stats.py`       | cv (empty + known), gini (extremes), Shannon entropy, milestone_at, pearson (perfect / zero), percentile / median, power_law_fit (`y=2x²` recovers slope=2), acceleration (const / accel / decel) | 10 |
+| `tests/test_extractors_smoke.py` | Builds a synthetic `~/.claude/projects/` fixture with 3 controlled sessions (Operator-Fish, Constructor with feat+fix+review-fix+push, ghost). Sets `CLAUDE_PROJECTS_ROOT`, runs all 10 extractors, asserts schemas + specific values (e.g. session2 must have `feat=1, fix=2, review_fix=1, prod_fix=1, pushes=1, archetype=Constructor`). | 1 (full pipeline) |
+| `tests/test_audit_anon.py`  | Builds anon parquets with synthetic content; asserts `pattern_detector.py --audit-anon` returns 0 on clean fixture and 1 on each kind of leak (raw UUID, abs path, raw bash, raw branch in nested list, bad sid format). | 6 |
+
+```bash
+bash .claude/skills/analyze-usage/tests/run_all.sh
+```
+
+When you add an extractor, add a corresponding assertion to
+`test_extractors_smoke.py` so future refactors stay honest.
 
 ## Anonymization contract
 
@@ -128,20 +180,29 @@ When emitting to `outputs/anon/`:
 - `mcp_server_slug` → hash, keep verb intact
 - Any aggregate with N<5 sessions in the bucket → suppress (K=5 threshold)
 
-The `outputs/anon/` directory must be auditable: see `pattern_detector.py
---audit-anon` (planned) which walks every parquet and asserts no
-non-hashed strings leak.
+The `outputs/anon/` directory is auditable via `pattern_detector.py
+--audit-anon`: it walks every parquet, recursively scans every string-
+typed column (including nested lists/dicts), and exits 1 if it finds
+raw UUIDs, absolute paths, bash commands, branch names, or un-hashed
+MCP slugs. Run after every pipeline regeneration before sharing.
 
 ## Extending the pipeline
 
 To add a new metric `foo`:
 
-1. Create `scripts/extract_foo.py` reading from `lib/parsers.py` outputs.
-2. Emit two parquet files: `outputs/raw/foo.parquet` and the anonymized
-   variant in `outputs/anon/foo.parquet` (use `lib/anonymize.py`).
-3. Append `extract_foo` to the orchestrator list in `pipeline.py`.
+1. Create `scripts/extract_foo.py` using `lib/parsers.py` to load sessions
+   and `lib/classifiers.py` / `lib/stats.py` / `lib/anonymize.py` /
+   `lib/io.py` for the rest. Follow the shape of existing extractors
+   (CLI: `--since YYYY-MM-DD`, `--outputs DIR`).
+2. Emit two parquet files: `outputs/raw/foo.parquet` (full data) and
+   `outputs/anon/foo.parquet` (anonymized via `SidProjector` + `hash_path`
+   + token hashes).
+3. Append `extract_foo` to the `EXTRACTORS` list in `scripts/pipeline.py`.
 4. Add a row to the `Available extractors` table above.
-5. Add an entry to `docs/METRICS.md` describing the schema and intent.
+5. Add an assertion in `tests/test_extractors_smoke.py` checking the new
+   schema + at least one value on the synthetic fixture.
+6. Run `bash tests/run_all.sh` — must stay 22+/22+ green.
 
-Do not assume only humans extend this — the agent itself adds extractors when
-the user asks "what about <new angle>" and the existing tables don't cover it.
+Do not assume only humans extend this — the agent itself adds extractors
+when the user asks "what about <new angle>" and the existing tables don't
+cover it.

--- a/.claude/skills/analyze-usage/SKILL.md
+++ b/.claude/skills/analyze-usage/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: analyze-usage
+description: Analyze higher-level patterns in Claude Code usage — biome (whale/shark/.../plankton), archetype (constructor/operator/researcher), growth curves, milestones, idle gaps, subagent pyramids, compact patterns, parallelism. Builds on research-pipeline. Use when the user asks about session biomes, productivity profiles, "what kind of work" was done, when a session became a whale, what shaped a long-running project, or wants to see drill-down view of a specific session.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+---
+
+# analyze-usage
+
+Higher-level usage analytics on top of `research-pipeline`. Extracts **patterns**
+that the existing pipeline does not surface directly: biome class, archetype,
+growth curves, milestones, gaps, subagent pyramids, compact patterns, and
+burst-level RW classes. Output is a pair of parquet bundles plus an
+agent-written markdown report.
+
+## When to use
+
+Trigger on any of:
+
+- "biome", "whale", "shark", "creature", "плактон", "кит", "акула"
+- "archetype", "constructor", "operator", "researcher"
+- "growth", "milestone", "когда сессия стала", "rate of growth"
+- "subagent pyramid", "subagent stats", "сабагенты"
+- "compact pattern", "context window over time", "автокомпакты"
+- "idle gaps", "should I split this session", "split point"
+- "drill into session", "view session timeline" + a session id
+
+If the user only wants the base research dataset (sessions, turns, tool_calls,
+loops, correlations), use `research-pipeline` instead. This skill **extends**
+that dataset.
+
+## Two-layer output
+
+```
+outputs/
+  raw/        non-anonymized parquet — owner only
+  anon/       anonymized parquet — shareable bundle
+  reports/    markdown reports written by the agent
+```
+
+- `raw/` keeps original session UUIDs, project paths, file paths, branch
+  names, and prompt token frequencies. Owner-only; never share without
+  re-running the anonymizer.
+- `anon/` follows the same anonymity contract as Papers 1-3: hashed session
+  ids (s0001 / a0001), hashed project slugs (p7d8fb1), file ext only, no raw
+  paths or branch names, prompt tokens replaced by 6-char hashes (sidecar
+  dictionary stays in `raw/`).
+- `reports/` is markdown the agent generates from the parquet tables. Reports
+  may include real session names and quotes if the user owns the data.
+
+## Tier model
+
+- **Tier 1 — always-on (no API key)**: pure Python extractors using regex
+  and statistics. Lives in `scripts/extract_*.py`. Reuses `lib/` helpers.
+- **Tier 2 — agent-side LLM**: when the skill is active, the agent itself
+  reads parquet + raw jsonl and adds the narrative layer (session naming,
+  phase detection, pattern interpretation, drill-down quotes). No external
+  LLM API call required.
+
+If you (the agent) need a metric that doesn't exist yet, **write a new
+`extract_<name>.py`**, wire it into `pipeline.py`, run it. The pipeline is
+designed to extend without rewrite.
+
+## Run
+
+```bash
+# Full pipeline (assumes research-pipeline has populated /tmp/claude_analysis/)
+uv run .claude/skills/analyze-usage/scripts/pipeline.py \
+  --since 2026-04-01 \
+  --outputs .claude/skills/analyze-usage/outputs/
+
+# Only specific extractors
+uv run .claude/skills/analyze-usage/scripts/extract_biome.py
+uv run .claude/skills/analyze-usage/scripts/extract_growth.py
+
+# Drill into one session (requires raw jsonl, owner-only)
+uv run .claude/skills/analyze-usage/scripts/view_session.py 2c052d83
+```
+
+The pipeline expects `~/.claude/projects/*.jsonl` to be present. If
+`/tmp/claude_analysis/sessions.parquet` already exists from `research-pipeline`,
+the skill reuses it; otherwise it parses jsonl directly.
+
+## Available extractors
+
+| Script                          | Output (raw + anon)              | What it computes |
+|---------------------------------|----------------------------------|------------------|
+| `extract_biome.py`              | `biome.parquet`                  | Whale/Shark/Dolphin/Fish/Shrimp/Plankton class per session |
+| `extract_archetype.py`          | `archetype.parquet`              | Constructor/Operator/Researcher classification |
+| `extract_growth.py`             | `growth.parquet`, `milestones.parquet` | Daily rates, CV, Gini, acceleration; burst-index when each milestone was reached |
+| `extract_outputs.py`            | `outputs.parquet`                | Commits, pushes, PR/MR, issues, files, branches, TODOs |
+| `extract_subagents.py`          | `subagent_pyramid.parquet`       | Per-parent distribution of subagent sizes |
+| `extract_compacts.py`           | `compact_pattern.parquet`        | Per-session compact frequency, context size before each |
+| `extract_gaps.py`               | `idle_gaps.parquet`              | Gaps >8h with suggested split points |
+| `extract_topics.py`             | `topic_signatures.parquet`       | BoW per session, hashed for anon bundle |
+| `extract_burst_classes.py`      | `burst_classes.parquet`          | pure_qa / read_only / bash_only / mixed / write_heavy / write_only counts per session |
+| `extract_parallelism.py`        | `parallelism.parquet`            | Per-minute concurrent session counts, hour-of-day map |
+
+| Other tool                      | Purpose |
+|---------------------------------|---------|
+| `pipeline.py`                   | Orchestrator — runs all extractors, parallel where safe |
+| `view_session.py SID`           | Drill-down view of one session (raw jsonl required) |
+| `pattern_detector.py`           | Heuristic auto-detection (needs-split, concentrated, constructor) |
+| `report_generator.py`           | Markdown report skeleton from parquet tables |
+
+## Library helpers
+
+`lib/` holds the shared building blocks. Extractors should import from there
+rather than duplicate logic.
+
+| Module             | Provides |
+|--------------------|----------|
+| `lib/parsers.py`   | `parse_session(jsonl_path)`, `find_session_files(root)`, `find_subagents(parent_dir, sid)`, `build_bursts(events)`, `split_chain(cmd)` |
+| `lib/classifiers.py` | `classify_bash_part(cmd)` → read/write/build/test/env/neutral; `classify_burst(b)` → 7 burst classes; `biome_of(real_prompts)` → emoji + name; `archetype_of(stats)` → constructor/operator/researcher |
+| `lib/stats.py`     | `cv(xs)`, `gini(xs)`, `shannon_entropy(counter)`, `milestone_at(cum_R)`, `acceleration(daily_xs)` |
+| `lib/anonymize.py` | `hash_path(p)`, `hash_token(w)`, `anonymize_df(df, schema)`, `write_token_sidecar(dict, raw_dir)` |
+
+## Anonymization contract
+
+When emitting to `outputs/anon/`:
+
+- `session_id` → sequential `s0001` (main) or `a0001` (subagent)
+- `project_path` → `p<6-hex>` SHA-1 truncation
+- `file_path` → drop, keep `file_ext` and `file_type` only
+- `bash_command` → drop, keep `category` + structural flags only
+- `prompt_text` → drop, keep `chars`, `intent_flags`, and `token_hash` BoW
+- `branch_name` → drop, keep `branch_hash` only
+- `tool_use_id` → drop
+- `mcp_server_slug` → hash, keep verb intact
+- Any aggregate with N<5 sessions in the bucket → suppress (K=5 threshold)
+
+The `outputs/anon/` directory must be auditable: see `pattern_detector.py
+--audit-anon` (planned) which walks every parquet and asserts no
+non-hashed strings leak.
+
+## Extending the pipeline
+
+To add a new metric `foo`:
+
+1. Create `scripts/extract_foo.py` reading from `lib/parsers.py` outputs.
+2. Emit two parquet files: `outputs/raw/foo.parquet` and the anonymized
+   variant in `outputs/anon/foo.parquet` (use `lib/anonymize.py`).
+3. Append `extract_foo` to the orchestrator list in `pipeline.py`.
+4. Add a row to the `Available extractors` table above.
+5. Add an entry to `docs/METRICS.md` describing the schema and intent.
+
+Do not assume only humans extend this — the agent itself adds extractors when
+the user asks "what about <new angle>" and the existing tables don't cover it.

--- a/.claude/skills/analyze-usage/SKILL.md
+++ b/.claude/skills/analyze-usage/SKILL.md
@@ -58,9 +58,9 @@ outputs/
 
 ## Tier model
 
-- **Tier 0 — tests**: `tests/run_all.sh` runs 22 unit + smoke tests
-  (classifiers, stats, full extractor pipeline on a synthetic fixture).
-  Run before shipping a new extractor.
+- **Tier 0 — tests**: `tests/run_all.sh` runs 28 unit + smoke tests
+  (classifiers, stats, full extractor pipeline on a synthetic fixture,
+  anonymization leak audit). Run before shipping a new extractor.
 - **Tier 1 — always-on (no API key)**: pure Python extractors using regex
   and statistics. Lives in `scripts/extract_*.py`. Reuses `lib/` helpers.
 - **Tier 2 — agent-side LLM**: when the skill is active, the agent itself
@@ -105,9 +105,11 @@ The pipeline expects `~/.claude/projects/*.jsonl` to be present. Override
 the location by setting `CLAUDE_PROJECTS_ROOT=/some/dir/projects` (used by
 the smoke tests; useful for sandboxed runs on someone else's logs).
 
-If `/tmp/claude_analysis/sessions.parquet` already exists from
-`research-pipeline`, the skill reuses it; otherwise it parses jsonl
-directly.
+The current extractors parse the jsonl logs directly — they do not
+reuse `/tmp/claude_analysis/sessions.parquet` from `research-pipeline`.
+A future extractor can short-circuit by reading that parquet if it
+exists, but until that lands, every extractor walks `~/.claude/projects/`
+on each run.
 
 ## Available extractors
 
@@ -201,7 +203,7 @@ To add a new metric `foo`:
 4. Add a row to the `Available extractors` table above.
 5. Add an assertion in `tests/test_extractors_smoke.py` checking the new
    schema + at least one value on the synthetic fixture.
-6. Run `bash tests/run_all.sh` — must stay 22+/22+ green.
+6. Run `bash tests/run_all.sh` — must stay 28+/28+ green.
 
 Do not assume only humans extend this — the agent itself adds extractors
 when the user asks "what about <new angle>" and the existing tables don't

--- a/.claude/skills/analyze-usage/bin/analyze-usage
+++ b/.claude/skills/analyze-usage/bin/analyze-usage
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# analyze-usage — standalone CLI wrapper for the analyze-usage skill.
+#
+# Subcommands:
+#   period    — graphic monthly/weekly digest (text/markdown/html)
+#   pipeline  — run all 10 extractors → outputs/raw + outputs/anon
+#   session   — drill-down view of one session by sid prefix
+#   audit     — verify outputs/anon/ has no leaks
+#   patterns  — heuristic flags (needs_split, ghost_session, …)
+#   report    — markdown summary from existing parquet
+#   test      — run all unit + smoke tests
+#
+# Usage:
+#   analyze-usage period --from 2026-02-01 --to 2026-04-30 --period both --format html --open
+#   analyze-usage pipeline --since 2026-04-01
+#   analyze-usage session 2c052d83
+#   analyze-usage audit
+#   analyze-usage --help
+
+set -e
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS="$SKILL_DIR/scripts"
+TESTS="$SKILL_DIR/tests"
+
+usage() {
+    cat <<EOF
+analyze-usage — Claude Code usage analytics (skill standalone CLI)
+
+USAGE:
+    analyze-usage <command> [args...]
+
+COMMANDS:
+    period       Graphic monthly/weekly digest (text/markdown/html/all)
+    pipeline     Run all 10 extractors, write parquet to outputs/raw + outputs/anon
+    session SID  Drill-down view of one session by uuid prefix
+    audit        Verify outputs/anon/ has no raw-identifier leaks
+    patterns     Heuristic flags from parquet (needs_split, ghost_session, …)
+    report       Markdown summary from existing parquet → outputs/reports/<date>.md
+    test         Run all unit + smoke tests
+
+EXAMPLES:
+    analyze-usage period --from 2026-02-01 --to 2026-04-30 --period both
+    analyze-usage period --from 2026-04-23 --to 2026-04-30 --format html --open
+    analyze-usage period --from 2026-02-01 --to 2026-04-30 --format all --out-dir /tmp/q1
+
+    analyze-usage pipeline                  # full corpus, all extractors
+    analyze-usage pipeline --since 2026-04-01
+
+    analyze-usage session 2c052d83
+    analyze-usage audit
+    analyze-usage patterns
+    analyze-usage test
+
+ENV:
+    CLAUDE_PROJECTS_ROOT    Override default ~/.claude/projects/ location
+
+Run any subcommand with --help for full args.
+EOF
+}
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+    period)
+        exec uv run --quiet "$SCRIPTS/period_report.py" "$@"
+        ;;
+    pipeline)
+        exec uv run --quiet "$SCRIPTS/pipeline.py" "$@"
+        ;;
+    session|view|drill)
+        exec uv run --quiet "$SCRIPTS/view_session.py" "$@"
+        ;;
+    audit)
+        exec uv run --quiet "$SCRIPTS/pattern_detector.py" --audit-anon "$@"
+        ;;
+    patterns)
+        exec uv run --quiet "$SCRIPTS/pattern_detector.py" "$@"
+        ;;
+    report)
+        exec uv run --quiet "$SCRIPTS/report_generator.py" "$@"
+        ;;
+    test)
+        exec bash "$TESTS/run_all.sh" "$@"
+        ;;
+    -h|--help|help|"")
+        usage
+        ;;
+    *)
+        echo "unknown command: $cmd" >&2
+        echo
+        usage
+        exit 2
+        ;;
+esac

--- a/.claude/skills/analyze-usage/bin/analyze-usage
+++ b/.claude/skills/analyze-usage/bin/analyze-usage
@@ -37,6 +37,8 @@ COMMANDS:
     audit        Verify outputs/anon/ has no raw-identifier leaks
     patterns     Heuristic flags from parquet (needs_split, ghost_session, …)
     report       Markdown summary from existing parquet → outputs/reports/<date>.md
+    llm-queue    Tier 2 — enqueue Whale/Shark/Dolphin sessions for narrative
+                 summarisation by the agent (writes outputs/llm/_queue.jsonl)
     test         Run all unit + smoke tests
 
 EXAMPLES:
@@ -80,6 +82,9 @@ case "$cmd" in
         ;;
     report)
         exec uv run --quiet "$SCRIPTS/report_generator.py" "$@"
+        ;;
+    llm-queue)
+        exec uv run --quiet "$SCRIPTS/extract_llm_session_names.py" "$@"
         ;;
     test)
         exec bash "$TESTS/run_all.sh" "$@"

--- a/.claude/skills/analyze-usage/lib/__init__.py
+++ b/.claude/skills/analyze-usage/lib/__init__.py
@@ -1,0 +1,6 @@
+"""analyze-usage shared library.
+
+Pure functions for parsing, classifying, computing stats, and anonymizing
+Claude Code session logs. Extractors in `scripts/` should import from here
+rather than duplicate logic.
+"""

--- a/.claude/skills/analyze-usage/lib/anonymize.py
+++ b/.claude/skills/analyze-usage/lib/anonymize.py
@@ -1,0 +1,108 @@
+"""Anonymization helpers for outputs/anon/ bundle.
+
+Anonymity contract (mirrors SKILL.md):
+
+- session_id  → sequential s0001 (main) / a0001 (subagent)
+- project_path → p<6-hex> SHA-1 truncation
+- file_path    → drop, keep file_ext + stack_class only
+- bash_command → drop, keep category + structural flags only
+- prompt_text  → drop, keep chars + intent flags + token_hash BoW
+- branch_name  → drop, keep 6-hex branch_hash only
+- tool_use_id  → drop
+- mcp slug     → 6-hex hash, verb intact
+- aggregate with N<5 distinct sessions → suppress (K=5)
+
+The anonymizer keeps a sidecar dictionary (raw_dir/_token_dict.json) so the
+owner can look up hashes back to original strings.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+K_THRESHOLD = 5
+
+
+def hash_path(p: str, length: int = 6) -> str:
+    """SHA-1 truncation of a path or string. Stable across runs."""
+    if not p:
+        return ""
+    h = hashlib.sha1(p.encode("utf-8")).hexdigest()
+    return "p" + h[:length]
+
+
+def hash_token(word: str, length: int = 6) -> str:
+    """Deterministic 6-hex hash of a token (for prompt BoW)."""
+    if not word:
+        return ""
+    h = hashlib.sha1(word.lower().encode("utf-8")).hexdigest()
+    return h[:length]
+
+
+def hash_branch(branch: str, length: int = 6) -> str:
+    if not branch:
+        return ""
+    return "b" + hashlib.sha1(branch.encode("utf-8")).hexdigest()[:length]
+
+
+def hash_mcp_slug(name: str) -> str:
+    """`mcp__<server>__<verb>` → `mcp__<6-hex>__<verb>` (server hashed, verb kept)."""
+    if not name.startswith("mcp__"):
+        return name
+    parts = name.split("__")
+    if len(parts) < 3:
+        return name
+    server = parts[1]
+    verb = "__".join(parts[2:])
+    return f"mcp__{hash_token(server)}__{verb}"
+
+
+class SidProjector:
+    """Deterministic mapping `full_uuid → s0001 / a0001` for anon output."""
+
+    def __init__(self, prefix: str = "s"):
+        self.prefix = prefix
+        self._map: dict[str, str] = {}
+
+    def get(self, full_id: str) -> str:
+        if full_id not in self._map:
+            self._map[full_id] = f"{self.prefix}{len(self._map) + 1:04d}"
+        return self._map[full_id]
+
+    def dump(self, path: Path) -> None:
+        path.write_text(json.dumps(self._map, indent=2))
+
+
+def file_ext(path: str) -> str:
+    """Extension only, lowercase, leading dot stripped. '' for no extension."""
+    if not path:
+        return ""
+    base = os.path.basename(path)
+    if "." not in base:
+        return ""
+    return base.rsplit(".", 1)[1].lower()
+
+
+def k_anon_filter(rows: list[dict], group_key: str | tuple[str, ...]) -> list[dict]:
+    """Drop rows whose grouping key occurs <K_THRESHOLD times.
+
+    group_key may be a single column name or a tuple of column names.
+    """
+    keys = (group_key,) if isinstance(group_key, str) else tuple(group_key)
+    counts: dict[tuple, int] = {}
+    for r in rows:
+        k = tuple(r.get(c) for c in keys)
+        counts[k] = counts.get(k, 0) + 1
+    return [r for r in rows if counts[tuple(r.get(c) for c in keys)] >= K_THRESHOLD]
+
+
+def write_token_sidecar(token_to_hash: dict, raw_dir: Path) -> None:
+    """Persist the prompt-token reverse-lookup (raw → hash) dictionary.
+
+    Lives in `outputs/raw/` only, never copied to anon.
+    """
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    (raw_dir / "_token_dict.json").write_text(json.dumps(token_to_hash, indent=2, ensure_ascii=False))

--- a/.claude/skills/analyze-usage/lib/classifiers.py
+++ b/.claude/skills/analyze-usage/lib/classifiers.py
@@ -1,0 +1,291 @@
+"""Classifiers for sessions: biome, archetype, rhythm, stack, bash sub.
+
+Each function takes minimal aggregated data and returns a label. Pure
+functions, no I/O.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections import Counter
+
+
+# ─── Biome (size class) ───────────────────────────────────────────────────
+
+
+BIOME_THRESHOLDS = [
+    (500, "Whale"),
+    (100, "Shark"),
+    (30,  "Dolphin"),
+    (10,  "Fish"),
+    (3,   "Shrimp"),
+]
+
+BIOME_EMOJI = {
+    "Whale":    "🐋",
+    "Shark":    "🦈",
+    "Dolphin":  "🐬",
+    "Fish":     "🐟",
+    "Shrimp":   "🦐",
+    "Plankton": "🦠",
+}
+
+
+def biome_of(real_prompts: int) -> str:
+    """Map real-human prompt count to biome label."""
+    for thr, name in BIOME_THRESHOLDS:
+        if real_prompts >= thr:
+            return name
+    return "Plankton"
+
+
+# ─── Archetype (Variant B: pure ≥45%, hybrid each ≥25%) ───────────────────
+
+
+ARCHETYPE_EMOJI = {
+    "Constructor": "🏗",
+    "Operator":    "⚙️",
+    "Researcher":  "🔬",
+    "Builder":     "🛠",
+    "Scholar":     "📝",
+    "Inspector":   "🔍",
+    "Polymath":    "🌐",
+    "Discusser":   "💬",
+}
+
+
+def archetype_of(edit: int, bash: int, read: int) -> str:
+    """Variant B archetype classifier.
+
+    Pure single-axis ≥45% → Constructor / Operator / Researcher.
+    Hybrid two-axis ≥25% each → Builder (E+B) / Scholar (E+R) / Inspector (B+R).
+    All three ≥25% → Polymath.
+    Else → Discusser.
+    """
+    total = edit + bash + read
+    if total < 5:
+        return "Discusser"
+    e, b, r = edit / total, bash / total, read / total
+    if e >= 0.45:
+        return "Constructor"
+    if b >= 0.45:
+        return "Operator"
+    if r >= 0.45:
+        return "Researcher"
+    if e >= 0.25 and b >= 0.25 and r >= 0.25:
+        return "Polymath"
+    if e >= 0.25 and b >= 0.25:
+        return "Builder"
+    if e >= 0.25 and r >= 0.25:
+        return "Scholar"
+    if b >= 0.25 and r >= 0.25:
+        return "Inspector"
+    return "Discusser"
+
+
+# ─── Rhythm (10-window dominant tool) ─────────────────────────────────────
+
+
+RHYTHM_EMOJI = {
+    "Mono":   "🎼",
+    "Phased": "📊",
+    "Mixed":  "🎲",
+    "Chaos":  "🌪",
+    "—":      "·",
+}
+
+
+def rhythm_of(event_seq: list[str]) -> str:
+    """Classify rhythm based on dominant-tool sequence over 10 windows.
+
+    Mono   = top tool ≥80% of windows.
+    Chaos  = ≥6 transitions and ≥4 unique tops.
+    Phased = ≤4 transitions and ≤3 unique tops.
+    Mixed  = everything else.
+    "—" if too few events (<10).
+    """
+    if not event_seq or len(event_seq) < 10:
+        return "—"
+    n = len(event_seq)
+    bsize = max(1, n // 10)
+    top_seq: list[str] = []
+    for i in range(10):
+        end = (i + 1) * bsize if i < 9 else n
+        win = event_seq[i * bsize:end]
+        if not win:
+            continue
+        top_seq.append(Counter(win).most_common(1)[0][0])
+    if not top_seq:
+        return "—"
+    mode_share = Counter(top_seq).most_common(1)[0][1] / len(top_seq)
+    n_unique = len(set(top_seq))
+    switches = sum(1 for i in range(1, len(top_seq)) if top_seq[i] != top_seq[i - 1])
+    if mode_share >= 0.80:
+        return "Mono"
+    if switches >= 6 and n_unique >= 4:
+        return "Chaos"
+    if switches <= 4 and n_unique <= 3:
+        return "Phased"
+    return "Mixed"
+
+
+# ─── Stack (file path → frontend/backend/infra/docs/config/other) ─────────
+
+
+_INFRA_K8S = re.compile(
+    r"(values\.yaml|chart\.yaml|deployment\.yaml|service\.yaml|ingress\.yaml|"
+    r"configmap\.yaml|hpa\.yaml|statefulset\.yaml|/charts/|/templates/|"
+    r"/helm/|/k8s/|/kubernetes/|deckhouse|werf\.yaml)",
+    re.I,
+)
+_INFRA_CI = re.compile(r"(\.github/workflows/|\.gitlab-ci|/ci/|/pipelines/|jenkinsfile)", re.I)
+_FRONT_DIRS = re.compile(
+    r"(/(frontend|ui|web|client|dashboard|landing|admin|wwwroot|public|static|"
+    r"pages|components|views)(/|$))",
+    re.I,
+)
+_FRONT_DASH = re.compile(
+    r"(-ui(/|$|-)|-web(/|$|-)|-frontend(/|$|-)|-dashboard(/|$|-)|-landing(/|$|-)"
+    r"|-admin(/|$|-)|-app(/|$|-)|-client(/|$|-))",
+    re.I,
+)
+_BACK_DIRS = re.compile(
+    r"(/(api|backend|server|worker|services|service|cron|jobs|consumer|producer|graphql)(/|$))",
+    re.I,
+)
+_BACK_DASH = re.compile(
+    r"(-api(/|$|-)|-service(/|$|-)|-worker(/|$|-)|-server(/|$|-)|-bot(/|$|-)|"
+    r"-consumer(/|$|-)|-cron(/|$|-)|-mcp(/|$|-))",
+    re.I,
+)
+
+
+def stack_of(file_path: str) -> str:
+    """Classify a file path into frontend / backend / infra / docs / config / other."""
+    if not file_path:
+        return "other"
+    p = file_path.lower()
+    fname = os.path.basename(p)
+    ext = "." + fname.rsplit(".", 1)[1] if "." in fname else ""
+
+    # Skip lockfiles and binaries
+    if ext in (".lock", ".lockb"):
+        return "other"
+    if fname.endswith((".png", ".jpg", ".gif", ".ico", ".svg", ".bin", ".so", ".dll",
+                       ".exe", ".zip", ".tar", ".gz")):
+        return "other"
+
+    # Infra
+    if ext in (".tf", ".tfvars", ".hcl"):
+        return "infra"
+    if "dockerfile" in fname or "compose.yml" in fname or "compose.yaml" in fname:
+        return "infra"
+    if _INFRA_CI.search(p):
+        return "infra"
+    if ext in (".yaml", ".yml"):
+        if _INFRA_K8S.search(p):
+            return "infra"
+        return "config"
+    if ext in (".sh", ".bash", ".zsh", ".fish"):
+        return "infra"
+
+    # Docs
+    if ext in (".md", ".mdx", ".rst", ".adoc"):
+        return "docs"
+    if ext == ".txt":
+        return "docs"
+
+    # Frontend explicit
+    if ext in (".tsx", ".jsx"):
+        return "frontend"
+    if ext in (".vue", ".svelte"):
+        return "frontend"
+    if ext in (".css", ".scss", ".sass", ".less", ".styl", ".pcss"):
+        return "frontend"
+    if ext == ".html":
+        return "frontend"
+
+    # Path-based
+    is_front = bool(_FRONT_DIRS.search(p) or _FRONT_DASH.search(p))
+    is_back = bool(_BACK_DIRS.search(p) or _BACK_DASH.search(p))
+
+    if ext in (".ts", ".js", ".mjs", ".cjs"):
+        if is_front and not is_back:
+            return "frontend"
+        return "backend"
+    if ext in (".py", ".rs", ".go", ".sql", ".proto", ".graphql"):
+        return "backend"
+    if ext in (".java", ".kt", ".kts", ".rb", ".php", ".cs"):
+        return "backend"
+    if ext == ".swift":
+        return "frontend"
+
+    if ext == ".toml":
+        return "config"
+    if ext in (".ini",):
+        return "config"
+    if ext == ".json":
+        return "config"
+
+    return "other"
+
+
+# ─── Bash subcategory ─────────────────────────────────────────────────────
+
+
+_BASH_RX = [
+    ("git",     re.compile(r"\b(git\s+|gh\s+|glab\s+)", re.I)),
+    ("test",    re.compile(r"\b(cargo\s+test|cargo\s+nextest|pytest|jest|vitest|"
+                           r"nx\s+\S+\s+test|playwright(?!-cli)|npm\s+test|pnpm\s+test)\b", re.I)),
+    ("build",   re.compile(r"\b(cargo\s+(?:build|check)|tsc|vite\s+build|webpack|"
+                           r"nx\s+\S+\s+build|cargo\s+ndk)\b", re.I)),
+    ("run",     re.compile(r"\b(cargo\s+run|npm\s+(?:start|run)|pnpm\s+(?:start|run|dev)|"
+                           r"node\s+|deno\s+(?:run|task)|python[23]?\s+|uv\s+run|bun\s+run)\b", re.I)),
+    ("device",  re.compile(r"\b(adb\s+|simctl\s+|fastboot|ios-deploy)\b", re.I)),
+    ("deploy",  re.compile(r"\b(kubectl|helm\s+|terraform\s+|werf\s+|"
+                           r"docker\s+(?:compose|run|build)|docker-compose|skopeo|podman)\b", re.I)),
+    ("format",  re.compile(r"\b(prettier|black\s+|rustfmt|cargo\s+fmt|eslint|ruff|clippy)\b", re.I)),
+    ("net",     re.compile(r"\b(curl\s+|wget\s+|ping\s+|nc\s+)", re.I)),
+    ("playwright_cli", re.compile(r"playwright-cli", re.I)),
+    ("shell",   re.compile(r"^\s*(?:cd|ls|cat|head|tail|mv|cp|mkdir|find|grep|sed|"
+                           r"awk|rg|tree|chmod|touch|rm|pwd|tar|wc|sort|uniq|tee|jq|yq|echo)\b")),
+]
+
+
+def bash_sub_of(cmd: str) -> str:
+    """Classify a bash command into git / test / build / run / device / deploy /
+    format / net / playwright_cli / shell / other."""
+    if not cmd:
+        return "other"
+    c = cmd.strip()
+    for label, rx in _BASH_RX:
+        if rx.search(c):
+            return label
+    return "other"
+
+
+# ─── Conventional commits ─────────────────────────────────────────────────
+
+
+COMMIT_HEAD_RX = re.compile(
+    r"\b(feat|fix|refactor|chore|docs|test|ci|perf|style|build|revert)"
+    r"(\([\w\-,/]+\))?(!)?\s*:\s*(.*)",
+    re.I | re.DOTALL,
+)
+COMMIT_REVIEW_RX = re.compile(
+    r"(review|review[- ]?comment|комментар|обратн[ыая]|copilot|artslob|cr[\s-]|"
+    r"nitpick|address|reviewer|по\s+ревью|fix\s+review|after\s+review)",
+    re.I,
+)
+
+
+def commit_type_of(message_first_line: str) -> str:
+    """Extract conventional commit type, or 'uncategorized'."""
+    m = COMMIT_HEAD_RX.match(message_first_line)
+    return m.group(1).lower() if m else "uncategorized"
+
+
+def is_review_fix(message_body: str) -> bool:
+    """Heuristic: does this fix-commit reference review feedback?"""
+    return bool(COMMIT_REVIEW_RX.search(message_body))

--- a/.claude/skills/analyze-usage/lib/io.py
+++ b/.claude/skills/analyze-usage/lib/io.py
@@ -1,0 +1,53 @@
+"""I/O helpers for extractors: parquet write + output paths."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+DEFAULT_OUTPUTS = Path(__file__).resolve().parent.parent / "outputs"
+
+
+def outputs_dirs(base: Path | None = None) -> tuple[Path, Path]:
+    """Return (raw_dir, anon_dir), creating them if needed.
+
+    Backwards-compatible: returns just (raw, anon). Use `outputs_dirs_v2()`
+    if you also need the LLM dir.
+    """
+    raw, anon, _ = outputs_dirs_v2(base)
+    return raw, anon
+
+
+def outputs_dirs_v2(base: Path | None = None) -> tuple[Path, Path, Path]:
+    """Three-tier output directories.
+
+    raw/   — Tier 1 stat extraction with original identifiers (owner-only)
+    anon/  — Tier 1 anonymized version (shareable)
+    llm/   — Tier 2 LLM-augmented features (session names, phase narratives,
+             pattern interpretations). Owner-only because narrative content
+             may include real session/project names.
+    """
+    base = Path(base) if base else DEFAULT_OUTPUTS
+    raw = base / "raw"
+    anon = base / "anon"
+    llm = base / "llm"
+    for d in (raw, anon, llm):
+        d.mkdir(parents=True, exist_ok=True)
+    return raw, anon, llm
+
+
+def write_parquet(rows: list[dict], path: Path) -> int:
+    """Write rows to parquet. Returns number of rows written."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        # write an empty marker so pipeline can detect the run happened
+        empty = pa.Table.from_pylist([])
+        pq.write_table(empty, str(path))
+        return 0
+    table = pa.Table.from_pylist(rows)
+    pq.write_table(table, str(path), compression="snappy")
+    return len(rows)

--- a/.claude/skills/analyze-usage/lib/io.py
+++ b/.claude/skills/analyze-usage/lib/io.py
@@ -40,12 +40,26 @@ def outputs_dirs_v2(base: Path | None = None) -> tuple[Path, Path, Path]:
     return raw, anon, llm
 
 
-def write_parquet(rows: list[dict], path: Path) -> int:
-    """Write rows to parquet. Returns number of rows written."""
+def write_parquet(
+    rows: list[dict], path: Path, schema: pa.Schema | None = None
+) -> int:
+    """Write rows to parquet. Returns number of rows written.
+
+    When `rows` is empty and `schema` is provided, writes an empty table
+    with the given schema so downstream consumers see a stable column set
+    (matters for Tier-2 stubs like `session_names.parquet` where the
+    file may be queried before any rows are populated).
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     if not rows:
-        # write an empty marker so pipeline can detect the run happened
-        empty = pa.Table.from_pylist([])
+        # Write an empty marker so the pipeline can detect the run happened.
+        if schema is not None:
+            empty = pa.Table.from_arrays(
+                [pa.array([], type=field.type) for field in schema],
+                schema=schema,
+            )
+        else:
+            empty = pa.Table.from_pylist([])
         pq.write_table(empty, str(path))
         return 0
     table = pa.Table.from_pylist(rows)

--- a/.claude/skills/analyze-usage/lib/parsers.py
+++ b/.claude/skills/analyze-usage/lib/parsers.py
@@ -21,10 +21,12 @@ from typing import Iterable, Iterator
 
 # ─── Paths ────────────────────────────────────────────────────────────────
 
-DEFAULT_ROOT = Path.home() / ".claude" / "projects"
+DEFAULT_ROOT = Path(os.environ.get("CLAUDE_PROJECTS_ROOT", str(Path.home() / ".claude" / "projects")))
 
 
-def find_session_files(root: Path = DEFAULT_ROOT) -> list[Path]:
+def find_session_files(root: Path | None = None) -> list[Path]:
+    if root is None:
+        root = Path(os.environ.get("CLAUDE_PROJECTS_ROOT", str(DEFAULT_ROOT)))
     """Return all main-session jsonl files (top-level under each project dir).
 
     Subagent jsonls live one level deeper (in `<sid>/subagents/`) and are
@@ -54,12 +56,14 @@ def find_subagents(session_jsonl: Path) -> list[Path]:
     return sorted(sub_dir.glob("agent-*.jsonl"))
 
 
-def project_name_from_path(jsonl: Path, root: Path = DEFAULT_ROOT) -> str:
+def project_name_from_path(jsonl: Path, root: Path | None = None) -> str:
     """Reconstruct the original project path from the encoded directory name.
 
     Claude Code stores `~/projects/foo/bar` as `~/.claude/projects/-foo-bar`
     (slashes replaced with dashes, leading dash for the absolute root).
     """
+    if root is None:
+        root = Path(os.environ.get("CLAUDE_PROJECTS_ROOT", str(DEFAULT_ROOT)))
     proj_dir = jsonl.parent
     while proj_dir.parent != root and proj_dir != root:
         # subagent jsonl is two levels deep; walk up to the project dir
@@ -512,7 +516,7 @@ def load_session(
     since: datetime | None = None,
     until: datetime | None = None,
     include_subagents: bool = True,
-    root: Path = DEFAULT_ROOT,
+    root: Path | None = None,
 ) -> ParsedSession:
     """Parse one main-session jsonl and (optionally) all its subagents."""
     events = list(parse_session(jsonl, since=since, until=until))

--- a/.claude/skills/analyze-usage/lib/parsers.py
+++ b/.claude/skills/analyze-usage/lib/parsers.py
@@ -1,0 +1,541 @@
+"""Parsers for Claude Code session jsonl files.
+
+Reads `~/.claude/projects/<project>/<session_uuid>.jsonl` and the matching
+subagent files at `~/.claude/projects/<project>/<session_uuid>/subagents/agent-*.jsonl`.
+
+The parsers return plain Python data — extractors decide how to aggregate.
+No anonymization happens here; that lives in `lib/anonymize.py` and is applied
+by the extractor when writing to `outputs/anon/`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, Iterator
+
+
+# ─── Paths ────────────────────────────────────────────────────────────────
+
+DEFAULT_ROOT = Path.home() / ".claude" / "projects"
+
+
+def find_session_files(root: Path = DEFAULT_ROOT) -> list[Path]:
+    """Return all main-session jsonl files (top-level under each project dir).
+
+    Subagent jsonls live one level deeper (in `<sid>/subagents/`) and are
+    excluded here. Use `find_subagents()` for those.
+    """
+    if not root.exists():
+        return []
+    out: list[Path] = []
+    for proj_dir in sorted(root.iterdir()):
+        if not proj_dir.is_dir():
+            continue
+        for jf in sorted(proj_dir.glob("*.jsonl")):
+            out.append(jf)
+    return out
+
+
+def find_subagents(session_jsonl: Path) -> list[Path]:
+    """Return subagent jsonl files spawned from a given main-session jsonl.
+
+    Subagents live at `<project>/<sid>/subagents/agent-*.jsonl` where
+    `<sid>` matches the basename of the main jsonl (without `.jsonl`).
+    """
+    sid = session_jsonl.stem
+    sub_dir = session_jsonl.parent / sid / "subagents"
+    if not sub_dir.exists():
+        return []
+    return sorted(sub_dir.glob("agent-*.jsonl"))
+
+
+def project_name_from_path(jsonl: Path, root: Path = DEFAULT_ROOT) -> str:
+    """Reconstruct the original project path from the encoded directory name.
+
+    Claude Code stores `~/projects/foo/bar` as `~/.claude/projects/-foo-bar`
+    (slashes replaced with dashes, leading dash for the absolute root).
+    """
+    proj_dir = jsonl.parent
+    while proj_dir.parent != root and proj_dir != root:
+        # subagent jsonl is two levels deep; walk up to the project dir
+        proj_dir = proj_dir.parent
+        if proj_dir == proj_dir.parent:  # filesystem root, give up
+            return jsonl.parent.name
+    return proj_dir.name.lstrip("-").replace("-", "/")
+
+
+# ─── Event model ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class Event:
+    """One parsed line from a session jsonl."""
+
+    ts: datetime
+    type: str  # 'user' | 'assistant' | 'compact_boundary' | 'system' | ...
+    raw: dict  # original record for downstream consumers
+
+    # User-message-only fields
+    user_kind: str | None = None
+    """One of: 'real_human' | 'tool_result' | 'task_notification' |
+    'meta' | 'slash_meta' | 'system_reminder' | 'hook' | 'caveat' |
+    'cmd_output' | 'unknown'.
+
+    Set only when `type == 'user'`. `real_human` is the only category that
+    counts as a user-typed prompt for biome/growth metrics.
+    """
+    user_text: str = ""
+    """First text-block content if type=='user' and user_kind in
+    ('real_human', 'task_notification'). Empty otherwise."""
+
+    # Assistant-message-only fields
+    text_chars: int = 0
+    tool_uses: list[dict] = field(default_factory=list)
+    """Each entry: {'name': str, 'input': dict, 'id': str}."""
+    in_tokens: int = 0
+    out_tokens: int = 0
+    cache_read: int = 0
+    cache_create: int = 0
+
+
+META_PREFIXES = (
+    "<command-name>",
+    "<system-reminder>",
+    "<user-prompt-submit-hook>",
+    "<local-command-stdout>",
+    "Caveat:",
+)
+
+
+def _classify_user_kind(rec: dict, content: list | str | None, ctype: str, text: str) -> str:
+    """Classify a user-typed message into one of several buckets."""
+    if rec.get("isMeta"):
+        return "meta"
+    if ctype == "tool_result":
+        return "tool_result"
+    if not isinstance(text, str):
+        return "unknown"
+    if text.startswith("<task-notification>"):
+        return "task_notification"
+    if text.startswith("<command-name>"):
+        return "slash_meta"
+    if text.startswith("<system-reminder>"):
+        return "system_reminder"
+    if text.startswith("<user-prompt-submit-hook>"):
+        return "hook"
+    if text.startswith("<local-command-stdout>"):
+        return "cmd_output"
+    if text.startswith("Caveat:"):
+        return "caveat"
+    if ctype in ("string", "text"):
+        return "real_human"
+    return "unknown"
+
+
+def _is_compact(rec: dict) -> bool:
+    if rec.get("type") == "compact_boundary":
+        return True
+    if rec.get("isCompactSummary"):
+        return True
+    if rec.get("type") == "summary":
+        return True
+    return False
+
+
+def parse_session(
+    jsonl: Path,
+    *,
+    since: datetime | None = None,
+    until: datetime | None = None,
+) -> Iterator[Event]:
+    """Yield `Event` objects from a session jsonl file.
+
+    Optional `since`/`until` filter by timestamp (UTC, half-open range).
+    Malformed lines are skipped silently. Records without a parseable
+    timestamp are skipped.
+    """
+    try:
+        fh = jsonl.open("r", encoding="utf-8", errors="ignore")
+    except OSError:
+        return
+    with fh:
+        for line in fh:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts_raw = rec.get("timestamp")
+            if not ts_raw:
+                continue
+            try:
+                ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                continue
+            if since is not None and ts < since:
+                continue
+            if until is not None and ts >= until:
+                continue
+
+            ev_type = rec.get("type", "?")
+
+            # Compact events are surfaced as a special type for downstream consumers.
+            if _is_compact(rec):
+                yield Event(ts=ts, type="compact", raw=rec)
+                continue
+
+            if ev_type == "assistant":
+                msg = rec.get("message") or {}
+                usage = msg.get("usage", {}) if isinstance(msg, dict) else {}
+                content = msg.get("content") if isinstance(msg, dict) else None
+                tool_uses: list[dict] = []
+                text_chars = 0
+                if isinstance(content, list):
+                    for blk in content:
+                        if not isinstance(blk, dict):
+                            continue
+                        bt = blk.get("type", "")
+                        if bt == "tool_use":
+                            tool_uses.append(
+                                {
+                                    "name": blk.get("name", "?"),
+                                    "input": blk.get("input") or {},
+                                    "id": blk.get("id", ""),
+                                }
+                            )
+                        elif bt == "text":
+                            text_chars += len(blk.get("text", "") or "")
+                yield Event(
+                    ts=ts,
+                    type="assistant",
+                    raw=rec,
+                    text_chars=text_chars,
+                    tool_uses=tool_uses,
+                    in_tokens=int(usage.get("input_tokens") or 0),
+                    out_tokens=int(usage.get("output_tokens") or 0),
+                    cache_read=int(usage.get("cache_read_input_tokens") or 0),
+                    cache_create=int(usage.get("cache_creation_input_tokens") or 0),
+                )
+                continue
+
+            if ev_type == "user":
+                msg = rec.get("message") or {}
+                content = msg.get("content") if isinstance(msg, dict) else None
+                ctype = ""
+                text = ""
+                if isinstance(content, list) and content:
+                    first = content[0] if isinstance(content[0], dict) else {}
+                    ctype = first.get("type", "")
+                    if ctype == "text":
+                        text = first.get("text", "") or ""
+                elif isinstance(content, str):
+                    ctype = "string"
+                    text = content
+                kind = _classify_user_kind(rec, content, ctype, text)
+                yield Event(
+                    ts=ts,
+                    type="user",
+                    raw=rec,
+                    user_kind=kind,
+                    user_text=text if kind in ("real_human", "task_notification") else "",
+                )
+                continue
+
+            # Other types ('system', 'queue-operation', 'attachment', 'pr-link', ...) — pass through.
+            yield Event(ts=ts, type=ev_type, raw=rec)
+
+
+# ─── Bursts ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Burst:
+    """One human-prompt → agent-response cycle."""
+
+    sid: str
+    project: str
+    start: datetime
+    end: datetime
+    is_notify: bool
+    """True if this burst was opened by a `<task-notification>` (Monitor
+    trigger) rather than a real human prompt."""
+    prompt: str
+    """First 200 chars of the user prompt (or notification summary)."""
+    inferences: int = 0
+    text_chars: int = 0
+    tool_uses: list[dict] = field(default_factory=list)
+    in_tokens: int = 0
+    out_tokens: int = 0
+    cache_read: int = 0
+    cache_create: int = 0
+    context_size_max: int = 0
+    """Max of (input_tokens + cache_read + cache_create) across the burst's
+    assistant turns. Approximates the largest context window observed."""
+    final_text: str = ""
+    """Last assistant text-only/mixed message, truncated to 200 chars."""
+
+
+def build_bursts(events: Iterable[Event], sid: str, project: str) -> list[Burst]:
+    """Group events into bursts (one per real_human or task_notification prompt).
+
+    Tool-result and meta user messages are absorbed into the current burst.
+    Compact events terminate the current burst (the next user prompt starts
+    a fresh one).
+    """
+    bursts: list[Burst] = []
+    cur: Burst | None = None
+    for ev in events:
+        if ev.type == "compact":
+            if cur is not None:
+                bursts.append(cur)
+                cur = None
+            continue
+        if ev.type == "user":
+            if ev.user_kind in ("real_human", "task_notification"):
+                if cur is not None:
+                    bursts.append(cur)
+                cur = Burst(
+                    sid=sid,
+                    project=project,
+                    start=ev.ts,
+                    end=ev.ts,
+                    is_notify=(ev.user_kind == "task_notification"),
+                    prompt=ev.user_text[:200].replace("\n", " / "),
+                )
+            # tool_result / meta / etc. — stay in current burst, no new burst
+            continue
+        if ev.type == "assistant" and cur is not None:
+            cur.inferences += 1
+            cur.end = ev.ts
+            cur.text_chars += ev.text_chars
+            cur.tool_uses.extend(ev.tool_uses)
+            cur.in_tokens += ev.in_tokens
+            cur.out_tokens += ev.out_tokens
+            cur.cache_read += ev.cache_read
+            cur.cache_create += ev.cache_create
+            ctx = ev.in_tokens + ev.cache_read + ev.cache_create
+            if ctx > cur.context_size_max:
+                cur.context_size_max = ctx
+            for blk in ev.raw.get("message", {}).get("content", []) or []:
+                if isinstance(blk, dict) and blk.get("type") == "text":
+                    t = (blk.get("text") or "")[:200].replace("\n", " / ")
+                    if t:
+                        cur.final_text = t
+    if cur is not None:
+        bursts.append(cur)
+    return bursts
+
+
+# ─── Bash chain splitter ─────────────────────────────────────────────────
+
+
+_SHELL_OPEN = re.compile(r"\b(for|while|until|if|case|select)\b")
+_SHELL_CLOSE = re.compile(r"\b(done|fi|esac)\b")
+_HEREDOC_OPEN = re.compile(r"<<-?\s*([\'\"]?)(\w+)\1")
+
+
+def split_chain(cmd: str) -> list[str]:
+    """Split a bash command into top-level parts at &&, ||, and ;.
+
+    Honors single/double/backtick quoting, $(...) / ${...} substitution,
+    parentheses/braces depth, heredocs, and control-flow blocks (so
+    `for x; do a; done` stays one part). Escape sequences are passed
+    through unchanged.
+
+    Used by `lib/classifiers.classify_bash_part` to label each part as
+    read / write / build / test / env / neutral.
+    """
+    if not cmd:
+        return []
+
+    parts: list[str] = []
+    cur: list[str] = []
+    in_single = False
+    in_double = False
+    in_back = False
+    in_heredoc = False
+    heredoc_marker: str | None = None
+    paren_depth = 0
+    cf_depth = 0
+    i = 0
+    n = len(cmd)
+
+    def at_word_boundary(pos: int) -> bool:
+        return pos == 0 or (not cmd[pos - 1].isalnum() and cmd[pos - 1] != "_")
+
+    while i < n:
+        c = cmd[i]
+
+        # Inside a heredoc body, copy verbatim and look for the closing marker
+        if in_heredoc:
+            cur.append(c)
+            if c == "\n":
+                rest = cmd[i + 1 :]
+                line_end = rest.find("\n")
+                line = rest if line_end < 0 else rest[:line_end]
+                if line.strip() == heredoc_marker:
+                    cur.append(line + ("\n" if line_end >= 0 else ""))
+                    i += 1 + len(line) + (1 if line_end >= 0 else 0)
+                    in_heredoc = False
+                    heredoc_marker = None
+                    continue
+            i += 1
+            continue
+
+        # Quote toggling
+        if not in_double and not in_back and c == "'":
+            in_single = not in_single
+            cur.append(c)
+            i += 1
+            continue
+        if not in_single and not in_back and c == '"':
+            in_double = not in_double
+            cur.append(c)
+            i += 1
+            continue
+        if not in_single and not in_double and c == "`":
+            in_back = not in_back
+            cur.append(c)
+            i += 1
+            continue
+        if in_single or in_double or in_back:
+            cur.append(c)
+            i += 1
+            continue
+
+        # Escape
+        if c == "\\" and i + 1 < n:
+            cur.append(c)
+            cur.append(cmd[i + 1])
+            i += 2
+            continue
+
+        # Heredoc opener
+        m_hd = _HEREDOC_OPEN.match(cmd[i:])
+        if m_hd:
+            heredoc_marker = m_hd.group(2)
+            in_heredoc = True
+            cur.append(cmd[i : i + m_hd.end()])
+            i += m_hd.end()
+            continue
+
+        # Substitution: $(...) and ${...}
+        if cmd[i : i + 2] in ("$(", "${"):
+            paren_depth += 1
+            cur.append(cmd[i])
+            cur.append(cmd[i + 1])
+            i += 2
+            continue
+        if c == "(" or c == "{":
+            paren_depth += 1
+            cur.append(c)
+            i += 1
+            continue
+        if c == ")" or c == "}":
+            paren_depth = max(0, paren_depth - 1)
+            cur.append(c)
+            i += 1
+            continue
+
+        # Control-flow keywords (only at word boundaries, top paren level)
+        if paren_depth == 0 and at_word_boundary(i):
+            mo = _SHELL_OPEN.match(cmd[i:])
+            if mo:
+                cur.append(cmd[i : i + mo.end()])
+                cf_depth += 1
+                i += mo.end()
+                continue
+            mc = _SHELL_CLOSE.match(cmd[i:])
+            if mc:
+                cur.append(cmd[i : i + mc.end()])
+                cf_depth = max(0, cf_depth - 1)
+                i += mc.end()
+                continue
+
+        # Top-level splitters
+        if paren_depth == 0 and cf_depth == 0:
+            if cmd[i : i + 2] in ("&&", "||"):
+                parts.append("".join(cur).strip())
+                cur = []
+                i += 2
+                continue
+            if cmd[i : i + 2] == ";;":  # case fallthrough — keep glued
+                cur.append(cmd[i : i + 2])
+                i += 2
+                continue
+            if c == ";":
+                parts.append("".join(cur).strip())
+                cur = []
+                i += 1
+                continue
+
+        cur.append(c)
+        i += 1
+
+    if cur:
+        parts.append("".join(cur).strip())
+    return [p for p in parts if p]
+
+
+# ─── Convenience: end-to-end load ────────────────────────────────────────
+
+
+@dataclass
+class ParsedSession:
+    """Result of parsing one main-session jsonl plus its subagents."""
+
+    sid: str
+    """Full session UUID (basename of the jsonl file)."""
+    project: str
+    """Project path, dashes restored back to slashes."""
+    jsonl_path: Path
+    events: list[Event]
+    bursts: list[Burst]
+    subagents: list["ParsedSubagent"] = field(default_factory=list)
+
+
+@dataclass
+class ParsedSubagent:
+    sub_id: str
+    parent_sid: str
+    jsonl_path: Path
+    events: list[Event]
+
+
+def load_session(
+    jsonl: Path,
+    *,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    include_subagents: bool = True,
+    root: Path = DEFAULT_ROOT,
+) -> ParsedSession:
+    """Parse one main-session jsonl and (optionally) all its subagents."""
+    events = list(parse_session(jsonl, since=since, until=until))
+    sid = jsonl.stem
+    project = project_name_from_path(jsonl, root=root)
+    bursts = build_bursts(events, sid=sid, project=project)
+    subagents: list[ParsedSubagent] = []
+    if include_subagents:
+        for sf in find_subagents(jsonl):
+            sub_events = list(parse_session(sf, since=since, until=until))
+            subagents.append(
+                ParsedSubagent(
+                    sub_id=sf.stem.removeprefix("agent-"),
+                    parent_sid=sid,
+                    jsonl_path=sf,
+                    events=sub_events,
+                )
+            )
+    return ParsedSession(
+        sid=sid,
+        project=project,
+        jsonl_path=jsonl,
+        events=events,
+        bursts=bursts,
+        subagents=subagents,
+    )

--- a/.claude/skills/analyze-usage/lib/parsers.py
+++ b/.claude/skills/analyze-usage/lib/parsers.py
@@ -25,13 +25,13 @@ DEFAULT_ROOT = Path(os.environ.get("CLAUDE_PROJECTS_ROOT", str(Path.home() / ".c
 
 
 def find_session_files(root: Path | None = None) -> list[Path]:
-    if root is None:
-        root = Path(os.environ.get("CLAUDE_PROJECTS_ROOT", str(DEFAULT_ROOT)))
     """Return all main-session jsonl files (top-level under each project dir).
 
     Subagent jsonls live one level deeper (in `<sid>/subagents/`) and are
     excluded here. Use `find_subagents()` for those.
     """
+    if root is None:
+        root = Path(os.environ.get("CLAUDE_PROJECTS_ROOT", str(DEFAULT_ROOT)))
     if not root.exists():
         return []
     out: list[Path] = []

--- a/.claude/skills/analyze-usage/lib/render.py
+++ b/.claude/skills/analyze-usage/lib/render.py
@@ -1,0 +1,747 @@
+"""Period-report renderers: terminal / markdown / HTML.
+
+All three consume the same `aggregate()` data dict (from period_report.py)
+and produce a string. The terminal renderer mirrors what we used to print
+inline; markdown is GitHub/Slack-friendly; HTML is a single-file page with
+inline CSS (dark theme, biome colours).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta
+from html import escape as h
+
+from .classifiers import (
+    ARCHETYPE_EMOJI,
+    BIOME_EMOJI,
+    RHYTHM_EMOJI,
+)
+
+
+# ─── Common helpers ───────────────────────────────────────────────────────
+
+
+_BIOMES_ORDER = ["Whale", "Shark", "Dolphin", "Fish", "Shrimp", "Plankton"]
+_ARCHS_ORDER = ["Operator", "Researcher", "Polymath", "Inspector", "Builder",
+                "Scholar", "Constructor", "Discusser"]
+_RHYTHMS_ORDER = ["Mono", "Phased", "Mixed", "Chaos", "—"]
+_STACKS_ORDER = ["backend", "frontend", "infra", "docs", "config", "other"]
+_STACK_EMOJI = {
+    "frontend": "🎨", "backend": "⚡", "infra": "☁️",
+    "docs": "📖", "config": "⚙", "other": "📦",
+}
+# Biome colours for HTML
+_BIOME_COLOR = {
+    "Whale":    "#1e3a8a",  # deep navy
+    "Shark":    "#0369a1",  # steel blue
+    "Dolphin":  "#0891b2",  # sky / cyan
+    "Fish":     "#0d9488",  # teal
+    "Shrimp":   "#ea580c",  # coral
+    "Plankton": "#a3a3a3",  # neutral grey
+}
+
+
+def cfr_level(cfr: float) -> tuple[str, str]:
+    """Return (emoji, level)."""
+    if cfr < 0.3:
+        return ("🟢", "Elite")
+    if cfr < 1:
+        return ("🟡", "High")
+    if cfr < 3:
+        return ("🟠", "Medium")
+    return ("🔴", "Low")
+
+
+# ─── Terminal renderer ────────────────────────────────────────────────────
+
+
+def _term_aquarium(biomes: Counter) -> list[str]:
+    out = ["  🌊 АКВАРИУМ:"]
+    for b in _BIOMES_ORDER:
+        n = biomes.get(b, 0)
+        if n == 0:
+            continue
+        em = BIOME_EMOJI[b]
+        visual = em * n if n <= 30 else em * 5 + f"·×{n}"
+        out.append(f"     {b:<10s}  {visual}")
+    return out
+
+
+def _term_archs(archs: Counter, total: int) -> list[str]:
+    out = ["  🎭 АРХЕТИПЫ:"]
+    if total == 0:
+        return out
+    max_a = max(archs.values()) if archs else 1
+    width = 30
+    for a in _ARCHS_ORDER:
+        n = archs.get(a, 0)
+        if n == 0:
+            continue
+        bar_n = int(n * width / max_a)
+        bars = "█" * bar_n + "░" * (width - bar_n)
+        out.append(f"    {ARCHETYPE_EMOJI[a]} {a:<14s} {n:>3d}  │{bars}│ {n*100/total:>4.1f}%")
+    return out
+
+
+def _term_rhythm(rhythms: Counter, total: int) -> list[str]:
+    out = ["  🎵 РИТМЫ:"]
+    if total == 0:
+        return out
+    for r in _RHYTHMS_ORDER:
+        n = rhythms.get(r, 0)
+        if n == 0:
+            continue
+        em = RHYTHM_EMOJI[r]
+        bars = em * int(n * 20 / total)
+        out.append(f"     {em} {r:<8s} {n:>3d}  {bars}")
+    return out
+
+
+def _term_stack(stack_loc: Counter) -> list[str]:
+    out = ["  🎨 ПАЛИТРА КОДА (LOC):"]
+    total = sum(stack_loc.values()) or 1
+    for st in _STACKS_ORDER:
+        v = stack_loc.get(st, 0)
+        if v == 0:
+            continue
+        pct = v * 100 / total
+        n_icons = max(1, int(pct / 2))
+        bar = (_STACK_EMOJI[st] * n_icons)[:50]
+        out.append(f"     {st:<10s} {pct:>4.1f}%  {bar}")
+    return out
+
+
+def _term_dora(agg: dict) -> list[str]:
+    cfr = (agg["fix"] - agg["review_fix"]) / (agg["feat"] + 1) if agg["feat"] else 0
+    em, level = cfr_level(cfr)
+    return [
+        "  🚀 DORA-радар:",
+        "     ┌────────────────────────────────────────────┐",
+        f"     │  📤 Pushes:       {agg['pushes']:>4d}                       │",
+        f"     │  🔀 PR/MR:        {agg['pr_mr']:>4d}                       │",
+        f"     │  ✨ feat:         {agg['feat']:>4d}                       │",
+        f"     │  🐛 fix:          {agg['fix']:>4d}  (review {agg['review_fix']}, prod {agg['fix']-agg['review_fix']})  │",
+        f"     │  {em} CFR:          {cfr:>4.2f}  [{level:<6s}]            │",
+        "     └────────────────────────────────────────────┘",
+    ]
+
+
+def _term_friction(agg: dict) -> list[str]:
+    return [
+        "  ⚡ ТРЕНИЕ:",
+        f"     compacts ({agg['compacts']})    {'🌀' * min(agg['compacts'] // 10, 30)}",
+        f"     pivots   ({agg['pivots']})    {'🚧' * min(agg['pivots'] // 5, 30)}",
+        f"     subagents({agg['subs']})    {'🤖' * min(agg['subs'] // 20, 30)}",
+    ]
+
+
+def render_period_terminal(label: str, agg: dict) -> list[str]:
+    out: list[str] = []
+    out.append("")
+    out.append("▓" * 100)
+    out.append(f"  {label}")
+    out.append("▓" * 100)
+    wall_h = int(agg["wall_min"] / 60)
+    act_h = int(agg["active_min"] / 60)
+    ratio = act_h * 100 / wall_h if wall_h else 0
+    out.append(
+        f"  📊 {agg['n']} sessions | +{agg['lines_added']:,} LOC | "
+        f"wall {wall_h}h | active {act_h}h ({ratio:.0f}%)"
+    )
+    out.append("")
+    out.extend(_term_aquarium(agg["biomes"]))
+    out.append("")
+    out.extend(_term_archs(agg["archs"], agg["n"]))
+    out.append("")
+    out.extend(_term_rhythm(agg["rhythms"], agg["n"]))
+    out.append("")
+    out.extend(_term_stack(agg["stack_loc"]))
+    out.append("")
+    out.extend(_term_dora(agg))
+    out.append("")
+    out.extend(_term_friction(agg))
+    return out
+
+
+# ─── Markdown renderer ───────────────────────────────────────────────────
+
+
+def _md_aquarium(biomes: Counter) -> list[str]:
+    out = ["### 🌊 Аквариум", ""]
+    for b in _BIOMES_ORDER:
+        n = biomes.get(b, 0)
+        if n == 0:
+            continue
+        em = BIOME_EMOJI[b]
+        visual = em * n if n <= 30 else em * 5 + f"·×{n}"
+        out.append(f"- {em} **{b}** — {visual}")
+    out.append("")
+    return out
+
+
+def _md_archs(archs: Counter, total: int) -> list[str]:
+    if total == 0:
+        return []
+    out = ["### 🎭 Архетипы", "", "| | Архетип | N | % | |", "|--|--|--:|--:|--|"]
+    for a in _ARCHS_ORDER:
+        n = archs.get(a, 0)
+        if n == 0:
+            continue
+        bar_n = int(n * 20 / max(1, max(archs.values())))
+        bar = "█" * bar_n + "░" * (20 - bar_n)
+        out.append(f"| {ARCHETYPE_EMOJI[a]} | {a} | {n} | {n*100/total:.1f}% | `{bar}` |")
+    out.append("")
+    return out
+
+
+def _md_rhythm(rhythms: Counter, total: int) -> list[str]:
+    if total == 0:
+        return []
+    out = ["### 🎵 Ритмы", "", "| Ритм | N | % |", "|--|--:|--:|"]
+    for r in _RHYTHMS_ORDER:
+        n = rhythms.get(r, 0)
+        if n == 0:
+            continue
+        out.append(f"| {RHYTHM_EMOJI[r]} {r} | {n} | {n*100/total:.1f}% |")
+    out.append("")
+    return out
+
+
+def _md_stack(stack_loc: Counter) -> list[str]:
+    total = sum(stack_loc.values())
+    if total == 0:
+        return []
+    out = ["### 🎨 Палитра кода (LOC)", "", "| Слой | LOC | % |", "|--|--:|--:|"]
+    for st in _STACKS_ORDER:
+        v = stack_loc.get(st, 0)
+        if v == 0:
+            continue
+        pct = v * 100 / total
+        out.append(f"| {_STACK_EMOJI[st]} {st} | {v:,} | {pct:.1f}% |")
+    out.append("")
+    return out
+
+
+def _md_dora(agg: dict) -> list[str]:
+    cfr = (agg["fix"] - agg["review_fix"]) / (agg["feat"] + 1) if agg["feat"] else 0
+    em, level = cfr_level(cfr)
+    return [
+        "### 🚀 DORA",
+        "",
+        "| Метрика | Значение |",
+        "|--|--:|",
+        f"| 📤 Pushes | {agg['pushes']} |",
+        f"| 🔀 PR/MR | {agg['pr_mr']} |",
+        f"| ✨ feat | {agg['feat']} |",
+        f"| 🐛 fix | {agg['fix']} (review {agg['review_fix']}, prod {agg['fix']-agg['review_fix']}) |",
+        f"| {em} **True CFR** | **{cfr:.2f}** ({level}) |",
+        "",
+    ]
+
+
+def _md_friction(agg: dict) -> list[str]:
+    return [
+        "### ⚡ Трение",
+        "",
+        f"- 🌀 compacts: **{agg['compacts']}**",
+        f"- 🚧 pivots: **{agg['pivots']}**",
+        f"- 🤖 subagent spawns: **{agg['subs']}**",
+        "",
+    ]
+
+
+def render_period_markdown(label: str, agg: dict) -> list[str]:
+    out: list[str] = ["", f"## {label}", ""]
+    wall_h = int(agg["wall_min"] / 60)
+    act_h = int(agg["active_min"] / 60)
+    ratio = act_h * 100 / wall_h if wall_h else 0
+    out.append(
+        f"**{agg['n']} sessions** · +{agg['lines_added']:,} LOC · "
+        f"wall {wall_h}h · active {act_h}h ({ratio:.0f}%)"
+    )
+    out.append("")
+    out.extend(_md_aquarium(agg["biomes"]))
+    out.extend(_md_archs(agg["archs"], agg["n"]))
+    out.extend(_md_rhythm(agg["rhythms"], agg["n"]))
+    out.extend(_md_stack(agg["stack_loc"]))
+    out.extend(_md_dora(agg))
+    out.extend(_md_friction(agg))
+    return out
+
+
+# ─── HTML renderer ───────────────────────────────────────────────────────
+
+
+_HTML_HEAD = """<!DOCTYPE html>
+<html lang="ru"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<style>
+:root {{
+  --bg: #0f172a;
+  --panel: #1e293b;
+  --panel-2: #334155;
+  --text: #e2e8f0;
+  --text-dim: #94a3b8;
+  --accent: #06b6d4;
+  --accent-dim: #0891b2;
+  --success: #10b981;
+  --warn: #f59e0b;
+  --danger: #ef4444;
+}}
+* {{ box-sizing: border-box; }}
+body {{
+  margin: 0; padding: 24px;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  background: linear-gradient(180deg, #0c1828 0%, #0f172a 100%);
+  color: var(--text);
+  line-height: 1.5;
+}}
+.container {{ max-width: 1100px; margin: 0 auto; }}
+h1 {{
+  font-size: 2.2rem;
+  background: linear-gradient(135deg, #06b6d4, #0891b2, #0ea5e9);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  margin: 0 0 8px;
+}}
+h2 {{ font-size: 1.6rem; margin: 0 0 12px; }}
+h3 {{ font-size: 1.1rem; margin: 24px 0 12px; color: var(--accent); }}
+.subtitle {{ color: var(--text-dim); margin-bottom: 32px; }}
+.period {{
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 24px;
+  border: 1px solid var(--panel-2);
+}}
+.meta {{
+  color: var(--text-dim);
+  font-size: 0.95rem;
+  margin-bottom: 16px;
+}}
+.meta strong {{ color: var(--text); font-size: 1.2rem; }}
+.aquarium {{ display: flex; flex-wrap: wrap; gap: 8px; }}
+.creature {{
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 500;
+  color: white;
+}}
+.bar-row {{
+  display: grid;
+  grid-template-columns: 180px 1fr 60px;
+  gap: 12px; align-items: center;
+  padding: 4px 0;
+}}
+.bar-label {{ font-weight: 500; }}
+.bar-track {{
+  background: var(--panel-2);
+  border-radius: 4px;
+  overflow: hidden;
+  height: 22px; position: relative;
+}}
+.bar-fill {{
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent-dim), var(--accent));
+  display: flex; align-items: center;
+  padding: 0 8px;
+  color: white; font-size: 0.85rem; font-weight: 500;
+  white-space: nowrap;
+}}
+.bar-value {{ text-align: right; color: var(--text-dim); font-variant-numeric: tabular-nums; }}
+.dora {{
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}}
+.dora-card {{
+  background: var(--panel-2);
+  padding: 12px 16px;
+  border-radius: 8px;
+}}
+.dora-card .label {{ color: var(--text-dim); font-size: 0.85rem; }}
+.dora-card .value {{ font-size: 1.6rem; font-weight: 600; margin-top: 4px; }}
+.dora-card.cfr-elite  {{ border-left: 4px solid var(--success); }}
+.dora-card.cfr-high   {{ border-left: 4px solid var(--warn); }}
+.dora-card.cfr-medium {{ border-left: 4px solid #fb923c; }}
+.dora-card.cfr-low    {{ border-left: 4px solid var(--danger); }}
+.friction {{
+  display: flex; gap: 24px; flex-wrap: wrap;
+  margin-top: 12px;
+}}
+.friction div {{
+  background: var(--panel-2);
+  padding: 8px 14px; border-radius: 6px;
+  font-size: 0.95rem;
+}}
+.weeks-table {{
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 12px;
+  font-size: 0.92rem;
+  font-variant-numeric: tabular-nums;
+}}
+.weeks-table th, .weeks-table td {{
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--panel-2);
+  text-align: left;
+}}
+.weeks-table th {{ color: var(--text-dim); font-weight: 500; }}
+.weeks-table td.num {{ text-align: right; }}
+.bar-mini {{
+  display: inline-block;
+  height: 8px; border-radius: 4px;
+  background: var(--accent);
+  vertical-align: middle;
+}}
+.trends-table {{
+  width: 100%; border-collapse: collapse; margin-top: 12px;
+  font-variant-numeric: tabular-nums;
+}}
+.trends-table th, .trends-table td {{
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--panel-2);
+}}
+.trends-table th {{ text-align: left; color: var(--text-dim); }}
+.trends-table td.num {{ text-align: right; }}
+.trend-arrow {{ font-size: 0.85rem; color: var(--text-dim); }}
+footer {{ color: var(--text-dim); font-size: 0.85rem; margin-top: 32px; text-align: center; }}
+</style></head><body>
+<div class="container">
+"""
+
+_HTML_TAIL = """
+<footer>Generated by analyze-usage skill · {ts}</footer>
+</div></body></html>
+"""
+
+
+def _html_aquarium(biomes: Counter) -> str:
+    out = ['<h3>🌊 Аквариум</h3>', '<div class="aquarium">']
+    for b in _BIOMES_ORDER:
+        n = biomes.get(b, 0)
+        if n == 0:
+            continue
+        em = BIOME_EMOJI[b]
+        color = _BIOME_COLOR[b]
+        out.append(
+            f'<div class="creature" style="background:{color}">'
+            f'{em} {h(b)} × {n}</div>'
+        )
+    out.append("</div>")
+    return "\n".join(out)
+
+
+def _html_bar_chart(title: str, items: list[tuple[str, str, int]], total: int) -> str:
+    """items: list of (emoji, label, count)."""
+    if total == 0:
+        return ""
+    max_v = max((c for _, _, c in items), default=1)
+    out = [f"<h3>{h(title)}</h3>", '<div class="bar-chart">']
+    for em, label, n in items:
+        if n == 0:
+            continue
+        pct = n * 100 / total
+        width = max(2, int(n * 100 / max_v))
+        out.append(
+            '<div class="bar-row">'
+            f'<span class="bar-label">{em} {h(label)}</span>'
+            f'<div class="bar-track"><div class="bar-fill" style="width:{width}%">{pct:.1f}%</div></div>'
+            f'<span class="bar-value">{n}</span>'
+            '</div>'
+        )
+    out.append("</div>")
+    return "\n".join(out)
+
+
+def _html_dora(agg: dict) -> str:
+    cfr = (agg["fix"] - agg["review_fix"]) / (agg["feat"] + 1) if agg["feat"] else 0
+    _, level = cfr_level(cfr)
+    cfr_class = f"cfr-{level.lower()}"
+    cards = [
+        ("📤 Pushes", agg["pushes"], ""),
+        ("🔀 PR/MR", agg["pr_mr"], ""),
+        ("✨ feat", agg["feat"], ""),
+        ("🐛 fix", f"{agg['fix']} ({agg['fix']-agg['review_fix']} prod, {agg['review_fix']} review)", ""),
+        (f"True CFR [{level}]", f"{cfr:.2f}", cfr_class),
+    ]
+    out = ['<h3>🚀 DORA</h3>', '<div class="dora">']
+    for label, val, cls in cards:
+        out.append(
+            f'<div class="dora-card {cls}">'
+            f'<div class="label">{h(str(label))}</div>'
+            f'<div class="value">{h(str(val))}</div>'
+            '</div>'
+        )
+    out.append("</div>")
+    return "\n".join(out)
+
+
+def _html_friction(agg: dict) -> str:
+    return (
+        '<h3>⚡ Трение</h3>'
+        '<div class="friction">'
+        f'<div>🌀 compacts: <strong>{agg["compacts"]}</strong></div>'
+        f'<div>🚧 pivots: <strong>{agg["pivots"]}</strong></div>'
+        f'<div>🤖 subagents: <strong>{agg["subs"]}</strong></div>'
+        '</div>'
+    )
+
+
+def _html_stack(stack_loc: Counter) -> str:
+    total = sum(stack_loc.values())
+    if total == 0:
+        return ""
+    items = []
+    for st in _STACKS_ORDER:
+        v = stack_loc.get(st, 0)
+        if v == 0:
+            continue
+        items.append((_STACK_EMOJI[st], st, v))
+    return _html_bar_chart("🎨 Палитра кода (LOC)", items, total)
+
+
+def render_period_html_section(label: str, agg: dict) -> str:
+    wall_h = int(agg["wall_min"] / 60)
+    act_h = int(agg["active_min"] / 60)
+    ratio = act_h * 100 / wall_h if wall_h else 0
+
+    out = [f'<section class="period"><h2>{h(label)}</h2>']
+    out.append(
+        '<div class="meta">'
+        f'<strong>{agg["n"]} sessions</strong> · '
+        f'+{agg["lines_added"]:,} LOC · '
+        f'wall {wall_h}h · active {act_h}h ({ratio:.0f}%)'
+        '</div>'
+    )
+    out.append(_html_aquarium(agg["biomes"]))
+
+    arch_items = [(ARCHETYPE_EMOJI[a], a, agg["archs"].get(a, 0)) for a in _ARCHS_ORDER]
+    out.append(_html_bar_chart("🎭 Архетипы", arch_items, agg["n"]))
+
+    rhy_items = [(RHYTHM_EMOJI[r], r, agg["rhythms"].get(r, 0)) for r in _RHYTHMS_ORDER]
+    out.append(_html_bar_chart("🎵 Ритмы", rhy_items, agg["n"]))
+
+    out.append(_html_stack(agg["stack_loc"]))
+    out.append(_html_dora(agg))
+    out.append(_html_friction(agg))
+    out.append("</section>")
+    return "\n".join(out)
+
+
+def render_html_doc(title: str, body_sections: list[str]) -> str:
+    head = _HTML_HEAD.format(title=h(title))
+    header = (
+        f'<h1>🌊 {h(title)}</h1>'
+        '<div class="subtitle">'
+        '<em>aquarium of biomes · archetypes · rhythm · stack · DORA</em>'
+        '</div>'
+    )
+    tail = _HTML_TAIL.format(ts=datetime.now().isoformat(timespec="seconds"))
+    return head + header + "\n".join(body_sections) + tail
+
+
+# ─── Weekly table & bars ─────────────────────────────────────────────────
+
+
+def render_weekly_table_terminal(weeks: list[tuple[tuple[int, int], dict]]) -> list[str]:
+    out = []
+    out.append("")
+    out.append("═" * 100)
+    out.append("  📅 НЕДЕЛЬНАЯ ТЕМПЕРАТУРА")
+    out.append("═" * 100)
+    out.append("")
+    out.append(f"  {'неделя':<22s}  {'sess':>4s}  {'+LOC':>7s}  {'feat':>4s}  "
+               f"{'fix':>4s}  {'CFR':>4s}  {'biomes':<32s}  {'top arch':<14s}")
+    out.append(f"  {'─'*22}  {'─'*4}  {'─'*7}  {'─'*4}  {'─'*4}  {'─'*4}  {'─'*32}  {'─'*14}")
+    for (yr, wk), a in weeks:
+        d_start = datetime.fromisocalendar(yr, wk, 1)
+        d_end = d_start + timedelta(days=6)
+        label = f"W{wk:02d} {d_start.strftime('%b %d')}-{d_end.strftime('%b %d')}"
+        biomes_str = ""
+        for b in _BIOMES_ORDER:
+            n = a["biomes"].get(b, 0)
+            if n > 0:
+                biomes_str += BIOME_EMOJI[b] + f"{n} "
+        top_arch = a["archs"].most_common(1)[0] if a["archs"] else ("—", 0)
+        cfr = (a["fix"] - a["review_fix"]) / (a["feat"] + 1) if a["feat"] else 0
+        em, _ = cfr_level(cfr)
+        out.append(
+            f"  {label:<22s}  {a['n']:>4d}  {a['lines_added']:>7,d}  "
+            f"{a['feat']:>4d}  {a['fix']:>4d}  {em}{cfr:>3.1f}  "
+            f"{biomes_str[:32]:<32s}  "
+            f"{ARCHETYPE_EMOJI.get(top_arch[0], '·')+top_arch[0][:11]:<14s}"
+        )
+
+    # Bar charts
+    out.append("")
+    out.append("  📊 +LOC по неделям:")
+    max_loc = max((a["lines_added"] for _, a in weeks), default=1) or 1
+    for (yr, wk), a in weeks:
+        d_start = datetime.fromisocalendar(yr, wk, 1)
+        d_end = d_start + timedelta(days=6)
+        label = f"W{wk:02d} {d_start.strftime('%b %d')}-{d_end.strftime('%b %d')}"
+        bar_n = int(a["lines_added"] * 40 / max_loc)
+        out.append(f"  {label:<22s} │{'█'*bar_n}{'░'*(40-bar_n)}│ {a['lines_added']:>7,d}")
+    return out
+
+
+def render_weekly_table_markdown(weeks: list[tuple[tuple[int, int], dict]]) -> list[str]:
+    out = ["", "## 📅 Недели", ""]
+    out.append("| Неделя | sess | +LOC | feat | fix | CFR | биомы | top archetype |")
+    out.append("|--|--:|--:|--:|--:|--:|--|--|")
+    for (yr, wk), a in weeks:
+        d_start = datetime.fromisocalendar(yr, wk, 1)
+        d_end = d_start + timedelta(days=6)
+        label = f"W{wk:02d} {d_start.strftime('%b %d')}-{d_end.strftime('%b %d')}"
+        biomes_str = ""
+        for b in _BIOMES_ORDER:
+            n = a["biomes"].get(b, 0)
+            if n > 0:
+                biomes_str += BIOME_EMOJI[b] + f"{n} "
+        top_arch = a["archs"].most_common(1)[0] if a["archs"] else ("—", 0)
+        cfr = (a["fix"] - a["review_fix"]) / (a["feat"] + 1) if a["feat"] else 0
+        em, _ = cfr_level(cfr)
+        out.append(
+            f"| {label} | {a['n']} | {a['lines_added']:,} | {a['feat']} | {a['fix']} | "
+            f"{em}{cfr:.1f} | {biomes_str.strip()} | "
+            f"{ARCHETYPE_EMOJI.get(top_arch[0], '·')} {top_arch[0]} |"
+        )
+    out.append("")
+    return out
+
+
+def render_weekly_table_html(weeks: list[tuple[tuple[int, int], dict]]) -> str:
+    if not weeks:
+        return ""
+    max_loc = max((a["lines_added"] for _, a in weeks), default=1) or 1
+    out = ['<section class="period"><h2>📅 Недели</h2>']
+    out.append('<table class="weeks-table">')
+    out.append(
+        '<thead><tr><th>Неделя</th><th class="num">sess</th>'
+        '<th class="num">+LOC</th><th class="num">feat</th><th class="num">fix</th>'
+        '<th class="num">CFR</th><th>биомы</th><th>top arch</th><th>+LOC bar</th></tr></thead>'
+    )
+    out.append("<tbody>")
+    for (yr, wk), a in weeks:
+        d_start = datetime.fromisocalendar(yr, wk, 1)
+        d_end = d_start + timedelta(days=6)
+        label = f"W{wk:02d} {d_start.strftime('%b %d')}-{d_end.strftime('%b %d')}"
+        biomes_str = ""
+        for b in _BIOMES_ORDER:
+            n = a["biomes"].get(b, 0)
+            if n > 0:
+                biomes_str += BIOME_EMOJI[b] + f"{n} "
+        top_arch = a["archs"].most_common(1)[0] if a["archs"] else ("—", 0)
+        cfr = (a["fix"] - a["review_fix"]) / (a["feat"] + 1) if a["feat"] else 0
+        em, _ = cfr_level(cfr)
+        bar_w = int(a["lines_added"] * 200 / max_loc)
+        out.append(
+            f'<tr><td>{h(label)}</td>'
+            f'<td class="num">{a["n"]}</td>'
+            f'<td class="num">{a["lines_added"]:,}</td>'
+            f'<td class="num">{a["feat"]}</td>'
+            f'<td class="num">{a["fix"]}</td>'
+            f'<td class="num">{em} {cfr:.1f}</td>'
+            f'<td>{h(biomes_str.strip())}</td>'
+            f'<td>{ARCHETYPE_EMOJI.get(top_arch[0], "·")} {h(top_arch[0])}</td>'
+            f'<td><span class="bar-mini" style="width:{bar_w}px"></span></td>'
+            "</tr>"
+        )
+    out.append("</tbody></table></section>")
+    return "\n".join(out)
+
+
+# ─── Trends ──────────────────────────────────────────────────────────────
+
+
+def trend_arrow(vs: list[float]) -> str:
+    if all(vs[i] > vs[i - 1] for i in range(1, len(vs))):
+        return "🚀↑↑↑"
+    if all(vs[i] < vs[i - 1] for i in range(1, len(vs))):
+        return "📉↓↓↓"
+    if len(vs) >= 3 and vs[len(vs) // 2] > vs[0] and vs[len(vs) // 2] > vs[-1]:
+        return "🌋 peak mid"
+    if len(vs) >= 3 and vs[len(vs) // 2] < vs[0] and vs[len(vs) // 2] < vs[-1]:
+        return "🪂 dip mid"
+    return "~ stable"
+
+
+_TREND_METRICS = [
+    ("Sessions", "n", "{:,.0f}"),
+    ("+LOC", "lines_added", "{:,.0f}"),
+    ("feat commits", "feat", "{:,.0f}"),
+    ("fix commits", "fix", "{:,.0f}"),
+    ("pushes", "pushes", "{:,.0f}"),
+    ("PR/MR", "pr_mr", "{:,.0f}"),
+    ("compacts", "compacts", "{:,.0f}"),
+    ("pivots", "pivots", "{:,.0f}"),
+    ("subagents", "subs", "{:,.0f}"),
+    ("wall hours", "wall_min", "{:.0f}"),
+    ("active hours", "active_min", "{:.0f}"),
+]
+
+
+def _trend_value(agg: dict, key: str, name: str) -> float:
+    v = agg.get(key, 0)
+    if "hour" in name:
+        return v / 60
+    return v
+
+
+def render_trends_terminal(months_data: dict[int, dict], months_labels: dict[int, str]) -> list[str]:
+    out = ["", "═" * 100, "  📈 ТРЕНДЫ (по периодам)", "═" * 100, ""]
+    keys = sorted(months_data.keys())
+    if len(keys) < 2:
+        return out
+    headers = "  ".join(f"{months_labels[k][:14]:>14s}" for k in keys)
+    out.append(f"  {'метрика':<24s}     {headers}    тренд")
+    out.append(f"  {'─'*24}     {'  '.join('─'*14 for _ in keys)}    ─────")
+    for name, key, fmt in _TREND_METRICS:
+        vs = [_trend_value(months_data[k], key, name) for k in keys]
+        cells = "   ".join(f"{fmt.format(v):>14s}" for v in vs)
+        out.append(f"  {name:<24s}     {cells}    {trend_arrow(vs)}")
+    return out
+
+
+def render_trends_markdown(months_data: dict[int, dict], months_labels: dict[int, str]) -> list[str]:
+    out = ["", "## 📈 Тренды", ""]
+    keys = sorted(months_data.keys())
+    if len(keys) < 2:
+        return out
+    header = "| Метрика | " + " | ".join(months_labels[k] for k in keys) + " | Тренд |"
+    sep = "|--|" + "|".join("--:" for _ in keys) + "|--|"
+    out.append(header)
+    out.append(sep)
+    for name, key, fmt in _TREND_METRICS:
+        vs = [_trend_value(months_data[k], key, name) for k in keys]
+        cells = " | ".join(fmt.format(v) for v in vs)
+        out.append(f"| {name} | {cells} | {trend_arrow(vs)} |")
+    out.append("")
+    return out
+
+
+def render_trends_html(months_data: dict[int, dict], months_labels: dict[int, str]) -> str:
+    keys = sorted(months_data.keys())
+    if len(keys) < 2:
+        return ""
+    out = ['<section class="period"><h2>📈 Тренды</h2>']
+    out.append('<table class="trends-table"><thead><tr><th>Метрика</th>')
+    for k in keys:
+        out.append(f'<th class="num">{h(months_labels[k])}</th>')
+    out.append("<th>Тренд</th></tr></thead><tbody>")
+    for name, key, fmt in _TREND_METRICS:
+        vs = [_trend_value(months_data[k], key, name) for k in keys]
+        cells = "".join(f'<td class="num">{fmt.format(v)}</td>' for v in vs)
+        out.append(
+            f'<tr><td>{h(name)}</td>{cells}'
+            f'<td class="trend-arrow">{trend_arrow(vs)}</td></tr>'
+        )
+    out.append("</tbody></table></section>")
+    return "\n".join(out)

--- a/.claude/skills/analyze-usage/lib/render.py
+++ b/.claude/skills/analyze-usage/lib/render.py
@@ -113,7 +113,7 @@ def _term_stack(stack_loc: Counter) -> list[str]:
 
 
 def _term_dora(agg: dict) -> list[str]:
-    cfr = (agg["fix"] - agg["review_fix"]) / (agg["feat"] + 1) if agg["feat"] else 0
+    cfr = (agg["fix"] - agg["review_fix"]) / agg["feat"] if agg["feat"] else 0
     em, level = cfr_level(cfr)
     return [
         "  🚀 DORA-радар:",
@@ -224,7 +224,7 @@ def _md_stack(stack_loc: Counter) -> list[str]:
 
 
 def _md_dora(agg: dict) -> list[str]:
-    cfr = (agg["fix"] - agg["review_fix"]) / (agg["feat"] + 1) if agg["feat"] else 0
+    cfr = (agg["fix"] - agg["review_fix"]) / agg["feat"] if agg["feat"] else 0
     em, level = cfr_level(cfr)
     return [
         "### 🚀 DORA",
@@ -461,7 +461,7 @@ def _html_bar_chart(title: str, items: list[tuple[str, str, int]], total: int) -
 
 
 def _html_dora(agg: dict) -> str:
-    cfr = (agg["fix"] - agg["review_fix"]) / (agg["feat"] + 1) if agg["feat"] else 0
+    cfr = (agg["fix"] - agg["review_fix"]) / agg["feat"] if agg["feat"] else 0
     _, level = cfr_level(cfr)
     cfr_class = f"cfr-{level.lower()}"
     cards = [
@@ -570,7 +570,7 @@ def render_weekly_table_terminal(weeks: list[tuple[tuple[int, int], dict]]) -> l
             if n > 0:
                 biomes_str += BIOME_EMOJI[b] + f"{n} "
         top_arch = a["archs"].most_common(1)[0] if a["archs"] else ("—", 0)
-        cfr = (a["fix"] - a["review_fix"]) / (a["feat"] + 1) if a["feat"] else 0
+        cfr = (a["fix"] - a["review_fix"]) / a["feat"] if a["feat"] else 0
         em, _ = cfr_level(cfr)
         out.append(
             f"  {label:<22s}  {a['n']:>4d}  {a['lines_added']:>7,d}  "
@@ -606,7 +606,7 @@ def render_weekly_table_markdown(weeks: list[tuple[tuple[int, int], dict]]) -> l
             if n > 0:
                 biomes_str += BIOME_EMOJI[b] + f"{n} "
         top_arch = a["archs"].most_common(1)[0] if a["archs"] else ("—", 0)
-        cfr = (a["fix"] - a["review_fix"]) / (a["feat"] + 1) if a["feat"] else 0
+        cfr = (a["fix"] - a["review_fix"]) / a["feat"] if a["feat"] else 0
         em, _ = cfr_level(cfr)
         out.append(
             f"| {label} | {a['n']} | {a['lines_added']:,} | {a['feat']} | {a['fix']} | "
@@ -639,7 +639,7 @@ def render_weekly_table_html(weeks: list[tuple[tuple[int, int], dict]]) -> str:
             if n > 0:
                 biomes_str += BIOME_EMOJI[b] + f"{n} "
         top_arch = a["archs"].most_common(1)[0] if a["archs"] else ("—", 0)
-        cfr = (a["fix"] - a["review_fix"]) / (a["feat"] + 1) if a["feat"] else 0
+        cfr = (a["fix"] - a["review_fix"]) / a["feat"] if a["feat"] else 0
         em, _ = cfr_level(cfr)
         bar_w = int(a["lines_added"] * 200 / max_loc)
         out.append(

--- a/.claude/skills/analyze-usage/lib/stats.py
+++ b/.claude/skills/analyze-usage/lib/stats.py
@@ -1,0 +1,158 @@
+"""Pure statistical helpers used by extractors.
+
+No I/O, no pandas. Plain Python lists / counters. Each function safe for
+empty input (returns 0 or empty result, not raises).
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Iterable, Sequence
+
+
+def cv(xs: Sequence[float]) -> float:
+    """Coefficient of variation = std_dev / mean. Returns 0 if mean == 0."""
+    if not xs:
+        return 0.0
+    n = len(xs)
+    mean = sum(xs) / n
+    if mean == 0:
+        return 0.0
+    var = sum((x - mean) ** 2 for x in xs) / n
+    return math.sqrt(var) / mean
+
+
+def gini(xs: Sequence[float]) -> float:
+    """Gini coefficient on a non-negative numeric sequence.
+
+    0 = perfectly equal, ~1 = max concentration (one value holds everything).
+    Treats negatives as 0. Empty input → 0.
+    """
+    if not xs:
+        return 0.0
+    vals = sorted(max(x, 0) for x in xs)
+    n = len(vals)
+    total = sum(vals)
+    if total == 0:
+        return 0.0
+    cum = 0.0
+    weighted = 0.0
+    for i, v in enumerate(vals, start=1):
+        cum += v
+        weighted += i * v
+    return (2 * weighted) / (n * total) - (n + 1) / n
+
+
+def shannon_entropy(counter: Counter | dict) -> float:
+    """Shannon entropy in bits (log2)."""
+    total = sum(counter.values())
+    if total == 0:
+        return 0.0
+    h = 0.0
+    for v in counter.values():
+        if v <= 0:
+            continue
+        p = v / total
+        h -= p * math.log2(p)
+    return h
+
+
+def milestone_at(cum_R: Sequence[int], threshold: int) -> int | None:
+    """Index (1-based burst position) where cumulative R first crosses threshold.
+
+    Returns None if never reached.
+    """
+    for i, c in enumerate(cum_R, start=1):
+        if c >= threshold:
+            return i
+    return None
+
+
+def acceleration(daily_xs: Sequence[float]) -> float:
+    """Slope of the second-half — slope of the first-half (linear-fit comparison).
+
+    Positive value = output rate increasing over time (accelerating).
+    Negative = decelerating. Zero (or None for too-short) otherwise.
+    """
+    n = len(daily_xs)
+    if n < 4:
+        return 0.0
+    half = n // 2
+    first = daily_xs[:half]
+    second = daily_xs[half:]
+
+    def _slope(seq: Sequence[float]) -> float:
+        m = len(seq)
+        if m < 2:
+            return 0.0
+        mean_x = (m - 1) / 2
+        mean_y = sum(seq) / m
+        num = sum((i - mean_x) * (seq[i] - mean_y) for i in range(m))
+        den = sum((i - mean_x) ** 2 for i in range(m))
+        return num / den if den else 0.0
+
+    return _slope(second) - _slope(first)
+
+
+def pearson(xs: Sequence[float], ys: Sequence[float]) -> float:
+    """Pearson correlation coefficient. 0 for empty / degenerate."""
+    n = min(len(xs), len(ys))
+    if n < 2:
+        return 0.0
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    num = sum((xs[i] - mx) * (ys[i] - my) for i in range(n))
+    dx = math.sqrt(sum((xs[i] - mx) ** 2 for i in range(n)))
+    dy = math.sqrt(sum((ys[i] - my) ** 2 for i in range(n)))
+    if dx == 0 or dy == 0:
+        return 0.0
+    return num / (dx * dy)
+
+
+def percentile(xs: Sequence[float], p: float) -> float:
+    """p-th percentile (p in [0, 100]). Linear interpolation between ranks."""
+    if not xs:
+        return 0.0
+    s = sorted(xs)
+    n = len(s)
+    if p <= 0:
+        return s[0]
+    if p >= 100:
+        return s[-1]
+    rank = (p / 100) * (n - 1)
+    lo = int(rank)
+    hi = min(lo + 1, n - 1)
+    frac = rank - lo
+    return s[lo] * (1 - frac) + s[hi] * frac
+
+
+def median(xs: Sequence[float]) -> float:
+    return percentile(xs, 50)
+
+
+def power_law_fit(xs: Sequence[float], ys: Sequence[float]) -> dict:
+    """Log-log linear fit: y ≈ a * x^k.
+
+    Returns {"slope": k, "intercept_log": log(a), "scale": a, "r": pearson_r}.
+    Drops pairs where x or y ≤ 0.
+    """
+    pairs = [(x, y) for x, y in zip(xs, ys) if x > 0 and y > 0]
+    if len(pairs) < 3:
+        return {"slope": 0.0, "intercept_log": 0.0, "scale": 0.0, "r": 0.0, "n": len(pairs)}
+    log_x = [math.log(p[0]) for p in pairs]
+    log_y = [math.log(p[1]) for p in pairs]
+    n = len(pairs)
+    mx = sum(log_x) / n
+    my = sum(log_y) / n
+    num = sum((log_x[i] - mx) * (log_y[i] - my) for i in range(n))
+    den = sum((log_x[i] - mx) ** 2 for i in range(n))
+    slope = num / den if den else 0.0
+    intercept = my - slope * mx
+    return {
+        "slope": slope,
+        "intercept_log": intercept,
+        "scale": math.exp(intercept),
+        "r": pearson(log_x, log_y),
+        "n": n,
+    }

--- a/.claude/skills/analyze-usage/scripts/extract_archetype.py
+++ b/.claude/skills/analyze-usage/scripts/extract_archetype.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Per-session archetype + rhythm classification.
+
+Schema (raw + anon):
+  sid, project, edit_count, bash_count, read_count, archetype, rhythm,
+  edit_share, bash_share, read_share, total_tools
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.parsers import find_session_files, load_session, find_subagents  # noqa: E402
+from lib.classifiers import (  # noqa: E402
+    archetype_of, rhythm_of, bash_sub_of,
+    ARCHETYPE_EMOJI, RHYTHM_EMOJI,
+)
+from lib.anonymize import hash_path, SidProjector  # noqa: E402
+from lib.io import outputs_dirs, write_parquet  # noqa: E402
+
+
+def _classify_session(events) -> tuple[int, int, int, list[str]]:
+    edit = bash = read = 0
+    seq: list[str] = []
+    for ev in events:
+        if ev.type != "assistant":
+            continue
+        for tu in ev.tool_uses:
+            n = tu.get("name", "")
+            if n in ("Edit", "MultiEdit", "Write"):
+                edit += 1
+                seq.append("Edit")
+            elif n in ("Read", "Grep", "Glob", "ToolSearch"):
+                read += 1
+                seq.append("Read")
+            elif n == "Bash":
+                bash += 1
+                cmd = (tu.get("input", {}) or {}).get("command", "") or ""
+                seq.append(f"Bash:{bash_sub_of(cmd)}")
+    return edit, bash, read, seq
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--since", default=None)
+    p.add_argument("--outputs", default=None)
+    args = p.parse_args(argv)
+
+    since = datetime.fromisoformat(args.since) if args.since else None
+    raw_dir, anon_dir = outputs_dirs(Path(args.outputs) if args.outputs else None)
+
+    sid_main = SidProjector("s")
+    sid_sub = SidProjector("a")
+    raw_rows = []
+    anon_rows = []
+
+    for jf in find_session_files():
+        try:
+            sess = load_session(jf, include_subagents=False, since=since)
+        except Exception:
+            continue
+        if not sess.events:
+            continue
+        e, b, r, seq = _classify_session(sess.events)
+        total = e + b + r
+        arch = archetype_of(e, b, r)
+        rh = rhythm_of(seq)
+        raw_rows.append({
+            "sid": sess.sid, "project": sess.project,
+            "edit_count": e, "bash_count": b, "read_count": r,
+            "edit_share": e / total if total else 0.0,
+            "bash_share": b / total if total else 0.0,
+            "read_share": r / total if total else 0.0,
+            "total_tools": total,
+            "archetype": arch, "archetype_emoji": ARCHETYPE_EMOJI[arch],
+            "rhythm": rh, "rhythm_emoji": RHYTHM_EMOJI[rh],
+        })
+        anon_rows.append({
+            "sid": sid_main.get(sess.sid), "project": hash_path(sess.project),
+            "edit_count": e, "bash_count": b, "read_count": r,
+            "edit_share": e / total if total else 0.0,
+            "bash_share": b / total if total else 0.0,
+            "read_share": r / total if total else 0.0,
+            "total_tools": total,
+            "archetype": arch, "rhythm": rh,
+        })
+        for sf in find_subagents(jf):
+            try:
+                sub = load_session(sf, include_subagents=False, since=since)
+            except Exception:
+                continue
+            if not sub.events:
+                continue
+            e2, b2, r2, seq2 = _classify_session(sub.events)
+            total2 = e2 + b2 + r2
+            arch2 = archetype_of(e2, b2, r2)
+            rh2 = rhythm_of(seq2)
+            raw_rows.append({
+                "sid": "sub_" + sub.sid, "project": sess.project,
+                "edit_count": e2, "bash_count": b2, "read_count": r2,
+                "edit_share": e2 / total2 if total2 else 0.0,
+                "bash_share": b2 / total2 if total2 else 0.0,
+                "read_share": r2 / total2 if total2 else 0.0,
+                "total_tools": total2,
+                "archetype": arch2, "archetype_emoji": ARCHETYPE_EMOJI[arch2],
+                "rhythm": rh2, "rhythm_emoji": RHYTHM_EMOJI[rh2],
+            })
+            anon_rows.append({
+                "sid": sid_sub.get(sub.sid), "project": hash_path(sess.project),
+                "edit_count": e2, "bash_count": b2, "read_count": r2,
+                "edit_share": e2 / total2 if total2 else 0.0,
+                "bash_share": b2 / total2 if total2 else 0.0,
+                "read_share": r2 / total2 if total2 else 0.0,
+                "total_tools": total2,
+                "archetype": arch2, "rhythm": rh2,
+            })
+
+    n_raw = write_parquet(raw_rows, raw_dir / "archetype.parquet")
+    n_anon = write_parquet(anon_rows, anon_dir / "archetype.parquet")
+    print(f"archetype: raw {n_raw}, anon {n_anon}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/extract_biome.py
+++ b/.claude/skills/analyze-usage/scripts/extract_biome.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Per-session biome classification.
+
+Schema (raw):
+  sid, project, real_prompts, asst_count, biome, biome_emoji,
+  first_ts, last_ts, jsonl_path
+
+Schema (anon):
+  sid (s0001/a0001), project (p<6hex>), real_prompts, asst_count, biome,
+  first_iso_week, last_iso_week
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.parsers import find_session_files, load_session, find_subagents  # noqa: E402
+from lib.classifiers import biome_of, BIOME_EMOJI  # noqa: E402
+from lib.anonymize import hash_path, SidProjector  # noqa: E402
+from lib.io import outputs_dirs, write_parquet  # noqa: E402
+
+
+def _iso_week(ts: datetime | None) -> str:
+    if ts is None:
+        return ""
+    iy, iw, _ = ts.isocalendar()
+    return f"{iy}-W{iw:02d}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--since", default=None, help="YYYY-MM-DD")
+    p.add_argument("--outputs", default=None)
+    args = p.parse_args(argv)
+
+    since = datetime.fromisoformat(args.since) if args.since else None
+    raw_dir, anon_dir = outputs_dirs(Path(args.outputs) if args.outputs else None)
+
+    sid_proj = SidProjector("s")
+    sub_proj = SidProjector("a")
+
+    raw_rows: list[dict] = []
+    anon_rows: list[dict] = []
+
+    files = find_session_files()
+    for jf in files:
+        try:
+            sess = load_session(jf, include_subagents=False, since=since)
+        except Exception:
+            continue
+        if not sess.events:
+            continue
+        real = sum(1 for ev in sess.events if ev.type == "user" and ev.user_kind == "real_human")
+        asst = sum(1 for ev in sess.events if ev.type == "assistant")
+        b = biome_of(real)
+        first_ts = sess.events[0].ts
+        last_ts = sess.events[-1].ts
+        raw_rows.append({
+            "sid": sess.sid,
+            "project": sess.project,
+            "real_prompts": real,
+            "asst_count": asst,
+            "biome": b,
+            "biome_emoji": BIOME_EMOJI[b],
+            "first_ts": first_ts.isoformat() if first_ts else None,
+            "last_ts": last_ts.isoformat() if last_ts else None,
+            "jsonl_path": str(jf),
+        })
+        anon_rows.append({
+            "sid": sid_proj.get(sess.sid),
+            "project": hash_path(sess.project),
+            "real_prompts": real,
+            "asst_count": asst,
+            "biome": b,
+            "first_iso_week": _iso_week(first_ts),
+            "last_iso_week": _iso_week(last_ts),
+        })
+        # subagents
+        for sf in find_subagents(jf):
+            try:
+                sub = load_session(sf, include_subagents=False, since=since)
+            except Exception:
+                continue
+            if not sub.events:
+                continue
+            asst_s = sum(1 for ev in sub.events if ev.type == "assistant")
+            # subagent biome thresholds differ; reuse asst not real
+            b_sub = biome_of(asst_s)  # threshold-by-asst proxy
+            raw_rows.append({
+                "sid": "sub_" + sub.sid,
+                "project": sess.project,
+                "real_prompts": 0,
+                "asst_count": asst_s,
+                "biome": b_sub,
+                "biome_emoji": BIOME_EMOJI[b_sub],
+                "first_ts": sub.events[0].ts.isoformat() if sub.events[0].ts else None,
+                "last_ts": sub.events[-1].ts.isoformat() if sub.events[-1].ts else None,
+                "jsonl_path": str(sf),
+            })
+            anon_rows.append({
+                "sid": sub_proj.get(sub.sid),
+                "project": hash_path(sess.project),
+                "real_prompts": 0,
+                "asst_count": asst_s,
+                "biome": b_sub,
+                "first_iso_week": _iso_week(sub.events[0].ts),
+                "last_iso_week": _iso_week(sub.events[-1].ts),
+            })
+
+    n_raw = write_parquet(raw_rows, raw_dir / "biome.parquet")
+    n_anon = write_parquet(anon_rows, anon_dir / "biome.parquet")
+    sid_proj.dump(raw_dir / "_sid_main.json")
+    sub_proj.dump(raw_dir / "_sid_sub.json")
+    print(f"biome: raw {n_raw} rows, anon {n_anon} rows", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/extract_burst_classes.py
+++ b/.claude/skills/analyze-usage/scripts/extract_burst_classes.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Per-session burst-class counts: pure_qa / read_only / bash_only / mixed /
+write_heavy / write_only / chain_run.
+
+Per burst we look at its tool-uses and bucket the burst into one of 7 classes:
+  - pure_qa     no tools at all
+  - read_only   only Read/Grep/Glob/ToolSearch
+  - bash_only   only Bash
+  - write_only  only Edit/MultiEdit/Write
+  - write_heavy ≥50% Edit/Write of tools
+  - chain_run   only Bash with chained commands (>3 split parts)
+  - mixed       all the rest
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.parsers import find_session_files, load_session, split_chain  # noqa: E402
+from lib.anonymize import hash_path, SidProjector  # noqa: E402
+from lib.io import outputs_dirs, write_parquet  # noqa: E402
+
+
+def _classify_burst(b) -> str:
+    if not b.tool_uses:
+        return "pure_qa"
+    cats = Counter()
+    chain_lengths = []
+    for tu in b.tool_uses:
+        n = tu.get("name", "")
+        if n in ("Edit", "MultiEdit", "Write"):
+            cats["write"] += 1
+        elif n in ("Read", "Grep", "Glob", "ToolSearch"):
+            cats["read"] += 1
+        elif n == "Bash":
+            cats["bash"] += 1
+            cmd = (tu.get("input", {}) or {}).get("command", "") or ""
+            chain_lengths.append(len(split_chain(cmd)))
+        else:
+            cats["other"] += 1
+    total = sum(cats.values())
+    if cats["read"] == total:
+        return "read_only"
+    if cats["write"] == total:
+        return "write_only"
+    if cats["bash"] == total:
+        if chain_lengths and max(chain_lengths) >= 3:
+            return "chain_run"
+        return "bash_only"
+    if cats["write"] >= total / 2:
+        return "write_heavy"
+    return "mixed"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--since", default=None)
+    p.add_argument("--outputs", default=None)
+    args = p.parse_args(argv)
+    since = datetime.fromisoformat(args.since) if args.since else None
+    raw_dir, anon_dir = outputs_dirs(Path(args.outputs) if args.outputs else None)
+    sid_main = SidProjector("s")
+    raw_rows = []
+    anon_rows = []
+    classes = ("pure_qa","read_only","bash_only","write_only","write_heavy","chain_run","mixed")
+    for jf in find_session_files():
+        try:
+            sess = load_session(jf, include_subagents=False, since=since)
+        except Exception:
+            continue
+        cnt = Counter()
+        for b in sess.bursts:
+            cnt[_classify_burst(b)] += 1
+        if not cnt:
+            continue
+        row = {"sid": sess.sid, "project": sess.project,
+               "burst_total": sum(cnt.values()), **{c: cnt.get(c, 0) for c in classes}}
+        raw_rows.append(row)
+        anon_rows.append({**row, "sid": sid_main.get(sess.sid), "project": hash_path(sess.project)})
+    n_raw = write_parquet(raw_rows, raw_dir / "burst_classes.parquet")
+    n_anon = write_parquet(anon_rows, anon_dir / "burst_classes.parquet")
+    print(f"burst_classes: raw {n_raw}, anon {n_anon}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/extract_burst_classes.py
+++ b/.claude/skills/analyze-usage/scripts/extract_burst_classes.py
@@ -12,7 +12,7 @@ Per burst we look at its tool-uses and bucket the burst into one of 7 classes:
   - bash_only   only Bash
   - write_only  only Edit/MultiEdit/Write
   - write_heavy ≥50% Edit/Write of tools
-  - chain_run   only Bash with chained commands (>3 split parts)
+  - chain_run   only Bash with chained commands (>=3 split parts)
   - mixed       all the rest
 """
 from __future__ import annotations

--- a/.claude/skills/analyze-usage/scripts/extract_compacts.py
+++ b/.claude/skills/analyze-usage/scripts/extract_compacts.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Per-session compact pattern: how many compactов, max context size before each.
+
+Schema (raw + anon):
+  sid, project, compacts, real_prompts_before_first_compact,
+  context_size_max, asst_count, compact_per_asst
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.parsers import find_session_files, load_session  # noqa: E402
+from lib.anonymize import hash_path, SidProjector  # noqa: E402
+from lib.io import outputs_dirs, write_parquet  # noqa: E402
+
+
+def _stats(events) -> dict:
+    compacts = 0
+    real_before = 0
+    real_seen = 0
+    seen_first = False
+    ctx_max = 0
+    asst = 0
+    for ev in events:
+        if ev.type == "compact":
+            compacts += 1
+            if not seen_first:
+                real_before = real_seen
+                seen_first = True
+        elif ev.type == "user" and ev.user_kind == "real_human":
+            real_seen += 1
+        elif ev.type == "assistant":
+            asst += 1
+            ctx = ev.in_tokens + ev.cache_read + ev.cache_create
+            if ctx > ctx_max:
+                ctx_max = ctx
+    return {
+        "compacts": compacts,
+        "real_prompts_before_first_compact": real_before,
+        "context_size_max": ctx_max,
+        "asst_count": asst,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--since", default=None)
+    p.add_argument("--outputs", default=None)
+    args = p.parse_args(argv)
+    since = datetime.fromisoformat(args.since) if args.since else None
+    raw_dir, anon_dir = outputs_dirs(Path(args.outputs) if args.outputs else None)
+    sid_main = SidProjector("s")
+    raw_rows = []
+    anon_rows = []
+    for jf in find_session_files():
+        try:
+            sess = load_session(jf, include_subagents=False, since=since)
+        except Exception:
+            continue
+        if not sess.events:
+            continue
+        s = _stats(sess.events)
+        cpa = s["compacts"] / s["asst_count"] if s["asst_count"] else 0.0
+        raw_rows.append({
+            "sid": sess.sid, "project": sess.project,
+            **s, "compact_per_asst": cpa,
+        })
+        anon_rows.append({
+            "sid": sid_main.get(sess.sid), "project": hash_path(sess.project),
+            **s, "compact_per_asst": cpa,
+        })
+    n_raw = write_parquet(raw_rows, raw_dir / "compact_pattern.parquet")
+    n_anon = write_parquet(anon_rows, anon_dir / "compact_pattern.parquet")
+    print(f"compact_pattern: raw {n_raw}, anon {n_anon}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/extract_gaps.py
+++ b/.claude/skills/analyze-usage/scripts/extract_gaps.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Idle-gap detection: per-session list of gaps >8h with suggested split point.
+
+Schema (raw + anon):
+  sid, project, gap_idx, gap_start, gap_end, gap_hours, before_burst_idx,
+  after_burst_idx
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.parsers import find_session_files, load_session  # noqa: E402
+from lib.anonymize import hash_path, SidProjector  # noqa: E402
+from lib.io import outputs_dirs, write_parquet  # noqa: E402
+
+
+GAP_HOURS = 8
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--since", default=None)
+    p.add_argument("--outputs", default=None)
+    p.add_argument("--threshold-hours", type=int, default=GAP_HOURS)
+    args = p.parse_args(argv)
+    since = datetime.fromisoformat(args.since) if args.since else None
+    raw_dir, anon_dir = outputs_dirs(Path(args.outputs) if args.outputs else None)
+    sid_main = SidProjector("s")
+    raw_rows = []
+    anon_rows = []
+    threshold = timedelta(hours=args.threshold_hours)
+    for jf in find_session_files():
+        try:
+            sess = load_session(jf, include_subagents=False, since=since)
+        except Exception:
+            continue
+        if len(sess.bursts) < 2:
+            continue
+        for i in range(1, len(sess.bursts)):
+            gap = sess.bursts[i].start - sess.bursts[i - 1].end
+            if gap < threshold:
+                continue
+            raw_rows.append({
+                "sid": sess.sid, "project": sess.project,
+                "gap_idx": i,
+                "gap_start": sess.bursts[i - 1].end.isoformat(),
+                "gap_end": sess.bursts[i].start.isoformat(),
+                "gap_hours": gap.total_seconds() / 3600,
+                "before_burst_idx": i - 1,
+                "after_burst_idx": i,
+            })
+            anon_rows.append({
+                "sid": sid_main.get(sess.sid), "project": hash_path(sess.project),
+                "gap_idx": i,
+                "gap_hours": gap.total_seconds() / 3600,
+                "before_burst_idx": i - 1,
+                "after_burst_idx": i,
+            })
+    n_raw = write_parquet(raw_rows, raw_dir / "idle_gaps.parquet")
+    n_anon = write_parquet(anon_rows, anon_dir / "idle_gaps.parquet")
+    print(f"idle_gaps: raw {n_raw}, anon {n_anon}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/extract_growth.py
+++ b/.claude/skills/analyze-usage/scripts/extract_growth.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Per-session growth metrics + milestone burst-indices.
+
+For each session: prompts cum-curve over its bursts.
+- daily_R / daily_LOC (CV / Gini / acceleration on day-buckets)
+- milestone_at(R=10, 30, 100, 500) — at which burst index R first reaches threshold
+- session-level Gini of LOC across bursts
+
+Outputs:
+  growth.parquet      — per-session aggregate metrics
+  milestones.parquet  — long-form (sid, threshold, burst_idx)
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.parsers import find_session_files, load_session  # noqa: E402
+from lib.stats import cv, gini, acceleration, milestone_at  # noqa: E402
+from lib.anonymize import hash_path, SidProjector  # noqa: E402
+from lib.io import outputs_dirs, write_parquet  # noqa: E402
+
+
+MILESTONES = (10, 30, 100, 500)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--since", default=None)
+    p.add_argument("--outputs", default=None)
+    args = p.parse_args(argv)
+    since = datetime.fromisoformat(args.since) if args.since else None
+    raw_dir, anon_dir = outputs_dirs(Path(args.outputs) if args.outputs else None)
+    sid_main = SidProjector("s")
+    growth_raw = []
+    growth_anon = []
+    miles_raw = []
+    miles_anon = []
+    for jf in find_session_files():
+        try:
+            sess = load_session(jf, include_subagents=False, since=since)
+        except Exception:
+            continue
+        if not sess.bursts:
+            continue
+        # cumulative real prompts (each burst = +1 if not is_notify)
+        cum_R = []
+        c = 0
+        burst_loc = []
+        for b in sess.bursts:
+            if not b.is_notify:
+                c += 1
+            cum_R.append(c)
+            # LOC per burst (rough): count Edit/Write tools * proxy
+            loc = 0
+            for tu in b.tool_uses:
+                if tu.get("name") in ("Edit", "MultiEdit", "Write"):
+                    loc += 1
+            burst_loc.append(loc)
+        # daily aggregation
+        per_day_R: Counter[str] = Counter()
+        per_day_LOC: Counter[str] = Counter()
+        for b, lo in zip(sess.bursts, burst_loc):
+            day = b.start.date().isoformat()
+            if not b.is_notify:
+                per_day_R[day] += 1
+            per_day_LOC[day] += lo
+        days = sorted(per_day_R.keys() | per_day_LOC.keys())
+        daily_R = [per_day_R.get(d, 0) for d in days]
+        daily_LOC = [per_day_LOC.get(d, 0) for d in days]
+
+        row = {
+            "sid": sess.sid,
+            "project": sess.project,
+            "n_bursts": len(sess.bursts),
+            "real_prompts": cum_R[-1] if cum_R else 0,
+            "n_days": len(days),
+            "cv_daily_R": cv(daily_R),
+            "gini_daily_R": gini(daily_R),
+            "cv_daily_LOC": cv(daily_LOC),
+            "gini_daily_LOC": gini(daily_LOC),
+            "acceleration_R": acceleration(daily_R),
+            "burst_loc_gini": gini(burst_loc),
+        }
+        growth_raw.append({**row, "sid": sess.sid, "project": sess.project})
+        growth_anon.append({**row, "sid": sid_main.get(sess.sid), "project": hash_path(sess.project)})
+
+        for thr in MILESTONES:
+            idx = milestone_at(cum_R, thr)
+            if idx is None:
+                continue
+            miles_raw.append({"sid": sess.sid, "project": sess.project, "threshold": thr, "burst_idx": idx})
+            miles_anon.append({"sid": sid_main.get(sess.sid), "project": hash_path(sess.project), "threshold": thr, "burst_idx": idx})
+
+    n_g = write_parquet(growth_raw, raw_dir / "growth.parquet")
+    write_parquet(growth_anon, anon_dir / "growth.parquet")
+    n_m = write_parquet(miles_raw, raw_dir / "milestones.parquet")
+    write_parquet(miles_anon, anon_dir / "milestones.parquet")
+    print(f"growth: raw {n_g} | milestones: raw {n_m}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/extract_llm_session_names.py
+++ b/.claude/skills/analyze-usage/scripts/extract_llm_session_names.py
@@ -73,10 +73,23 @@ def main(argv: list[str] | None = None) -> int:
     queue_path.write_text("\n".join(json.dumps(q, ensure_ascii=False) for q in queue))
     print(f"queue: {len(queue)} sessions → {queue_path}", file=sys.stderr)
 
-    # Stub the parquet so consumers know it exists (empty until agent fills)
+    # Stub the parquet so consumers know it exists (empty until agent fills).
+    # Pin the schema so consumers querying column names get a stable answer
+    # even before any rows are written.
     if not (llm / "session_names.parquet").exists():
+        import pyarrow as pa
         from lib.io import write_parquet
-        write_parquet([], llm / "session_names.parquet")
+        schema = pa.schema([
+            pa.field("sid", pa.string()),
+            pa.field("project", pa.string()),
+            pa.field("name", pa.string()),
+            pa.field("summary", pa.string()),
+            pa.field("phases", pa.list_(pa.string())),
+            pa.field("pivots", pa.int64()),
+            pa.field("generator", pa.string()),
+            pa.field("generated_at", pa.string()),
+        ])
+        write_parquet([], llm / "session_names.parquet", schema=schema)
         print(f"  empty stub → {llm}/session_names.parquet", file=sys.stderr)
 
     print(

--- a/.claude/skills/analyze-usage/scripts/extract_llm_session_names.py
+++ b/.claude/skills/analyze-usage/scripts/extract_llm_session_names.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Tier-2 (agent-side LLM) extractor: per-session narrative names.
+
+Reads `outputs/raw/biome.parquet` to know which sessions exist, then for
+each Whale/Shark/Dolphin spawns the agent (via stdin protocol) with the
+session jsonl path and asks for: name (≤8 words), one-paragraph summary,
+phase list, pivot count.
+
+This script does **not** call an LLM directly — it emits a JSONL queue
+to `outputs/llm/_queue.jsonl` that the agent consumes when it runs the
+skill. Each queue entry has:
+  {sid, jsonl_path, why_selected, status: "pending"}
+
+When the agent reads the queue and writes back narrative, it appends to
+`outputs/llm/session_names.parquet` with schema:
+  sid, project, name, summary, phases (list[str]), pivots, generator,
+  generated_at
+
+Why split: Tier 1 must be reproducible offline (pure stat). Tier 2
+narrative depends on the agent — keeping it as a separate parquet
+ensures Tier 1 stays deterministic and shareable, while Tier 2 enriches
+when the agent is involved.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.io import outputs_dirs_v2  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--outputs", default=None)
+    p.add_argument("--biomes", nargs="+", default=["Whale", "Shark", "Dolphin"],
+                   help="Biome classes to enqueue for narrative")
+    args = p.parse_args(argv)
+    raw, _, llm = outputs_dirs_v2(Path(args.outputs) if args.outputs else None)
+
+    biome_path = raw / "biome.parquet"
+    if not biome_path.exists():
+        print(f"missing {biome_path} — run pipeline.py first", file=sys.stderr)
+        return 1
+
+    rows = pq.read_table(biome_path).to_pylist()
+    queue: list[dict] = []
+    for r in rows:
+        if r["biome"] not in args.biomes:
+            continue
+        queue.append({
+            "sid": r["sid"],
+            "project": r["project"],
+            "biome": r["biome"],
+            "jsonl_path": r.get("jsonl_path", ""),
+            "real_prompts": r["real_prompts"],
+            "status": "pending",
+            "queued_at": datetime.now().isoformat(timespec="seconds"),
+        })
+
+    queue_path = llm / "_queue.jsonl"
+    queue_path.write_text("\n".join(json.dumps(q, ensure_ascii=False) for q in queue))
+    print(f"queue: {len(queue)} sessions → {queue_path}", file=sys.stderr)
+
+    # Stub the parquet so consumers know it exists (empty until agent fills)
+    if not (llm / "session_names.parquet").exists():
+        from lib.io import write_parquet
+        write_parquet([], llm / "session_names.parquet")
+        print(f"  empty stub → {llm}/session_names.parquet", file=sys.stderr)
+
+    print(
+        f"\nNext step: agent reads {queue_path}, summarises each session, "
+        f"appends rows to {llm}/session_names.parquet.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/extract_outputs.py
+++ b/.claude/skills/analyze-usage/scripts/extract_outputs.py
@@ -25,7 +25,7 @@ sys.path.insert(0, str(_HERE.parent))
 
 from lib.parsers import find_session_files, load_session, find_subagents  # noqa: E402
 from lib.classifiers import commit_type_of, is_review_fix  # noqa: E402
-from lib.anonymize import hash_path, hash_branch, SidProjector  # noqa: E402
+from lib.anonymize import hash_path, SidProjector  # noqa: E402
 from lib.io import outputs_dirs, write_parquet  # noqa: E402
 
 RX_GIT_COMMIT_M = re.compile(

--- a/.claude/skills/analyze-usage/scripts/extract_outputs.py
+++ b/.claude/skills/analyze-usage/scripts/extract_outputs.py
@@ -153,7 +153,6 @@ def _aggregate(events) -> dict:
                         a["unique_branches"].add(br)
                 for m in RX_ISSUE.finditer(cmd):
                     a["unique_issues"].add(m.group(0))
-        # also extract issue refs from user prompts text
     return a
 
 

--- a/.claude/skills/analyze-usage/scripts/extract_outputs.py
+++ b/.claude/skills/analyze-usage/scripts/extract_outputs.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Per-session outputs: commits/pushes/PR/MR/issues/files/+LOC + commit-type breakdown.
+
+Schema (raw):
+  sid, project, lines_added, lines_removed, files_edited, files_written,
+  edit_calls, write_calls, multiedit_calls,
+  commits_total, feat, fix, refactor, chore, docs_c, test_c, ci_c, review_fix,
+  pushes, pr_create, mr_create, issue_create, comments,
+  unique_branches, unique_issues
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.parsers import find_session_files, load_session, find_subagents  # noqa: E402
+from lib.classifiers import commit_type_of, is_review_fix  # noqa: E402
+from lib.anonymize import hash_path, hash_branch, SidProjector  # noqa: E402
+from lib.io import outputs_dirs, write_parquet  # noqa: E402
+
+RX_GIT_COMMIT_M = re.compile(
+    r"git\s+commit\s+(?:[^']*\s)?-m\s+(?:'((?:[^'\\]|\\.)*)'|\"((?:[^\"\\]|\\.)*)\")",
+    re.DOTALL,
+)
+RX_HEREDOC_MSG = re.compile(
+    r"-m\s+\"\$\(\s*cat\s*<<\s*'?(\w+)'?\s*\n(.*?)\n\1\s*\)\"",
+    re.DOTALL,
+)
+RX_BRANCH = re.compile(
+    r"\bgit\s+(?:checkout\s+-[bB]\s+|switch\s+-c\s+|branch\s+)([\w/\-\.]+)",
+    re.I,
+)
+RX_ISSUE = re.compile(r"(DEV-\d+|CU-[\w]+|JIRA-\d+|GH-\d+|#\d+)", re.I)
+
+
+def _extract_msgs(cmd: str) -> list[str]:
+    out = []
+    for m in RX_HEREDOC_MSG.finditer(cmd):
+        out.append(m.group(2))
+    for m in RX_GIT_COMMIT_M.finditer(cmd):
+        out.append(m.group(1) or m.group(2) or "")
+    return out
+
+
+def _cnt_lines(s: str) -> int:
+    if not s:
+        return 0
+    return s.count("\n") + (0 if s.endswith("\n") else 1)
+
+
+def _aggregate(events) -> dict:
+    a = {
+        "lines_added": 0, "lines_removed": 0,
+        "edit_calls": 0, "write_calls": 0, "multiedit_calls": 0,
+        "files_edited": set(), "files_written": set(),
+        "commits_total": 0, "feat": 0, "fix": 0, "refactor": 0,
+        "chore": 0, "docs_c": 0, "test_c": 0, "ci_c": 0, "review_fix": 0,
+        "pushes": 0, "pr_create": 0, "mr_create": 0,
+        "issue_create": 0, "comments": 0,
+        "unique_branches": set(), "unique_issues": set(),
+    }
+    for ev in events:
+        if ev.type != "assistant":
+            continue
+        for tu in ev.tool_uses:
+            n = tu.get("name", "")
+            inp = tu.get("input", {}) or {}
+            if n == "Write":
+                a["write_calls"] += 1
+                fp = inp.get("file_path", "") or ""
+                if fp:
+                    a["files_written"].add(fp)
+                a["lines_added"] += _cnt_lines(inp.get("content", "") or "")
+            elif n == "Edit":
+                a["edit_calls"] += 1
+                fp = inp.get("file_path", "") or ""
+                if fp:
+                    a["files_edited"].add(fp)
+                o = inp.get("old_string", "") or ""
+                nn = inp.get("new_string", "") or ""
+                ol, nl = _cnt_lines(o), _cnt_lines(nn)
+                add = max(nl - ol, 0)
+                rem = max(ol - nl, 0)
+                if ol == nl and o != nn:
+                    add = nl or 1
+                    rem = ol or 1
+                a["lines_added"] += add
+                a["lines_removed"] += rem
+            elif n == "MultiEdit":
+                a["multiedit_calls"] += 1
+                fp = inp.get("file_path", "") or ""
+                if fp:
+                    a["files_edited"].add(fp)
+                for e in inp.get("edits", []) or []:
+                    if not isinstance(e, dict):
+                        continue
+                    o = e.get("old_string", "") or ""
+                    nn = e.get("new_string", "") or ""
+                    ol, nl = _cnt_lines(o), _cnt_lines(nn)
+                    add = max(nl - ol, 0)
+                    rem = max(ol - nl, 0)
+                    if ol == nl and o != nn:
+                        add = nl or 1
+                        rem = ol or 1
+                    a["lines_added"] += add
+                    a["lines_removed"] += rem
+            elif n == "Bash":
+                cmd = inp.get("command", "") or ""
+                if "git push" in cmd:
+                    a["pushes"] += 1
+                if "git commit" in cmd:
+                    for body in _extract_msgs(cmd):
+                        first = body.strip().split("\n")[0] if body else ""
+                        ctype = commit_type_of(first)
+                        a["commits_total"] += 1
+                        if ctype == "feat":
+                            a["feat"] += 1
+                        elif ctype == "fix":
+                            a["fix"] += 1
+                            if is_review_fix(body):
+                                a["review_fix"] += 1
+                        elif ctype == "refactor":
+                            a["refactor"] += 1
+                        elif ctype == "chore":
+                            a["chore"] += 1
+                        elif ctype == "docs":
+                            a["docs_c"] += 1
+                        elif ctype == "test":
+                            a["test_c"] += 1
+                        elif ctype == "ci":
+                            a["ci_c"] += 1
+                if "gh pr create" in cmd:
+                    a["pr_create"] += 1
+                if "glab mr create" in cmd:
+                    a["mr_create"] += 1
+                if "gh issue create" in cmd:
+                    a["issue_create"] += 1
+                if "gh pr comment" in cmd or "glab mr note" in cmd or "gh issue comment" in cmd:
+                    a["comments"] += 1
+                for m in RX_BRANCH.finditer(cmd):
+                    br = m.group(1)
+                    if br:
+                        a["unique_branches"].add(br)
+                for m in RX_ISSUE.finditer(cmd):
+                    a["unique_issues"].add(m.group(0))
+        # also extract issue refs from user prompts text
+    return a
+
+
+def _row(sess_or_sub_id: str, project: str, agg: dict) -> dict:
+    return {
+        "sid": sess_or_sub_id,
+        "project": project,
+        "lines_added": agg["lines_added"],
+        "lines_removed": agg["lines_removed"],
+        "files_edited": len(agg["files_edited"]),
+        "files_written": len(agg["files_written"]),
+        "edit_calls": agg["edit_calls"],
+        "write_calls": agg["write_calls"],
+        "multiedit_calls": agg["multiedit_calls"],
+        "commits_total": agg["commits_total"],
+        "feat": agg["feat"],
+        "fix": agg["fix"],
+        "refactor": agg["refactor"],
+        "chore": agg["chore"],
+        "docs_c": agg["docs_c"],
+        "test_c": agg["test_c"],
+        "ci_c": agg["ci_c"],
+        "review_fix": agg["review_fix"],
+        "prod_fix": agg["fix"] - agg["review_fix"],
+        "pushes": agg["pushes"],
+        "pr_create": agg["pr_create"],
+        "mr_create": agg["mr_create"],
+        "issue_create": agg["issue_create"],
+        "comments": agg["comments"],
+        "unique_branches": len(agg["unique_branches"]),
+        "unique_issues": len(agg["unique_issues"]),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--since", default=None)
+    p.add_argument("--outputs", default=None)
+    args = p.parse_args(argv)
+
+    since = datetime.fromisoformat(args.since) if args.since else None
+    raw_dir, anon_dir = outputs_dirs(Path(args.outputs) if args.outputs else None)
+    sid_main = SidProjector("s")
+    sid_sub = SidProjector("a")
+    raw_rows: list[dict] = []
+    anon_rows: list[dict] = []
+
+    for jf in find_session_files():
+        try:
+            sess = load_session(jf, include_subagents=False, since=since)
+        except Exception:
+            continue
+        if not sess.events:
+            continue
+        agg = _aggregate(sess.events)
+        raw_rows.append(_row(sess.sid, sess.project, agg))
+        anon_rows.append(_row(sid_main.get(sess.sid), hash_path(sess.project), agg))
+        for sf in find_subagents(jf):
+            try:
+                sub = load_session(sf, include_subagents=False, since=since)
+            except Exception:
+                continue
+            if not sub.events:
+                continue
+            agg2 = _aggregate(sub.events)
+            raw_rows.append(_row("sub_" + sub.sid, sess.project, agg2))
+            anon_rows.append(_row(sid_sub.get(sub.sid), hash_path(sess.project), agg2))
+
+    n_raw = write_parquet(raw_rows, raw_dir / "outputs.parquet")
+    n_anon = write_parquet(anon_rows, anon_dir / "outputs.parquet")
+    print(f"outputs: raw {n_raw}, anon {n_anon}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/extract_parallelism.py
+++ b/.claude/skills/analyze-usage/scripts/extract_parallelism.py
@@ -3,24 +3,24 @@
 # requires-python = ">=3.10"
 # dependencies = ["pyarrow>=15"]
 # ///
-"""Per-minute concurrent session count + hour-of-day map.
+"""Hourly concurrent session count by date/hour bin.
 
 Schema:
-  parallelism.parquet — one row per (date, hour) with cnt_active, max_concurrent
+  parallelism.parquet — one row per (date, hour) with year, month, day,
+  hour, iso_date, concurrent_sessions.
 """
 from __future__ import annotations
 
 import argparse
 import sys
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
 _HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HERE.parent))
 
 from lib.parsers import find_session_files, load_session  # noqa: E402
-from lib.anonymize import SidProjector  # noqa: E402
 from lib.io import outputs_dirs, write_parquet  # noqa: E402
 
 

--- a/.claude/skills/analyze-usage/scripts/extract_parallelism.py
+++ b/.claude/skills/analyze-usage/scripts/extract_parallelism.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Per-minute concurrent session count + hour-of-day map.
+
+Schema:
+  parallelism.parquet — one row per (date, hour) with cnt_active, max_concurrent
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.parsers import find_session_files, load_session  # noqa: E402
+from lib.anonymize import SidProjector  # noqa: E402
+from lib.io import outputs_dirs, write_parquet  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--since", default=None)
+    p.add_argument("--outputs", default=None)
+    args = p.parse_args(argv)
+    since = datetime.fromisoformat(args.since) if args.since else None
+    raw_dir, anon_dir = outputs_dirs(Path(args.outputs) if args.outputs else None)
+
+    # For each session: list of (year, month, day, hour) bins where it had ≥1 event
+    hour_bin_to_sessions: dict[tuple, set[str]] = defaultdict(set)
+    for jf in find_session_files():
+        try:
+            sess = load_session(jf, include_subagents=False, since=since)
+        except Exception:
+            continue
+        for ev in sess.events:
+            t = ev.ts
+            key = (t.year, t.month, t.day, t.hour)
+            hour_bin_to_sessions[key].add(sess.sid)
+
+    rows = []
+    for (y, m, d, h), sids in sorted(hour_bin_to_sessions.items()):
+        rows.append({
+            "year": y, "month": m, "day": d, "hour": h,
+            "iso_date": f"{y:04d}-{m:02d}-{d:02d}",
+            "concurrent_sessions": len(sids),
+        })
+
+    n = write_parquet(rows, raw_dir / "parallelism.parquet")
+    write_parquet(rows, anon_dir / "parallelism.parquet")  # already aggregated, safe to anon-mirror
+    print(f"parallelism: {n} hour-bins", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/extract_subagents.py
+++ b/.claude/skills/analyze-usage/scripts/extract_subagents.py
@@ -22,7 +22,7 @@ sys.path.insert(0, str(_HERE.parent))
 
 from lib.parsers import find_session_files, load_session, find_subagents  # noqa: E402
 from lib.classifiers import biome_of  # noqa: E402
-from lib.stats import median, percentile  # noqa: E402
+from lib.stats import median  # noqa: E402
 from lib.anonymize import hash_path, SidProjector  # noqa: E402
 from lib.io import outputs_dirs, write_parquet  # noqa: E402
 
@@ -60,6 +60,7 @@ def main(argv: list[str] | None = None) -> int:
             "parent_sid": sess.sid,
             "project": sess.project,
             "subagent_count": len(sub_asst),
+            "whale_subs": bins["Whale"],
             "shark_subs": bins["Shark"],
             "dolphin_subs": bins["Dolphin"],
             "fish_subs": bins["Fish"],

--- a/.claude/skills/analyze-usage/scripts/extract_subagents.py
+++ b/.claude/skills/analyze-usage/scripts/extract_subagents.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Per-parent subagent pyramid: count + size distribution.
+
+Schema (raw + anon):
+  parent_sid, project, subagent_count,
+  shark_subs, dolphin_subs, fish_subs, shrimp_subs, plankton_subs,
+  median_sub_asst, max_sub_asst
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.parsers import find_session_files, load_session, find_subagents  # noqa: E402
+from lib.classifiers import biome_of  # noqa: E402
+from lib.stats import median, percentile  # noqa: E402
+from lib.anonymize import hash_path, SidProjector  # noqa: E402
+from lib.io import outputs_dirs, write_parquet  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--since", default=None)
+    p.add_argument("--outputs", default=None)
+    args = p.parse_args(argv)
+    since = datetime.fromisoformat(args.since) if args.since else None
+    raw_dir, anon_dir = outputs_dirs(Path(args.outputs) if args.outputs else None)
+    sid_main = SidProjector("s")
+    raw_rows = []
+    anon_rows = []
+    for jf in find_session_files():
+        try:
+            sess = load_session(jf, include_subagents=False, since=since)
+        except Exception:
+            continue
+        sub_files = find_subagents(jf)
+        sub_asst = []
+        for sf in sub_files:
+            try:
+                sub = load_session(sf, include_subagents=False, since=since)
+            except Exception:
+                continue
+            asst_n = sum(1 for ev in sub.events if ev.type == "assistant")
+            sub_asst.append(asst_n)
+        if not sub_asst and not sess.events:
+            continue
+        bins = {"Whale":0, "Shark":0, "Dolphin":0, "Fish":0, "Shrimp":0, "Plankton":0}
+        for n in sub_asst:
+            bins[biome_of(n)] += 1
+        row = {
+            "parent_sid": sess.sid,
+            "project": sess.project,
+            "subagent_count": len(sub_asst),
+            "shark_subs": bins["Shark"],
+            "dolphin_subs": bins["Dolphin"],
+            "fish_subs": bins["Fish"],
+            "shrimp_subs": bins["Shrimp"],
+            "plankton_subs": bins["Plankton"],
+            "median_sub_asst": median(sub_asst),
+            "max_sub_asst": max(sub_asst) if sub_asst else 0,
+        }
+        raw_rows.append({**row, "parent_sid": sess.sid, "project": sess.project})
+        anon_rows.append({**row, "parent_sid": sid_main.get(sess.sid), "project": hash_path(sess.project)})
+    n_raw = write_parquet(raw_rows, raw_dir / "subagent_pyramid.parquet")
+    n_anon = write_parquet(anon_rows, anon_dir / "subagent_pyramid.parquet")
+    print(f"subagent_pyramid: raw {n_raw}, anon {n_anon}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/extract_topics.py
+++ b/.claude/skills/analyze-usage/scripts/extract_topics.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Per-session topic signature: BoW from real-human prompts.
+
+raw/topic_signatures.parquet keeps original tokens + counts (sidecar dict
+not separate; tokens themselves are the keys).
+anon/topic_signatures.parquet replaces tokens with 6-hex hashes.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.parsers import find_session_files, load_session  # noqa: E402
+from lib.anonymize import hash_path, hash_token, SidProjector, write_token_sidecar  # noqa: E402
+from lib.io import outputs_dirs, write_parquet  # noqa: E402
+
+WORD_RX = re.compile(r"[a-zа-я0-9_\-]{3,}", re.I)
+STOPWORDS = {
+    "the","and","that","with","this","from","have","not","you","for","but",
+    "и","в","на","с","что","это","как","но","для","или","же","ли",
+    "the","a","an","of","to","is","are","be","was","were","by","at","or",
+}
+
+TOP_K = 20
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--since", default=None)
+    p.add_argument("--outputs", default=None)
+    args = p.parse_args(argv)
+    since = datetime.fromisoformat(args.since) if args.since else None
+    raw_dir, anon_dir = outputs_dirs(Path(args.outputs) if args.outputs else None)
+    sid_main = SidProjector("s")
+
+    raw_rows = []
+    anon_rows = []
+    token_to_hash: dict[str, str] = {}
+
+    for jf in find_session_files():
+        try:
+            sess = load_session(jf, include_subagents=False, since=since)
+        except Exception:
+            continue
+        bow: Counter[str] = Counter()
+        for ev in sess.events:
+            if ev.type == "user" and ev.user_kind == "real_human":
+                for w in WORD_RX.findall(ev.user_text.lower()):
+                    if w in STOPWORDS:
+                        continue
+                    bow[w] += 1
+        if not bow:
+            continue
+        top = bow.most_common(TOP_K)
+        raw_rows.append({
+            "sid": sess.sid, "project": sess.project,
+            "tokens": [t for t, _ in top],
+            "counts": [c for _, c in top],
+        })
+        # anon: hash tokens
+        anon_tokens = []
+        for t, _ in top:
+            if t not in token_to_hash:
+                token_to_hash[t] = hash_token(t)
+            anon_tokens.append(token_to_hash[t])
+        anon_rows.append({
+            "sid": sid_main.get(sess.sid),
+            "project": hash_path(sess.project),
+            "token_hashes": anon_tokens,
+            "counts": [c for _, c in top],
+        })
+
+    n_raw = write_parquet(raw_rows, raw_dir / "topic_signatures.parquet")
+    n_anon = write_parquet(anon_rows, anon_dir / "topic_signatures.parquet")
+    write_token_sidecar(token_to_hash, raw_dir)
+    print(f"topic_signatures: raw {n_raw}, anon {n_anon}, sidecar {len(token_to_hash)} tokens", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/install.sh
+++ b/.claude/skills/analyze-usage/scripts/install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# install.sh — fetch the analyze-usage skill into ~/.claude/skills/ without
+# cloning the whole devboy-tools repo.
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/meteora-pro/devboy-tools/main/.claude/skills/analyze-usage/scripts/install.sh | bash
+#
+# Or with a pinned version:
+#   REF=v0.22.0 curl ... | bash
+
+set -e
+
+REPO="${REPO:-meteora-pro/devboy-tools}"
+REF="${REF:-main}"
+DEST="${DEST:-$HOME/.claude/skills/analyze-usage}"
+
+echo "→ Installing analyze-usage skill"
+echo "  repo: $REPO @ $REF"
+echo "  dest: $DEST"
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "✗ git is required" >&2
+    exit 1
+fi
+if ! command -v uv >/dev/null 2>&1; then
+    echo "⚠  uv is required to run the skill — install: https://docs.astral.sh/uv/" >&2
+fi
+
+# Sparse-checkout the subdir only
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+
+git clone --depth 1 --filter=blob:none --sparse \
+    --branch "$REF" \
+    "https://github.com/${REPO}.git" "$TMP/repo" >/dev/null 2>&1
+
+cd "$TMP/repo"
+git sparse-checkout set ".claude/skills/analyze-usage" >/dev/null 2>&1
+
+# Move into place
+mkdir -p "$(dirname "$DEST")"
+if [ -d "$DEST" ]; then
+    echo "⚠  $DEST already exists — backing up to ${DEST}.backup-$(date +%s)"
+    mv "$DEST" "${DEST}.backup-$(date +%s)"
+fi
+mv "$TMP/repo/.claude/skills/analyze-usage" "$DEST"
+
+# Make CLI executable
+chmod +x "$DEST/bin/analyze-usage" 2>/dev/null || true
+
+echo
+echo "✓ installed to $DEST"
+echo
+echo "Add to your PATH (zsh/bash):"
+echo "  echo 'export PATH=\"$DEST/bin:\$PATH\"' >> ~/.zshrc"
+echo
+echo "Or run directly:"
+echo "  $DEST/bin/analyze-usage --help"

--- a/.claude/skills/analyze-usage/scripts/install.sh
+++ b/.claude/skills/analyze-usage/scripts/install.sh
@@ -28,7 +28,7 @@ fi
 
 # Sparse-checkout the subdir only
 TMP=$(mktemp -d)
-trap "rm -rf $TMP" EXIT
+trap 'rm -rf "$TMP"' EXIT
 
 git clone --depth 1 --filter=blob:none --sparse \
     --branch "$REF" \
@@ -40,8 +40,9 @@ git sparse-checkout set ".claude/skills/analyze-usage" >/dev/null 2>&1
 # Move into place
 mkdir -p "$(dirname "$DEST")"
 if [ -d "$DEST" ]; then
-    echo "⚠  $DEST already exists — backing up to ${DEST}.backup-$(date +%s)"
-    mv "$DEST" "${DEST}.backup-$(date +%s)"
+    BACKUP="${DEST}.backup-$(date +%s)"
+    echo "⚠  $DEST already exists — backing up to $BACKUP"
+    mv "$DEST" "$BACKUP"
 fi
 mv "$TMP/repo/.claude/skills/analyze-usage" "$DEST"
 

--- a/.claude/skills/analyze-usage/scripts/pattern_detector.py
+++ b/.claude/skills/analyze-usage/scripts/pattern_detector.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Heuristic pattern detector + anonymization audit.
+
+Default mode reads `outputs/raw/*.parquet` and flags sessions matching
+patterns from our hypothesis loop:
+
+  needs_split         ≥2 idle gaps >8h
+  pure_constructor    archetype=Constructor AND rhythm=Phased
+  feature_with_debug  Inspector + compacts ≥2 (proxy for retry-loop)
+  pipeline_rescue     compacts ≥3 AND lines_added <500 AND commits >0
+  ghost_session       Plankton + 0 tools
+
+`--audit-anon` mode walks `outputs/anon/*.parquet` and asserts every
+column is free of:
+
+  - raw session UUIDs (8-4-4-4-12 hex pattern)
+  - absolute filesystem paths (/Users/, /home/, /tmp/, ~)
+  - raw bash commands (`git push`, `kubectl …`, `cargo …`, etc.)
+  - raw branch names (`feat/…`, `fix/…`, …)
+  - raw mcp slugs (only `mcp__<6hex>__<verb>` allowed)
+
+Exit code is 0 if clean, 1 if any leak found.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.io import outputs_dirs  # noqa: E402
+
+
+# ─── Anon-audit patterns ──────────────────────────────────────────────────
+
+# Full-form session UUID like "2c052d83-b765-440b-923d-72b7be0f7b30"
+RX_UUID = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+    re.I,
+)
+# Absolute filesystem paths
+RX_ABS_PATH = re.compile(r"(?:^|[\s'\"])(?:/Users/|/home/|/tmp/|/var/|~/)", re.I)
+# Raw bash commands (smell test)
+RX_RAW_BASH = re.compile(
+    r"\b(git\s+(?:push|commit|status|checkout|switch)|gh\s+(?:pr|issue)|"
+    r"glab\s+(?:mr|api)|kubectl\s+\w+|helm\s+\w+|terraform\s+\w+|"
+    r"cargo\s+(?:build|test|check|run|fmt)|docker\s+(?:run|build|compose)|"
+    r"npm\s+(?:install|test|run)|pnpm\s+\w+)",
+    re.I,
+)
+# Raw branch names like feat/DEV-123-foo, fix/something, chore/cleanup
+RX_RAW_BRANCH = re.compile(r"\b(feat|fix|chore|docs|refactor|test|ci)/[a-zA-Z0-9_\-]{3,}", re.I)
+# Raw MCP slug: mcp__server__verb where server is NOT a 6-hex hash
+# Allowed form: mcp__[0-9a-f]{6}__verb
+RX_MCP_RAW = re.compile(r"mcp__(?![0-9a-f]{6}__)[a-zA-Z][\w\-]*__[\w\-]+")
+
+
+def _is_string_col(table: pq.lib.Table, col: str) -> bool:  # type: ignore[name-defined]
+    t = table.schema.field(col).type
+    # arrow types: string, large_string, list<string>, etc.
+    return "string" in str(t).lower()
+
+
+def _walk_strings(value):
+    """Yield every string nested anywhere in `value` (lists / tuples / dicts)."""
+    if value is None:
+        return
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, (list, tuple)):
+        for v in value:
+            yield from _walk_strings(v)
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _walk_strings(v)
+
+
+def audit_anon(anon_dir: Path) -> int:
+    """Walk every parquet in anon/ and assert no leaks. Returns leak count."""
+    leaks: list[tuple[str, str, str, str]] = []  # (file, col, kind, sample)
+    parquets = sorted(anon_dir.glob("*.parquet"))
+    if not parquets:
+        print(f"⚠  no parquet files in {anon_dir}", file=sys.stderr)
+        return 0
+
+    for pf in parquets:
+        try:
+            table = pq.read_table(pf)
+        except Exception as e:
+            print(f"  ⚠  cannot read {pf.name}: {e}", file=sys.stderr)
+            continue
+        for col in table.column_names:
+            if not _is_string_col(table, col):
+                continue
+            col_data = table.column(col).to_pylist()
+            for value in col_data:
+                for s in _walk_strings(value):
+                    if not s:
+                        continue
+                    if RX_UUID.search(s):
+                        leaks.append((pf.name, col, "raw_uuid", s[:80]))
+                    if RX_ABS_PATH.search(s):
+                        leaks.append((pf.name, col, "abs_path", s[:80]))
+                    if RX_RAW_BASH.search(s):
+                        leaks.append((pf.name, col, "raw_bash", s[:80]))
+                    if RX_RAW_BRANCH.search(s):
+                        leaks.append((pf.name, col, "raw_branch", s[:80]))
+                    if RX_MCP_RAW.search(s):
+                        leaks.append((pf.name, col, "raw_mcp_slug", s[:80]))
+
+    # Specific schema rules
+    biome_path = anon_dir / "biome.parquet"
+    if biome_path.exists():
+        rows = pq.read_table(biome_path).to_pylist()
+        for r in rows:
+            sid = r.get("sid", "")
+            if not (
+                re.fullmatch(r"s\d{4,}", sid)
+                or re.fullmatch(r"a\d{4,}", sid)
+                or sid.startswith("sub_")
+                or sid == ""
+            ):
+                leaks.append(("biome.parquet", "sid", "bad_sid_format", sid[:80]))
+            project = r.get("project", "")
+            if project and not re.fullmatch(r"p[0-9a-f]{4,}", project):
+                leaks.append(("biome.parquet", "project", "bad_project_format", project[:80]))
+
+    # Print report
+    print("Anon audit report:")
+    print(f"  files scanned: {len(parquets)}")
+    if not leaks:
+        print(f"  ✓ no leaks found")
+        return 0
+    print(f"  ✗ {len(leaks)} leaks found")
+    by_kind: dict[str, int] = {}
+    for f, c, k, s in leaks:
+        by_kind[k] = by_kind.get(k, 0) + 1
+    for k, n in sorted(by_kind.items(), key=lambda x: -x[1]):
+        print(f"    {k:<20s} {n:>4d}")
+    print("  first 10 examples:")
+    for f, c, k, s in leaks[:10]:
+        print(f"    [{f}].{c} {k}: {s!r}")
+    return 1
+
+
+# ─── Heuristic pattern detection (default) ────────────────────────────────
+
+
+def detect_patterns(raw_dir: Path) -> int:
+    biome = pq.read_table(raw_dir / "biome.parquet").to_pylist()
+    arch = {r["sid"]: r for r in pq.read_table(raw_dir / "archetype.parquet").to_pylist()}
+    cmp = {r["sid"]: r for r in pq.read_table(raw_dir / "compact_pattern.parquet").to_pylist()}
+    out = {r["sid"]: r for r in pq.read_table(raw_dir / "outputs.parquet").to_pylist()}
+    gaps_per_sid: dict[str, int] = {}
+    try:
+        for r in pq.read_table(raw_dir / "idle_gaps.parquet").to_pylist():
+            gaps_per_sid[r["sid"]] = gaps_per_sid.get(r["sid"], 0) + 1
+    except Exception:
+        pass
+
+    flags = {
+        "needs_split": [],
+        "pure_constructor": [],
+        "feature_with_debug": [],
+        "pipeline_rescue": [],
+        "ghost_session": [],
+    }
+
+    for r in biome:
+        sid = r["sid"]
+        a = arch.get(sid, {})
+        c = cmp.get(sid, {})
+        o = out.get(sid, {})
+        if r["biome"] == "Plankton" and a.get("total_tools", 0) == 0:
+            flags["ghost_session"].append(sid)
+        if gaps_per_sid.get(sid, 0) >= 2:
+            flags["needs_split"].append(sid)
+        if a.get("archetype") == "Constructor" and a.get("rhythm") == "Phased":
+            flags["pure_constructor"].append(sid)
+        if a.get("archetype") == "Inspector" and c.get("compacts", 0) >= 2:
+            flags["feature_with_debug"].append(sid)
+        if c.get("compacts", 0) >= 3 and o.get("lines_added", 0) < 500 and o.get("commits_total", 0) > 0:
+            flags["pipeline_rescue"].append(sid)
+
+    print("Pattern detector report:")
+    for k, sids in flags.items():
+        print(f"  {k:<22s} {len(sids):>4d}  examples: {[s[:8] for s in sids[:5]]}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--outputs", default=None)
+    p.add_argument("--audit-anon", action="store_true",
+                   help="Walk anon/ parquets and check for leaks. Exit 1 if any.")
+    args = p.parse_args(argv)
+    raw_dir, anon_dir = outputs_dirs(Path(args.outputs) if args.outputs else None)
+    if args.audit_anon:
+        leak_count = audit_anon(anon_dir)
+        return 1 if leak_count else 0
+    return detect_patterns(raw_dir)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/pattern_detector.py
+++ b/.claude/skills/analyze-usage/scripts/pattern_detector.py
@@ -85,7 +85,10 @@ def _walk_strings(value):
 
 
 def audit_anon(anon_dir: Path) -> int:
-    """Walk every parquet in anon/ and assert no leaks. Returns leak count."""
+    """Walk every parquet in anon/ and assert no leaks. Returns the total
+    number of leak findings (0 means clean). The CLI translates this into
+    an exit code via `1 if leak_count else 0`.
+    """
     leaks: list[tuple[str, str, str, str]] = []  # (file, col, kind, sample)
     parquets = sorted(anon_dir.glob("*.parquet"))
     if not parquets:
@@ -138,7 +141,7 @@ def audit_anon(anon_dir: Path) -> int:
     print("Anon audit report:")
     print(f"  files scanned: {len(parquets)}")
     if not leaks:
-        print(f"  ✓ no leaks found")
+        print("  ✓ no leaks found")
         return 0
     print(f"  ✗ {len(leaks)} leaks found")
     by_kind: dict[str, int] = {}
@@ -149,7 +152,7 @@ def audit_anon(anon_dir: Path) -> int:
     print("  first 10 examples:")
     for f, c, k, s in leaks[:10]:
         print(f"    [{f}].{c} {k}: {s!r}")
-    return 1
+    return len(leaks)
 
 
 # ─── Heuristic pattern detection (default) ────────────────────────────────

--- a/.claude/skills/analyze-usage/scripts/period_report.py
+++ b/.claude/skills/analyze-usage/scripts/period_report.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""period_report.py — graphic monthly/weekly digest with our metaphors.
+
+Aquarium of biomes (🐋🦈🐬🐟🦐🦠), archetypes (⚙️🔬🌐🛠📝🔍🏗💬), rhythm,
+stack palette, DORA radar (CFR + lead time + pushes), friction (compacts,
+pivots, subagents). Active-vs-wallclock ratio.
+
+Output formats: terminal text / markdown / html / all.
+
+Usage:
+    period_report.py --from 2026-02-01 --to 2026-04-30 --period both
+    period_report.py --from 2026-04-23 --to 2026-04-30 --format html --open
+    period_report.py --from 2026-02-01 --to 2026-04-30 --format all --out-dir /tmp/usage
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import webbrowser
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Make `lib/` importable when invoked directly
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.classifiers import (  # noqa: E402
+    biome_of, archetype_of, rhythm_of, stack_of, bash_sub_of,
+    commit_type_of, is_review_fix,
+)
+from lib.render import (  # noqa: E402
+    render_period_terminal,
+    render_period_markdown,
+    render_period_html_section,
+    render_html_doc,
+    render_weekly_table_terminal,
+    render_weekly_table_markdown,
+    render_weekly_table_html,
+    render_trends_terminal,
+    render_trends_markdown,
+    render_trends_html,
+)
+
+DEFAULT_ROOT = Path.home() / ".claude" / "projects"
+
+# ─── Commit message extraction (heredoc + -m '...') ───────────────────────
+RX_GIT_COMMIT_M = re.compile(
+    r"git\s+commit\s+(?:[^']*\s)?-m\s+(?:'((?:[^'\\]|\\.)*)'|\"((?:[^\"\\]|\\.)*)\")",
+    re.DOTALL,
+)
+RX_HEREDOC_MSG = re.compile(
+    r"-m\s+\"\$\(\s*cat\s*<<\s*'?(\w+)'?\s*\n(.*?)\n\1\s*\)\"",
+    re.DOTALL,
+)
+
+
+def _extract_msgs(cmd: str) -> list[str]:
+    out = []
+    for m in RX_HEREDOC_MSG.finditer(cmd):
+        out.append(m.group(2))
+    for m in RX_GIT_COMMIT_M.finditer(cmd):
+        out.append(m.group(1) or m.group(2) or "")
+    return out
+
+
+def _cnt_lines(s: str) -> int:
+    if not s:
+        return 0
+    return s.count("\n") + (0 if s.endswith("\n") else 1)
+
+
+def _new_session() -> dict:
+    return {
+        "real": 0, "asst": 0, "project": None,
+        "first_ts": None, "last_ts": None,
+        "edit": 0, "bash": 0, "read": 0, "mcp": 0, "sub": 0, "lines_added": 0,
+        "compacts": 0, "pivots": 0,
+        "commits": Counter(), "review_fixes": 0,
+        "pr_create": 0, "mr_create": 0, "pushes": 0,
+        "event_seq": [], "stack_loc": Counter(), "all_event_ts": [],
+    }
+
+
+def parse_all(root: Path, since: datetime | None = None, until: datetime | None = None) -> dict:
+    """Parse every main jsonl under root. Returns dict[sid] -> session dict."""
+    sessions: dict[str, dict] = defaultdict(_new_session)
+    if not root.exists():
+        return sessions
+    for proj_dir in sorted(root.iterdir()):
+        if not proj_dir.is_dir():
+            continue
+        proj_slug = proj_dir.name
+        for jf in sorted(proj_dir.glob("*.jsonl")):
+            sid = jf.stem
+            try:
+                with jf.open() as fh:
+                    for line in fh:
+                        try:
+                            m = json.loads(line)
+                        except Exception:
+                            continue
+                        sd = sessions[sid]
+                        sd["project"] = proj_slug
+                        if m.get("isCompactSummary"):
+                            sd["compacts"] += 1
+                        ts_str = m.get("timestamp")
+                        t = None
+                        if ts_str:
+                            try:
+                                t = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                            except Exception:
+                                pass
+                        if t:
+                            if sd["first_ts"] is None or t < sd["first_ts"]:
+                                sd["first_ts"] = t
+                            if sd["last_ts"] is None or t > sd["last_ts"]:
+                                sd["last_ts"] = t
+                            sd["all_event_ts"].append(t)
+                        typ = m.get("type", "?")
+                        msg = m.get("message", {})
+                        content = msg.get("content") if isinstance(msg, dict) else None
+                        if typ == "assistant":
+                            sd["asst"] += 1
+                            if not isinstance(content, list):
+                                continue
+                            for blk in content:
+                                if not isinstance(blk, dict) or blk.get("type") != "tool_use":
+                                    continue
+                                name = blk.get("name", "?")
+                                inp = blk.get("input", {}) if isinstance(blk.get("input"), dict) else {}
+                                if name in ("Edit", "MultiEdit", "Write"):
+                                    sd["edit"] += 1
+                                    sd["event_seq"].append("Edit")
+                                    fp = inp.get("file_path", "") or ""
+                                    stack = stack_of(fp) if fp else "other"
+                                    if name == "Write":
+                                        cnt = inp.get("content", "") or ""
+                                        nl = _cnt_lines(cnt)
+                                        sd["lines_added"] += nl
+                                        sd["stack_loc"][stack] += nl
+                                    elif name == "Edit":
+                                        o = inp.get("old_string", "") or ""
+                                        n = inp.get("new_string", "") or ""
+                                        ol, nl = _cnt_lines(o), _cnt_lines(n)
+                                        add = max(nl - ol, 0)
+                                        if ol == nl and o != n:
+                                            add = nl or 1
+                                        sd["lines_added"] += add
+                                        sd["stack_loc"][stack] += add
+                                    else:  # MultiEdit
+                                        for e in inp.get("edits", []):
+                                            if not isinstance(e, dict):
+                                                continue
+                                            o = e.get("old_string", "") or ""
+                                            n = e.get("new_string", "") or ""
+                                            ol, nl = _cnt_lines(o), _cnt_lines(n)
+                                            add = max(nl - ol, 0)
+                                            if ol == nl and o != n:
+                                                add = nl or 1
+                                            sd["lines_added"] += add
+                                            sd["stack_loc"][stack] += add
+                                elif name in ("Read", "Grep", "Glob", "ToolSearch"):
+                                    sd["read"] += 1
+                                    sd["event_seq"].append("Read")
+                                elif name == "Bash":
+                                    sd["bash"] += 1
+                                    cmd = inp.get("command", "") or ""
+                                    sd["event_seq"].append(f"Bash:{bash_sub_of(cmd)}")
+                                    if "git push" in cmd:
+                                        sd["pushes"] += 1
+                                    if "git commit" in cmd:
+                                        for body in _extract_msgs(cmd):
+                                            first = body.strip().split("\n")[0] if body else ""
+                                            ctype = commit_type_of(first)
+                                            sd["commits"][ctype] += 1
+                                            if ctype == "fix" and is_review_fix(body):
+                                                sd["review_fixes"] += 1
+                                    if "gh pr create" in cmd:
+                                        sd["pr_create"] += 1
+                                    if "glab mr create" in cmd:
+                                        sd["mr_create"] += 1
+                                elif name in ("Task", "Agent"):
+                                    sd["sub"] += 1
+                                elif name.startswith("mcp__"):
+                                    sd["mcp"] += 1
+                        elif typ == "user":
+                            is_meta = m.get("isMeta", False)
+                            ctype = ""
+                            text = ""
+                            if isinstance(content, list) and content:
+                                fb = content[0] if isinstance(content[0], dict) else {}
+                                ctype = fb.get("type", "")
+                                if ctype == "text":
+                                    text = fb.get("text", "")
+                            elif isinstance(content, str):
+                                ctype = "string"
+                                text = content
+                            if not is_meta and ctype in ("string", "text"):
+                                txt = text.lstrip()
+                                if txt.startswith("[Request interrupted by user"):
+                                    sd["pivots"] += 1
+                                elif not txt.startswith((
+                                    "<command-name>", "<system-reminder>",
+                                    "<user-prompt-submit-hook>", "Caveat:",
+                                    "<local-command-stdout>", "<task-notification>",
+                                    "This session is being continued",
+                                )):
+                                    sd["real"] += 1
+            except Exception:
+                pass
+    if since or until:
+        kept = {}
+        for sid, sd in sessions.items():
+            if sd["first_ts"] is None:
+                continue
+            if since and sd["first_ts"] < since:
+                continue
+            if until and sd["first_ts"] > until:
+                continue
+            kept[sid] = sd
+        return kept
+    return sessions
+
+
+def active_minutes(ts_list: list[datetime], gap_min: int = 30) -> float:
+    if len(ts_list) < 2:
+        return 0
+    s = sorted(ts_list)
+    total = 0.0
+    gap = timedelta(minutes=gap_min)
+    for i in range(1, len(s)):
+        d = s[i] - s[i - 1]
+        if d <= gap:
+            total += d.total_seconds()
+    return total / 60
+
+
+def aggregate(sessions: list[tuple[str, dict]]) -> dict:
+    a = Counter()
+    biomes = Counter()
+    archs = Counter()
+    rhythms = Counter()
+    stack_loc = Counter()
+    a["n"] = len(sessions)
+    wall = 0.0
+    act = 0.0
+    for sid, d in sessions:
+        biomes[biome_of(d["real"])] += 1
+        archs[archetype_of(d["edit"], d["bash"], d["read"])] += 1
+        rhythms[rhythm_of(d["event_seq"])] += 1
+        for k, v in d["stack_loc"].items():
+            stack_loc[k] += v
+        a["feat"] += d["commits"].get("feat", 0)
+        a["fix"] += d["commits"].get("fix", 0)
+        a["review_fix"] += d["review_fixes"]
+        a["lines_added"] += d["lines_added"]
+        a["pushes"] += d["pushes"]
+        a["pr_mr"] += d["pr_create"] + d["mr_create"]
+        a["compacts"] += d["compacts"]
+        a["pivots"] += d["pivots"]
+        a["subs"] += d["sub"]
+        if d["first_ts"] and d["last_ts"]:
+            wall += (d["last_ts"] - d["first_ts"]).total_seconds() / 60
+            act += active_minutes(d["all_event_ts"])
+    a["wall_min"] = wall
+    a["active_min"] = act
+    a["biomes"] = biomes
+    a["archs"] = archs
+    a["rhythms"] = rhythms
+    a["stack_loc"] = stack_loc
+    return a
+
+
+# ─── Format builders ──────────────────────────────────────────────────────
+
+
+RU_MONTHS = {1: "Январь ❄️", 2: "Февраль ❄️", 3: "Март 🌸", 4: "Апрель 🌱",
+             5: "Май ☀️", 6: "Июнь ☀️", 7: "Июль ☀️", 8: "Август 🌾",
+             9: "Сентябрь 🍂", 10: "Октябрь 🍁", 11: "Ноябрь 🌨", 12: "Декабрь 🎄"}
+
+
+def build_terminal(period: str, dt_from, dt_to,
+                   month_groups, week_groups, n_total) -> str:
+    out = []
+    out.append("")
+    out.append("🌊" * 50)
+    out.append(f"  ОКЕАН CLAUDE CODE — {dt_from.date()} … {dt_to.date()}")
+    out.append(f"  {n_total} sessions, биомы от 🦠 до 🐋")
+    out.append("🌊" * 50)
+    if period in ("monthly", "both"):
+        months_data = {}
+        months_labels = {}
+        for (y, m) in sorted(month_groups.keys()):
+            agg = aggregate(month_groups[(y, m)])
+            label = f"📅 {RU_MONTHS.get(m, str(m))} {y}"
+            out.extend(render_period_terminal(label, agg))
+            months_data[m] = agg
+            months_labels[m] = RU_MONTHS.get(m, str(m)).split(" ")[0]
+        if len(months_data) >= 2:
+            out.extend(render_trends_terminal(months_data, months_labels))
+    if period in ("weekly", "both"):
+        weeks = sorted(week_groups.keys())
+        weekly_aggs = [(w, aggregate(week_groups[w])) for w in weeks]
+        out.extend(render_weekly_table_terminal(weekly_aggs))
+    return "\n".join(out)
+
+
+def build_markdown(period: str, dt_from, dt_to,
+                   month_groups, week_groups, n_total) -> str:
+    out = []
+    out.append(f"# 🌊 Океан Claude Code — {dt_from.date()} … {dt_to.date()}")
+    out.append("")
+    out.append(f"**{n_total} sessions** · биомы от 🦠 до 🐋")
+    out.append("")
+    if period in ("monthly", "both"):
+        months_data = {}
+        months_labels = {}
+        for (y, m) in sorted(month_groups.keys()):
+            agg = aggregate(month_groups[(y, m)])
+            label = f"📅 {RU_MONTHS.get(m, str(m))} {y}"
+            out.extend(render_period_markdown(label, agg))
+            months_data[m] = agg
+            months_labels[m] = RU_MONTHS.get(m, str(m)).split(" ")[0]
+        if len(months_data) >= 2:
+            out.extend(render_trends_markdown(months_data, months_labels))
+    if period in ("weekly", "both"):
+        weeks = sorted(week_groups.keys())
+        weekly_aggs = [(w, aggregate(week_groups[w])) for w in weeks]
+        out.extend(render_weekly_table_markdown(weekly_aggs))
+    return "\n".join(out)
+
+
+def build_html(period: str, dt_from, dt_to,
+               month_groups, week_groups, n_total) -> str:
+    title = f"Океан Claude Code · {dt_from.date()} … {dt_to.date()} · {n_total} sessions"
+    sections: list[str] = []
+    if period in ("monthly", "both"):
+        months_data = {}
+        months_labels = {}
+        for (y, m) in sorted(month_groups.keys()):
+            agg = aggregate(month_groups[(y, m)])
+            label = f"📅 {RU_MONTHS.get(m, str(m))} {y}"
+            sections.append(render_period_html_section(label, agg))
+            months_data[m] = agg
+            months_labels[m] = RU_MONTHS.get(m, str(m)).split(" ")[0]
+        if len(months_data) >= 2:
+            tr = render_trends_html(months_data, months_labels)
+            if tr:
+                sections.append(tr)
+    if period in ("weekly", "both"):
+        weeks = sorted(week_groups.keys())
+        weekly_aggs = [(w, aggregate(week_groups[w])) for w in weeks]
+        wt = render_weekly_table_html(weekly_aggs)
+        if wt:
+            sections.append(wt)
+    return render_html_doc(title, sections)
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Graphic period digest of Claude Code usage.")
+    p.add_argument("--from", dest="dt_from", required=True, help="YYYY-MM-DD start (inclusive)")
+    p.add_argument("--to", dest="dt_to", required=True, help="YYYY-MM-DD end (inclusive)")
+    p.add_argument("--period", choices=["monthly", "weekly", "both"], default="monthly")
+    p.add_argument("--format", choices=["text", "markdown", "html", "all"], default="text",
+                   help="Output format. 'all' writes text+md+html into --out-dir.")
+    p.add_argument("--root", default=str(DEFAULT_ROOT), help="Path to ~/.claude/projects")
+    p.add_argument("--out", default=None, help="Write to file (single format)")
+    p.add_argument("--out-dir", default=None,
+                   help="Directory for --format all (default: /tmp/analyze-usage-<date>)")
+    p.add_argument("--open", dest="open_in_browser", action="store_true",
+                   help="Auto-open HTML output in default browser (requires html or all format)")
+    args = p.parse_args(argv)
+
+    dt_from = datetime.fromisoformat(args.dt_from).replace(tzinfo=timezone.utc)
+    dt_to = datetime.fromisoformat(args.dt_to).replace(hour=23, minute=59, second=59, tzinfo=timezone.utc)
+
+    print(f"Парсим {args.root}…", file=sys.stderr, flush=True)
+    sessions = parse_all(Path(args.root), since=dt_from, until=dt_to)
+    items = list(sessions.items())
+    n_total = len(items)
+    print(f"  in period: {n_total} sessions", file=sys.stderr)
+
+    month_groups = defaultdict(list)
+    week_groups = defaultdict(list)
+    for sid, d in items:
+        if d["first_ts"] is None:
+            continue
+        month_groups[(d["first_ts"].year, d["first_ts"].month)].append((sid, d))
+        week_groups[d["first_ts"].isocalendar()[:2]].append((sid, d))
+
+    formats = [args.format] if args.format != "all" else ["text", "markdown", "html"]
+    artefacts: dict[str, str] = {}
+    for fmt in formats:
+        if fmt == "text":
+            artefacts["text"] = build_terminal(args.period, dt_from, dt_to,
+                                                month_groups, week_groups, n_total)
+        elif fmt == "markdown":
+            artefacts["markdown"] = build_markdown(args.period, dt_from, dt_to,
+                                                    month_groups, week_groups, n_total)
+        elif fmt == "html":
+            artefacts["html"] = build_html(args.period, dt_from, dt_to,
+                                            month_groups, week_groups, n_total)
+
+    out_paths: dict[str, Path] = {}
+    if args.format == "all":
+        out_dir = Path(args.out_dir) if args.out_dir else Path(f"/tmp/analyze-usage-{dt_to.date()}")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for fmt, content in artefacts.items():
+            ext = {"text": "txt", "markdown": "md", "html": "html"}[fmt]
+            p_path = out_dir / f"report.{ext}"
+            p_path.write_text(content, encoding="utf-8")
+            out_paths[fmt] = p_path
+        print(f"\n[saved 3 files to {out_dir}/]", file=sys.stderr)
+        # Print text to stdout for convenience
+        print(artefacts["text"])
+    elif args.out:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(artefacts[args.format], encoding="utf-8")
+        out_paths[args.format] = out_path
+        print(f"[saved to {out_path}]", file=sys.stderr)
+        # Also dump to stdout if format is text
+        if args.format == "text":
+            print(artefacts["text"])
+    else:
+        # No file output → just stdout (only valid for text by default)
+        if args.format == "text":
+            print(artefacts["text"])
+        elif args.format == "markdown":
+            print(artefacts["markdown"])
+        elif args.format == "html":
+            # html to stdout works but is weird; auto-save to /tmp instead
+            tmp_path = Path(f"/tmp/analyze-usage-{dt_to.date()}.html")
+            tmp_path.write_text(artefacts["html"], encoding="utf-8")
+            out_paths["html"] = tmp_path
+            print(f"[html saved to {tmp_path}]", file=sys.stderr)
+
+    # Auto-open in browser
+    if args.open_in_browser:
+        html_path = out_paths.get("html")
+        if html_path:
+            webbrowser.open(html_path.resolve().as_uri())
+            print(f"[opening {html_path} in browser]", file=sys.stderr)
+        else:
+            print("--open requires html or all format (no html artefact produced)", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/pipeline.py
+++ b/.claude/skills/analyze-usage/scripts/pipeline.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Pipeline orchestrator: runs all extractors and writes raw + anon parquet bundles.
+
+Usage:
+  pipeline.py --since 2026-04-01 --outputs .claude/skills/analyze-usage/outputs/
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+import time
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+EXTRACTORS = [
+    "extract_biome",
+    "extract_archetype",
+    "extract_outputs",
+    "extract_compacts",
+    "extract_growth",
+    "extract_subagents",
+    "extract_gaps",
+    "extract_burst_classes",
+    "extract_parallelism",
+    "extract_topics",
+]
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--since", default=None, help="YYYY-MM-DD")
+    p.add_argument("--outputs", default=None)
+    p.add_argument("--only", nargs="*", default=None,
+                   help="Run only listed extractors (without 'extract_' prefix)")
+    args = p.parse_args(argv)
+
+    sys.path.insert(0, str(_HERE))  # find sibling extract_*.py
+    targets = EXTRACTORS
+    if args.only:
+        wanted = {f"extract_{x}" if not x.startswith("extract_") else x for x in args.only}
+        targets = [t for t in EXTRACTORS if t in wanted]
+
+    summary: list[tuple[str, float, int]] = []
+    for name in targets:
+        t0 = time.time()
+        print(f"━━ {name} …", file=sys.stderr)
+        mod = importlib.import_module(name)
+        sub_argv = []
+        if args.since:
+            sub_argv += ["--since", args.since]
+        if args.outputs:
+            sub_argv += ["--outputs", args.outputs]
+        rc = mod.main(sub_argv)
+        elapsed = time.time() - t0
+        summary.append((name, elapsed, rc))
+
+    print("\n━━ summary ━━", file=sys.stderr)
+    for name, elapsed, rc in summary:
+        mark = "✓" if rc == 0 else "✗"
+        print(f"  {mark}  {name:<28s} {elapsed:>6.1f}s", file=sys.stderr)
+    return 0 if all(rc == 0 for _, _, rc in summary) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/report_generator.py
+++ b/.claude/skills/analyze-usage/scripts/report_generator.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyarrow>=15"]
+# ///
+"""Markdown report skeleton from parquet bundles.
+
+Reads `outputs/raw/*.parquet` and emits `outputs/reports/<date>.md`.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from datetime import date
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.io import outputs_dirs  # noqa: E402
+from lib.classifiers import BIOME_EMOJI, ARCHETYPE_EMOJI  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--outputs", default=None)
+    p.add_argument("--out", default=None, help="Output markdown path")
+    args = p.parse_args(argv)
+    raw_dir, _ = outputs_dirs(Path(args.outputs) if args.outputs else None)
+    reports_dir = raw_dir.parent / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    biome_rows = pq.read_table(raw_dir / "biome.parquet").to_pylist()
+    arch_rows = pq.read_table(raw_dir / "archetype.parquet").to_pylist()
+    out_rows = pq.read_table(raw_dir / "outputs.parquet").to_pylist()
+
+    biomes = Counter(r["biome"] for r in biome_rows)
+    archs = Counter(r["archetype"] for r in arch_rows)
+    total_loc = sum(r["lines_added"] for r in out_rows)
+    total_feat = sum(r["feat"] for r in out_rows)
+    total_fix = sum(r["fix"] for r in out_rows)
+    total_review = sum(r["review_fix"] for r in out_rows)
+    total_pushes = sum(r["pushes"] for r in out_rows)
+    cfr = (total_fix - total_review) / (total_feat + 1) if total_feat else 0
+
+    md = []
+    md.append(f"# Usage report — {date.today().isoformat()}\n")
+    md.append(f"## 🌊 Aquarium ({len(biome_rows)} entities)\n")
+    for b in ("Whale", "Shark", "Dolphin", "Fish", "Shrimp", "Plankton"):
+        n = biomes.get(b, 0)
+        if n == 0:
+            continue
+        md.append(f"- {BIOME_EMOJI[b]} **{b}**: {n}")
+    md.append("")
+
+    md.append(f"## 🎭 Archetypes ({len(arch_rows)} sessions)\n")
+    for a, n in archs.most_common():
+        md.append(f"- {ARCHETYPE_EMOJI.get(a, '·')} **{a}**: {n}")
+    md.append("")
+
+    md.append("## 🚀 DORA aggregates\n")
+    md.append(f"- +LOC: **{total_loc:,}**")
+    md.append(f"- feat: {total_feat}, fix: {total_fix} (review {total_review}, prod {total_fix-total_review})")
+    md.append(f"- pushes: {total_pushes}")
+    cfr_em = "🟢" if cfr < 0.3 else "🟡" if cfr < 1 else "🟠" if cfr < 3 else "🔴"
+    cfr_lvl = "Elite" if cfr < 0.3 else "High" if cfr < 1 else "Medium" if cfr < 3 else "Low"
+    md.append(f"- True CFR: {cfr_em} **{cfr:.2f}** ({cfr_lvl})")
+    md.append("")
+
+    md.append("## 🐋 Top sessions\n")
+    sorted_b = sorted(biome_rows, key=lambda r: -r["real_prompts"])[:10]
+    for r in sorted_b:
+        md.append(f"- {BIOME_EMOJI[r['biome']]} {r['sid'][:8]} R={r['real_prompts']} project={r['project']}")
+    md.append("")
+
+    out_path = Path(args.out) if args.out else (reports_dir / f"{date.today().isoformat()}.md")
+    out_path.write_text("\n".join(md))
+    print(f"report → {out_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/scripts/report_generator.py
+++ b/.claude/skills/analyze-usage/scripts/report_generator.py
@@ -44,7 +44,7 @@ def main(argv: list[str] | None = None) -> int:
     total_fix = sum(r["fix"] for r in out_rows)
     total_review = sum(r["review_fix"] for r in out_rows)
     total_pushes = sum(r["pushes"] for r in out_rows)
-    cfr = (total_fix - total_review) / (total_feat + 1) if total_feat else 0
+    cfr = (total_fix - total_review) / total_feat if total_feat else 0
 
     md = []
     md.append(f"# Usage report — {date.today().isoformat()}\n")

--- a/.claude/skills/analyze-usage/scripts/report_generator.py
+++ b/.claude/skills/analyze-usage/scripts/report_generator.py
@@ -77,7 +77,7 @@ def main(argv: list[str] | None = None) -> int:
     md.append("")
 
     out_path = Path(args.out) if args.out else (reports_dir / f"{date.today().isoformat()}.md")
-    out_path.write_text("\n".join(md))
+    out_path.write_text("\n".join(md), encoding="utf-8")
     print(f"report → {out_path}", file=sys.stderr)
     return 0
 

--- a/.claude/skills/analyze-usage/scripts/view_session.py
+++ b/.claude/skills/analyze-usage/scripts/view_session.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Drill-down view of one session by sid (UUID prefix is enough).
+
+Usage: view_session.py 2c052d83
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.parsers import find_session_files, load_session  # noqa: E402
+from lib.classifiers import (  # noqa: E402
+    biome_of, archetype_of, rhythm_of, bash_sub_of,
+    BIOME_EMOJI, ARCHETYPE_EMOJI, RHYTHM_EMOJI,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    if not argv:
+        argv = sys.argv[1:]
+    if not argv:
+        print("usage: view_session.py <sid_prefix>", file=sys.stderr)
+        return 2
+    prefix = argv[0]
+    files = find_session_files()
+    matches = [f for f in files if f.stem.startswith(prefix)]
+    if not matches:
+        print(f"no session matching {prefix!r}", file=sys.stderr)
+        return 1
+    if len(matches) > 1:
+        print(f"ambiguous: {len(matches)} matches", file=sys.stderr)
+        for m in matches[:10]:
+            print(f"  {m.stem}", file=sys.stderr)
+        return 1
+    jf = matches[0]
+    sess = load_session(jf, include_subagents=True)
+
+    e = b = r = 0
+    seq: list[str] = []
+    bash_subs: dict[str, int] = {}
+    real_prompts = 0
+    compacts = 0
+    pivots = 0
+    for ev in sess.events:
+        if ev.type == "compact":
+            compacts += 1
+            continue
+        if ev.type == "user":
+            if ev.user_kind == "real_human":
+                real_prompts += 1
+            if ev.user_text.startswith("[Request interrupted by user"):
+                pivots += 1
+            continue
+        if ev.type != "assistant":
+            continue
+        for tu in ev.tool_uses:
+            n = tu.get("name", "")
+            if n in ("Edit", "MultiEdit", "Write"):
+                e += 1
+                seq.append("Edit")
+            elif n in ("Read", "Grep", "Glob", "ToolSearch"):
+                r += 1
+                seq.append("Read")
+            elif n == "Bash":
+                b += 1
+                cmd = (tu.get("input", {}) or {}).get("command", "") or ""
+                sub = bash_sub_of(cmd)
+                bash_subs[sub] = bash_subs.get(sub, 0) + 1
+                seq.append(f"Bash:{sub}")
+
+    biome = biome_of(real_prompts)
+    arch = archetype_of(e, b, r)
+    rh = rhythm_of(seq)
+
+    print(f"╔══ {sess.sid[:8]} ═══════════════════════════════════════════════════════════════")
+    print(f"║  project: {sess.project}")
+    print(f"║  events: {len(sess.events)}, bursts: {len(sess.bursts)}, subagents: {len(sess.subagents)}")
+    print(f"║  {BIOME_EMOJI[biome]} {biome}  |  {ARCHETYPE_EMOJI[arch]} {arch}  |  {RHYTHM_EMOJI[rh]} {rh}")
+    print(f"║  R: {real_prompts}  Edit: {e}  Bash: {b}  Read: {r}")
+    print(f"║  compacts: {compacts}  pivots: {pivots}")
+    if bash_subs:
+        bs = ", ".join(f"{k} {v}" for k, v in sorted(bash_subs.items(), key=lambda x: -x[1])[:5])
+        print(f"║  bash sub: {bs}")
+    if sess.subagents:
+        print(f"║  subagent count: {len(sess.subagents)}")
+        for sub in sess.subagents[:5]:
+            asst_n = sum(1 for ev in sub.events if ev.type == "assistant")
+            print(f"║    sub {sub.sub_id[:8]} asst={asst_n}")
+    print(f"╚{'═'*78}")
+
+    print("\nFirst 5 real-human prompts:")
+    cnt = 0
+    for ev in sess.events:
+        if ev.type == "user" and ev.user_kind == "real_human":
+            print(f"  • {ev.user_text[:140]!r}")
+            cnt += 1
+            if cnt >= 5:
+                break
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/analyze-usage/tests/run_all.sh
+++ b/.claude/skills/analyze-usage/tests/run_all.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run all tests for analyze-usage skill.
+set -e
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+echo "━━ test_classifiers"
+uv run --quiet --with pyarrow test_classifiers.py
+
+echo
+echo "━━ test_stats"
+uv run --quiet test_stats.py
+
+echo
+echo "━━ test_extractors_smoke"
+uv run --quiet --with pyarrow test_extractors_smoke.py
+
+echo
+echo "━━ test_audit_anon"
+uv run --quiet --with pyarrow test_audit_anon.py
+
+echo
+echo "✓ all tests passed"

--- a/.claude/skills/analyze-usage/tests/test_audit_anon.py
+++ b/.claude/skills/analyze-usage/tests/test_audit_anon.py
@@ -1,0 +1,149 @@
+"""Tests for pattern_detector.py --audit-anon.
+
+(1) Audit on a clean fixture passes.
+(2) Audit on a poisoned fixture fails (returns 1) for each leak kind.
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+_HERE = Path(__file__).resolve().parent
+_SKILL = _HERE.parent
+sys.path.insert(0, str(_SKILL))
+sys.path.insert(0, str(_SKILL / "scripts"))
+
+
+def _fresh_outputs_dir() -> Path:
+    return Path(tempfile.mkdtemp(prefix="audit_anon_test_"))
+
+
+def _write_anon(anon_dir: Path, name: str, rows: list[dict]) -> None:
+    anon_dir.mkdir(parents=True, exist_ok=True)
+    pq.write_table(pa.Table.from_pylist(rows), str(anon_dir / name))
+
+
+def _run_audit(outputs_dir: Path) -> int:
+    """Reload the module and run main with --audit-anon."""
+    if "pattern_detector" in sys.modules:
+        del sys.modules["pattern_detector"]
+    import pattern_detector  # noqa: WPS433
+    return pattern_detector.main(["--outputs", str(outputs_dir), "--audit-anon"])
+
+
+def test_clean_anon_passes():
+    out = _fresh_outputs_dir()
+    try:
+        anon = out / "anon"
+        # Minimal valid anon biome.parquet
+        _write_anon(anon, "biome.parquet", [
+            {"sid": "s0001", "project": "pa1b2c3", "biome": "Fish", "real_prompts": 12},
+            {"sid": "a0001", "project": "pa1b2c3", "biome": "Shrimp", "real_prompts": 5},
+        ])
+        # Some other parquet with safe enum strings
+        _write_anon(anon, "archetype.parquet", [
+            {"sid": "s0001", "archetype": "Operator", "rhythm": "Mono"},
+        ])
+        rc = _run_audit(out)
+        assert rc == 0, "clean audit should return 0"
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
+def test_uuid_leak_fails():
+    out = _fresh_outputs_dir()
+    try:
+        anon = out / "anon"
+        _write_anon(anon, "biome.parquet", [
+            # Real UUID accidentally left in `sid`
+            {"sid": "2c052d83-b765-440b-923d-72b7be0f7b30", "project": "pa1b2c3",
+             "biome": "Whale", "real_prompts": 700},
+        ])
+        rc = _run_audit(out)
+        assert rc == 1, "UUID leak must fail audit"
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
+def test_abs_path_leak_fails():
+    out = _fresh_outputs_dir()
+    try:
+        anon = out / "anon"
+        _write_anon(anon, "biome.parquet", [{"sid": "s0001", "project": "pa1b2c3", "biome": "Fish"}])
+        _write_anon(anon, "outputs.parquet", [
+            {"sid": "s0001", "project": "pa1b2c3",
+             "leaked_path": "/Users/andreymaznyak/projects/foo/bar.rs"},
+        ])
+        rc = _run_audit(out)
+        assert rc == 1, "absolute path leak must fail audit"
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
+def test_raw_bash_leak_fails():
+    out = _fresh_outputs_dir()
+    try:
+        anon = out / "anon"
+        _write_anon(anon, "biome.parquet", [{"sid": "s0001", "project": "pa1b2c3", "biome": "Fish"}])
+        _write_anon(anon, "outputs.parquet", [
+            {"sid": "s0001", "leaked_cmd": "git push origin feat/foo"},
+        ])
+        rc = _run_audit(out)
+        assert rc == 1, "raw bash command must fail audit"
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
+def test_bad_sid_format_fails():
+    out = _fresh_outputs_dir()
+    try:
+        anon = out / "anon"
+        # sid not matching s/a/sub_ prefix
+        _write_anon(anon, "biome.parquet", [
+            {"sid": "wrong-format-sid", "project": "pa1b2c3", "biome": "Fish"},
+        ])
+        rc = _run_audit(out)
+        assert rc == 1, "bad sid format must fail audit"
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
+def test_raw_branch_in_list_field_fails():
+    out = _fresh_outputs_dir()
+    try:
+        anon = out / "anon"
+        _write_anon(anon, "biome.parquet", [{"sid": "s0001", "project": "pa1b2c3", "biome": "Fish"}])
+        # Branch hidden inside a list-of-strings column
+        _write_anon(anon, "topic_signatures.parquet", [
+            {"sid": "s0001", "project": "pa1b2c3",
+             "token_hashes": ["abc123", "feat/DEV-100-foo"]},
+        ])
+        rc = _run_audit(out)
+        assert rc == 1, "raw branch in nested list must fail audit"
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in dict(globals()).items() if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  ✗ {fn.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            import traceback
+            traceback.print_exc()
+            print(f"  ✗ {fn.__name__}: {e}")
+    if failed:
+        raise SystemExit(f"{failed}/{len(fns)} failed")
+    print(f"\n  {len(fns)}/{len(fns)} passed")

--- a/.claude/skills/analyze-usage/tests/test_classifiers.py
+++ b/.claude/skills/analyze-usage/tests/test_classifiers.py
@@ -1,0 +1,131 @@
+"""Unit tests for lib/classifiers.py — pure functions, no I/O."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.classifiers import (
+    biome_of, archetype_of, rhythm_of, stack_of, bash_sub_of,
+    commit_type_of, is_review_fix,
+)
+
+
+def test_biome_thresholds():
+    assert biome_of(0) == "Plankton"
+    assert biome_of(2) == "Plankton"
+    assert biome_of(3) == "Shrimp"
+    assert biome_of(9) == "Shrimp"
+    assert biome_of(10) == "Fish"
+    assert biome_of(29) == "Fish"
+    assert biome_of(30) == "Dolphin"
+    assert biome_of(99) == "Dolphin"
+    assert biome_of(100) == "Shark"
+    assert biome_of(499) == "Shark"
+    assert biome_of(500) == "Whale"
+    assert biome_of(10_000) == "Whale"
+
+
+def test_archetype_too_few():
+    assert archetype_of(0, 0, 0) == "Discusser"
+    assert archetype_of(2, 1, 1) == "Discusser"  # total<5
+
+
+def test_archetype_pure():
+    # Edit ≥45%
+    assert archetype_of(50, 25, 25) == "Constructor"
+    # Bash ≥45%
+    assert archetype_of(25, 50, 25) == "Operator"
+    # Read ≥45%
+    assert archetype_of(25, 25, 50) == "Researcher"
+
+
+def test_archetype_hybrid():
+    # All three ≥25 → Polymath
+    assert archetype_of(30, 30, 40) == "Polymath"  # 30/30/40
+    # Edit+Bash ≥25, Read <25 → Builder
+    assert archetype_of(40, 40, 20) == "Builder"
+    # Edit+Read ≥25 → Scholar
+    assert archetype_of(40, 20, 40) == "Scholar"
+    # Bash+Read ≥25 → Inspector
+    assert archetype_of(20, 40, 40) == "Inspector"
+
+
+def test_rhythm_too_short():
+    assert rhythm_of([]) == "—"
+    assert rhythm_of(["Edit"] * 5) == "—"
+
+
+def test_rhythm_mono():
+    # All Edit → Mono
+    assert rhythm_of(["Edit"] * 100) == "Mono"
+
+
+def test_rhythm_chaos():
+    # Highly varied seq where each of the 10 windows gets a different dominant tool.
+    # 10 windows × 4 events = 40 events, each window uniformly different top.
+    tools_per_window = ["Edit", "Bash:test", "Read", "Bash:git",
+                        "Edit", "Read", "Bash:build", "Bash:deploy",
+                        "Edit", "Read"]
+    seq = []
+    for t in tools_per_window:
+        seq.extend([t] * 4)  # window dominated by t
+    cls = rhythm_of(seq)
+    # Expected: 10 unique tops, 9 switches → fits Chaos
+    assert cls == "Chaos", cls
+
+
+def test_stack_basic():
+    assert stack_of("apps/api/src/main.rs") == "backend"
+    assert stack_of("apps/dashboard-ui/src/App.tsx") == "frontend"
+    assert stack_of("infra/k8s/deployment.yaml") == "infra"
+    assert stack_of("docs/README.md") == "docs"
+    assert stack_of("package.json") == "config"
+    assert stack_of("") == "other"
+    assert stack_of("infra/main.tf") == "infra"
+    assert stack_of("apps/web/styles.css") == "frontend"
+
+
+def test_bash_sub():
+    assert bash_sub_of("git status") == "git"
+    assert bash_sub_of("cargo test --all") == "test"
+    assert bash_sub_of("cargo build") == "build"
+    assert bash_sub_of("kubectl get pods") == "deploy"
+    assert bash_sub_of("ls -la") == "shell"
+    assert bash_sub_of("curl https://example.com") == "net"
+    assert bash_sub_of("playwright-cli snapshot") == "playwright_cli"
+    assert bash_sub_of("") == "other"
+    assert bash_sub_of("python3 setup.py") == "run"
+
+
+def test_commit_type():
+    assert commit_type_of("feat: add login") == "feat"
+    assert commit_type_of("feat(api): something") == "feat"
+    assert commit_type_of("fix: bug") == "fix"
+    assert commit_type_of("not a conventional commit") == "uncategorized"
+    assert commit_type_of("") == "uncategorized"
+
+
+def test_review_fix_detection():
+    assert is_review_fix("fix: address review comments")
+    assert is_review_fix("fix: copilot suggestion")
+    assert is_review_fix("fix: artslob review feedback")
+    assert not is_review_fix("fix: null pointer in user service")
+
+
+if __name__ == "__main__":
+    # Lightweight inline runner
+    fns = [v for k, v in dict(globals()).items() if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  ✗ {fn.__name__}: {e}")
+    if failed:
+        raise SystemExit(f"{failed}/{len(fns)} failed")
+    print(f"\n  {len(fns)}/{len(fns)} passed")

--- a/.claude/skills/analyze-usage/tests/test_extractors_smoke.py
+++ b/.claude/skills/analyze-usage/tests/test_extractors_smoke.py
@@ -1,0 +1,222 @@
+"""Extractor smoke test on a synthetic fixture.
+
+Builds a tiny ~/.claude/projects/ structure under a temp dir, runs each
+extractor pointing at it, and asserts:
+  - parquet file exists in raw/ and anon/
+  - row count > 0 (when fixture is non-empty)
+  - schema has the expected columns
+  - sample values make sense
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+_HERE = Path(__file__).resolve().parent
+_SKILL = _HERE.parent
+sys.path.insert(0, str(_SKILL))
+
+
+def _ev(typ: str, ts: datetime, **extra) -> dict:
+    rec = {"type": typ, "timestamp": ts.isoformat()}
+    rec.update(extra)
+    return rec
+
+
+def _user_text(ts: datetime, text: str) -> dict:
+    return _ev(
+        "user", ts,
+        message={"content": [{"type": "text", "text": text}]},
+    )
+
+
+def _assistant(ts: datetime, *, text: str = "", tool_uses: list[dict] | None = None,
+               in_tokens: int = 0, cache_read: int = 0) -> dict:
+    content = []
+    if text:
+        content.append({"type": "text", "text": text})
+    for tu in (tool_uses or []):
+        content.append({"type": "tool_use", "id": f"toolu_{tu.get('name')}_{ts.microsecond}",
+                        "name": tu["name"], "input": tu.get("input", {})})
+    return {
+        "type": "assistant",
+        "timestamp": ts.isoformat(),
+        "message": {
+            "content": content,
+            "usage": {"input_tokens": in_tokens, "cache_read_input_tokens": cache_read,
+                      "output_tokens": 50},
+        },
+    }
+
+
+def build_fixture_root() -> Path:
+    """Create a synthetic projects dir with 3 controlled sessions."""
+    tmpdir = Path(tempfile.mkdtemp(prefix="analyze_usage_test_"))
+    base = tmpdir / "projects"
+    proj = base / "-tmp-fixture-project"
+    proj.mkdir(parents=True)
+
+    t0 = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+
+    # SESSION 1: Operator-Mono whale-ish (lots of bash, R=15 → Fish)
+    s1 = proj / "11111111-1111-1111-1111-111111111111.jsonl"
+    with s1.open("w") as f:
+        for i in range(15):
+            ts = t0 + timedelta(minutes=i * 5)
+            f.write(json.dumps(_user_text(ts, f"do task {i}")) + "\n")
+            for k in range(8):
+                ts2 = ts + timedelta(seconds=k * 10)
+                f.write(json.dumps(_assistant(
+                    ts2,
+                    tool_uses=[{"name": "Bash", "input": {"command": "git status"}}],
+                )) + "\n")
+
+    # SESSION 2: Constructor (Edit-heavy), commits with feat + fix
+    s2 = proj / "22222222-2222-2222-2222-222222222222.jsonl"
+    with s2.open("w") as f:
+        ts = t0 + timedelta(hours=1)
+        f.write(json.dumps(_user_text(ts, "build me a feature")) + "\n")
+        for k in range(10):
+            f.write(json.dumps(_assistant(
+                ts + timedelta(seconds=k),
+                tool_uses=[{"name": "Write",
+                            "input": {"file_path": "/tmp/fix/api/svc.rs",
+                                      "content": "pub fn x() {\n    1\n}\n"}}],
+            )) + "\n")
+        # commit feat
+        f.write(json.dumps(_assistant(
+            ts + timedelta(seconds=20),
+            tool_uses=[{"name": "Bash", "input": {"command": "git commit -m 'feat: add svc'"}}],
+        )) + "\n")
+        # commit fix prod
+        f.write(json.dumps(_assistant(
+            ts + timedelta(seconds=30),
+            tool_uses=[{"name": "Bash", "input": {"command": "git commit -m 'fix: null pointer'"}}],
+        )) + "\n")
+        # commit fix review
+        f.write(json.dumps(_assistant(
+            ts + timedelta(seconds=40),
+            tool_uses=[{"name": "Bash",
+                        "input": {"command": "git commit -m 'fix: address review comments'"}}],
+        )) + "\n")
+        # push
+        f.write(json.dumps(_assistant(
+            ts + timedelta(seconds=50),
+            tool_uses=[{"name": "Bash", "input": {"command": "git push origin feat/x"}}],
+        )) + "\n")
+
+    # SESSION 3: ghost (R=0)
+    s3 = proj / "33333333-3333-3333-3333-333333333333.jsonl"
+    with s3.open("w") as f:
+        f.write(json.dumps({"type": "file-history-snapshot", "timestamp": t0.isoformat()}) + "\n")
+
+    return tmpdir
+
+
+def run_extractors(fixture_root: Path, outputs_dir: Path) -> None:
+    """Set CLAUDE_PROJECTS_ROOT env var so extractors find the fixture."""
+    import os
+    import importlib
+    os.environ["CLAUDE_PROJECTS_ROOT"] = str(fixture_root / "projects")
+    sys.path.insert(0, str(_SKILL / "scripts"))
+    for name in [
+        "extract_biome", "extract_archetype", "extract_outputs",
+        "extract_compacts", "extract_growth", "extract_subagents",
+        "extract_gaps", "extract_burst_classes", "extract_parallelism",
+        "extract_topics",
+    ]:
+        if name in sys.modules:
+            del sys.modules[name]
+        mod = importlib.import_module(name)
+        rc = mod.main(["--outputs", str(outputs_dir)])
+        if rc != 0:
+            raise AssertionError(f"{name} returned {rc}")
+
+
+def assert_parquet(path: Path, expected_cols: set[str], min_rows: int = 1) -> None:
+    if not path.exists():
+        raise AssertionError(f"{path} not created")
+    table = pq.read_table(path)
+    rows = table.num_rows
+    if rows < min_rows:
+        raise AssertionError(f"{path} has {rows} rows, expected ≥{min_rows}")
+    cols = set(table.column_names)
+    missing = expected_cols - cols
+    if missing:
+        raise AssertionError(f"{path} missing columns: {missing}")
+
+
+def test_full_pipeline_smoke():
+    fixture = build_fixture_root()
+    try:
+        out = fixture / "outputs"
+        run_extractors(fixture, out)
+        # All raw parquets exist with sensible schema
+        assert_parquet(out / "raw" / "biome.parquet", {"sid", "biome", "real_prompts"})
+        assert_parquet(out / "raw" / "archetype.parquet", {"sid", "archetype", "rhythm"})
+        assert_parquet(out / "raw" / "outputs.parquet",
+                       {"sid", "feat", "fix", "review_fix", "prod_fix", "lines_added"})
+        assert_parquet(out / "raw" / "compact_pattern.parquet", {"sid", "compacts"})
+        assert_parquet(out / "raw" / "growth.parquet", {"sid", "real_prompts", "n_bursts"})
+        # idle_gaps.parquet may be empty (no gaps in 1-hour fixture)
+        assert (out / "raw" / "idle_gaps.parquet").exists()
+        assert (out / "raw" / "burst_classes.parquet").exists()
+        assert (out / "raw" / "parallelism.parquet").exists()
+        assert (out / "raw" / "topic_signatures.parquet").exists()
+        assert (out / "raw" / "subagent_pyramid.parquet").exists()
+
+        # Anon mirrors
+        for f in (out / "raw").glob("*.parquet"):
+            anon = out / "anon" / f.name
+            assert anon.exists(), f"anon mirror missing for {f.name}"
+
+        # Specific value checks
+        biomes = pq.read_table(out / "raw" / "biome.parquet").to_pylist()
+        # session1 = R=15 → Fish; session2 R=1 → Plankton; session3 R=0 → Plankton (ghost)
+        sids_to_biome = {r["sid"][:8]: r["biome"] for r in biomes}
+        assert sids_to_biome.get("11111111") == "Fish", sids_to_biome
+        # session2 has only 1 prompt → Plankton
+        assert sids_to_biome.get("22222222") == "Plankton", sids_to_biome
+
+        outputs = pq.read_table(out / "raw" / "outputs.parquet").to_pylist()
+        s2 = next(r for r in outputs if r["sid"].startswith("22222222"))
+        assert s2["feat"] == 1, s2
+        assert s2["fix"] == 2, s2
+        assert s2["review_fix"] == 1, s2
+        assert s2["prod_fix"] == 1, s2
+        assert s2["pushes"] == 1, s2
+
+        archs = pq.read_table(out / "raw" / "archetype.parquet").to_pylist()
+        s1_arch = next(r for r in archs if r["sid"].startswith("11111111"))
+        assert s1_arch["archetype"] == "Operator", s1_arch
+        s2_arch = next(r for r in archs if r["sid"].startswith("22222222"))
+        # session2 has 10 Write + 4 Bash → Edit:Bash 71%:29% → Constructor (≥45% Edit)
+        assert s2_arch["archetype"] == "Constructor", s2_arch
+    finally:
+        shutil.rmtree(fixture, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in dict(globals()).items() if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  ✗ {fn.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            import traceback
+            traceback.print_exc()
+            print(f"  ✗ {fn.__name__}: {e}")
+    if failed:
+        raise SystemExit(f"{failed}/{len(fns)} failed")
+    print(f"\n  {len(fns)}/{len(fns)} passed")

--- a/.claude/skills/analyze-usage/tests/test_stats.py
+++ b/.claude/skills/analyze-usage/tests/test_stats.py
@@ -1,0 +1,110 @@
+"""Unit tests for lib/stats.py."""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from lib.stats import (
+    cv, gini, shannon_entropy, milestone_at, pearson, percentile, median,
+    power_law_fit, acceleration,
+)
+
+
+def test_cv_empty():
+    assert cv([]) == 0
+    assert cv([0, 0, 0]) == 0
+
+
+def test_cv_known():
+    # mean=10, std=0 → cv=0
+    assert cv([10, 10, 10]) == 0
+    # cv known: std/mean
+    xs = [1.0, 2.0, 3.0]
+    mean = 2.0
+    var = ((1-2)**2 + (2-2)**2 + (3-2)**2) / 3
+    expected = math.sqrt(var) / mean
+    assert abs(cv(xs) - expected) < 1e-6
+
+
+def test_gini_extremes():
+    # Equal → 0
+    assert gini([1, 1, 1, 1]) < 0.01
+    # All on one → near 1
+    assert gini([0, 0, 0, 100]) > 0.7
+
+
+def test_shannon_entropy():
+    assert shannon_entropy({}) == 0
+    # Equal 2-class: log2(2) = 1
+    assert abs(shannon_entropy({"a": 5, "b": 5}) - 1.0) < 1e-6
+    # Single class: 0
+    assert shannon_entropy({"a": 10}) == 0
+
+
+def test_milestone_at():
+    cum = [1, 5, 10, 15, 30]
+    assert milestone_at(cum, 10) == 3
+    assert milestone_at(cum, 30) == 5
+    assert milestone_at(cum, 100) is None
+    assert milestone_at([], 10) is None
+
+
+def test_pearson_perfect():
+    assert abs(pearson([1, 2, 3], [2, 4, 6]) - 1.0) < 1e-6
+    assert abs(pearson([1, 2, 3], [3, 2, 1]) + 1.0) < 1e-6
+
+
+def test_pearson_zero():
+    assert pearson([], []) == 0
+    assert pearson([1], [1]) == 0
+    assert pearson([1, 1, 1], [1, 2, 3]) == 0  # zero std
+
+
+def test_percentile():
+    xs = [1, 2, 3, 4, 5]
+    assert median(xs) == 3
+    assert percentile(xs, 0) == 1
+    assert percentile(xs, 100) == 5
+    assert abs(percentile(xs, 50) - 3) < 1e-6
+    assert percentile([], 50) == 0
+
+
+def test_power_law_fit_known():
+    # y = 2 * x^2 → log y = log2 + 2 log x → slope=2
+    xs = [1, 2, 3, 4, 5, 10, 20]
+    ys = [2 * x**2 for x in xs]
+    fit = power_law_fit(xs, ys)
+    assert abs(fit["slope"] - 2.0) < 0.01
+    assert fit["r"] > 0.99
+    assert fit["n"] == len(xs)
+
+
+def test_acceleration():
+    # Linear const slope → acceleration ~0
+    xs = [1, 2, 3, 4, 5, 6]
+    assert abs(acceleration(xs)) < 1e-6
+    # Accelerating (steeper second half): positive
+    xs2 = [1, 2, 3, 5, 8, 13]
+    assert acceleration(xs2) > 0
+    # Decelerating
+    xs3 = [1, 5, 10, 11, 11.5, 12]
+    assert acceleration(xs3) < 0
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in dict(globals()).items() if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  ✗ {fn.__name__}: {e}")
+    if failed:
+        raise SystemExit(f"{failed}/{len(fns)} failed")
+    print(f"\n  {len(fns)}/{len(fns)} passed")

--- a/README.md
+++ b/README.md
@@ -37,33 +37,43 @@ devboy skills upgrade                       # refresh every installed skill afte
 | `self-bootstrap` | `devboy-setup`, `devboy-repair`, `devboy-tools-catalog` |
 | `issue-tracking` | `devboy-get-issues`, `devboy-create-issue`, `devboy-update-issue`, `devboy-link-issues`, `devboy-solve-issue` |
 | `code-review` | `devboy-review-mr`, `devboy-fix-review-comments`, `devboy-self-review` |
-| `self-feedback` | `devboy-run-and-verify`, `devboy-daily-report`, `devboy-retro`, `devboy-knowledge-extract` |
+| `self-feedback` | `devboy-run-and-verify`, `devboy-daily-report`, `devboy-retro`, `devboy-knowledge-extract`, `analyze-usage` |
 | `meeting-notes` | `devboy-meeting-search`, `devboy-meeting-transcript`, `devboy-meeting-to-tasks` |
 | `messenger` | `devboy-chat-search`, `devboy-chat-summary`, `devboy-notify` |
 
 The design lives in `docs/architecture/adr/ADR-012-skills-subsystem.md`; the user guide is at `docs/guide/skills/`. Skill installs keep a per-location manifest with SHA256s so upgrades leave user-modified files alone (ADR-014), and the self-feedback category reads session traces written to `.devboy/sessions/` in the format defined by ADR-015.
 
-### Repo-local Claude skill: `analyze-usage`
+### Featured skill: `analyze-usage` (split: thin baseline + fat backend)
 
-In addition to the shipped catalogue above, this repository ships a **repo-local Claude Code skill** at [`.claude/skills/analyze-usage/`](./.claude/skills/analyze-usage/). It is **not** part of the baseline catalogue (it doesn't install via `devboy skills install`); it lives only here, for analysing your local `~/.claude/projects/*.jsonl` traces.
+`analyze-usage` is the first skill that ships in **two parts**:
+
+1. **Thin baseline** at [`skills/03-self-feedback/analyze-usage/SKILL.md`](./skills/03-self-feedback/analyze-usage/SKILL.md) — installs through the standard catalogue (`devboy skills install analyze-usage`). Single markdown file, embedded in the binary. Tells the agent *what* to do.
+2. **Fat backend** at [`./.claude/skills/analyze-usage/`](./.claude/skills/analyze-usage/) — Python pipeline (`bin/analyze-usage`, `lib/`, `scripts/`, parquet outputs). The agent fetches it on first use via curl-pipe-bash, no full clone:
+
+   ```bash
+   curl -sSL https://raw.githubusercontent.com/meteora-pro/devboy-tools/main/.claude/skills/analyze-usage/scripts/install.sh | bash
+   ```
+
+This pattern keeps the `devboy` binary small (no embedded Python code), lets the backend evolve independently of the binary release cadence, and still gives users a one-command install via the standard catalogue:
 
 ```bash
-# Run from the repo root, no extra install needed:
-.claude/skills/analyze-usage/bin/analyze-usage period \
-    --from 2026-04-01 --to 2026-04-30 --format html --open
-
-# Or add to PATH for system-wide use:
-export PATH="$PWD/.claude/skills/analyze-usage/bin:$PATH"
-analyze-usage --help
+devboy skills install analyze-usage --agent claude   # baseline
+# (the SKILL.md instructs the agent to curl-install the backend on first run)
 ```
 
-It produces a graphic monthly/weekly digest (terminal / markdown / html) with biome aquariums, archetype bars, DORA radar, friction markers; plus per-session parquet bundles for further analysis.
+Once installed, the skill auto-activates on triggers like *"weekly digest"*, *"DORA"*, *"когда сессия стала китом"*, *"drill into session 2c052d83"*. Or run the CLI directly:
 
-- Full readme: [`./.claude/skills/analyze-usage/README.md`](./.claude/skills/analyze-usage/README.md)
-- Glossary of concepts (biome, archetype, rhythm, stack, DORA, friction, …): [`./.claude/skills/analyze-usage/GLOSSARY.md`](./.claude/skills/analyze-usage/GLOSSARY.md)
+```bash
+~/.claude/skills/analyze-usage/bin/analyze-usage period \
+    --from 2026-04-01 --to 2026-04-30 --format html --open
+```
+
+It produces a graphic monthly/weekly digest (terminal / markdown / html) with biome aquariums (🐋🦈🐬🐟🦐🦠), 8-archetype bars, rhythm, stack palette, DORA radar (CFR + lead time + pushes), friction markers; plus per-session parquet bundles (`outputs/raw/`, `outputs/anon/`, `outputs/llm/`) for further analysis.
+
+- Backend readme: [`./.claude/skills/analyze-usage/README.md`](./.claude/skills/analyze-usage/README.md)
+- Concept glossary (biome, archetype, rhythm, stack, DORA, friction, scaling laws): [`./.claude/skills/analyze-usage/GLOSSARY.md`](./.claude/skills/analyze-usage/GLOSSARY.md)
 - Architecture reference (extractors, library API, anonymization contract): [`./.claude/skills/analyze-usage/SKILL.md`](./.claude/skills/analyze-usage/SKILL.md)
-
-When you use Claude Code inside this repo, the skill auto-activates on triggers like *"weekly digest"*, *"DORA"*, *"когда сессия стала китом"*, *"drill into session 2c052d83"*. Use the standalone CLI when you want a report without the agent.
+- Baseline skill (what `devboy skills install` ships): [`./skills/03-self-feedback/analyze-usage/SKILL.md`](./skills/03-self-feedback/analyze-usage/SKILL.md)
 
 ## Why DevBoy?
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,28 @@ devboy skills upgrade                       # refresh every installed skill afte
 
 The design lives in `docs/architecture/adr/ADR-012-skills-subsystem.md`; the user guide is at `docs/guide/skills/`. Skill installs keep a per-location manifest with SHA256s so upgrades leave user-modified files alone (ADR-014), and the self-feedback category reads session traces written to `.devboy/sessions/` in the format defined by ADR-015.
 
+### Repo-local Claude skill: `analyze-usage`
+
+In addition to the shipped catalogue above, this repository ships a **repo-local Claude Code skill** at [`.claude/skills/analyze-usage/`](./.claude/skills/analyze-usage/). It is **not** part of the baseline catalogue (it doesn't install via `devboy skills install`); it lives only here, for analysing your local `~/.claude/projects/*.jsonl` traces.
+
+```bash
+# Run from the repo root, no extra install needed:
+.claude/skills/analyze-usage/bin/analyze-usage period \
+    --from 2026-04-01 --to 2026-04-30 --format html --open
+
+# Or add to PATH for system-wide use:
+export PATH="$PWD/.claude/skills/analyze-usage/bin:$PATH"
+analyze-usage --help
+```
+
+It produces a graphic monthly/weekly digest (terminal / markdown / html) with biome aquariums, archetype bars, DORA radar, friction markers; plus per-session parquet bundles for further analysis.
+
+- Full readme: [`./.claude/skills/analyze-usage/README.md`](./.claude/skills/analyze-usage/README.md)
+- Glossary of concepts (biome, archetype, rhythm, stack, DORA, friction, …): [`./.claude/skills/analyze-usage/GLOSSARY.md`](./.claude/skills/analyze-usage/GLOSSARY.md)
+- Architecture reference (extractors, library API, anonymization contract): [`./.claude/skills/analyze-usage/SKILL.md`](./.claude/skills/analyze-usage/SKILL.md)
+
+When you use Claude Code inside this repo, the skill auto-activates on triggers like *"weekly digest"*, *"DORA"*, *"когда сессия стала китом"*, *"drill into session 2c052d83"*. Use the standalone CLI when you want a report without the agent.
+
 ## Why DevBoy?
 
 | | Others | DevBoy |

--- a/skills/03-self-feedback/analyze-usage/SKILL.md
+++ b/skills/03-self-feedback/analyze-usage/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: analyze-usage
+description: Graphic monthly/weekly digest of Claude Code session patterns — biome aquarium (whale/shark/dolphin/fish/shrimp/plankton), 8-class archetype, rhythm, stack palette, DORA radar (CFR + lead time + pushes), friction (compacts/pivots/subagents). Backend installs on first run via curl.
+category: self-feedback
+version: 1
+compatibility: devboy-tools >= 0.22
+activation:
+  - "weekly digest"
+  - "monthly report"
+  - "отчёт за неделю"
+  - "отчёт за месяц"
+  - "графический отчёт"
+  - "DORA"
+  - "CFR"
+  - "biome"
+  - "archetype"
+  - "когда сессия стала китом"
+  - "drill into session"
+tools:
+  - trace
+---
+
+# analyze-usage
+
+This is a **thin baseline skill** that delegates the heavy lifting to a
+sibling Python backend (`bin/analyze-usage` and `lib/`/`scripts/`)
+auto-installed on first use into `~/.claude/skills/analyze-usage/`. The
+backend reads `~/.claude/projects/*.jsonl` directly — there is nothing
+to push, post or upload.
+
+The output is a **graphic period digest** with metaphors:
+
+- 🌊 **Aquarium** of biomes: 🐋 Whale (R≥500) · 🦈 Shark (100-499) ·
+  🐬 Dolphin (30-99) · 🐟 Fish (10-29) · 🦐 Shrimp (3-9) · 🦠 Plankton (0-2)
+- 🎭 **8 archetypes** (Variant B 45/25 thresholds): 🏗 Constructor /
+  ⚙️ Operator / 🔬 Researcher / 🛠 Builder / 📝 Scholar / 🔍 Inspector /
+  🌐 Polymath / 💬 Discusser
+- 🎵 **Rhythm**: 🎼 Mono · 📊 Phased · 🎲 Mixed · 🌪 Chaos
+- 🎨 **Stack palette** (LOC by frontend/backend/infra/docs/config)
+- 🚀 **DORA radar**: pushes, PR/MR, feat, fix (review-fix vs prod-fix
+  split), True CFR with Elite/High/Medium/Low classification
+- ⚡ **Friction**: compacts · pivots · subagent spawns
+
+## When to use
+
+- *"Сделай отчёт за неделю / месяц / квартал"*
+- *"Какие у меня DORA метрики?"*, *"что с CFR?"*
+- *"Покажи биомы за апрель"*, *"когда сессия стала китом?"*
+- *"Drill into session 2c052d83"* — глубокий single-session breakdown
+- Quarterly review of how Claude Code time was actually spent
+
+## Procedure
+
+### 1. Ensure backend is installed
+
+The Python backend is **not** embedded in the `devboy` binary (it would
+bloat the release). Check whether it exists; if not, fetch it.
+
+```bash
+SKILL_DIR="$HOME/.claude/skills/analyze-usage"
+if [ ! -x "$SKILL_DIR/bin/analyze-usage" ]; then
+    echo "Installing analyze-usage backend (~1MB sparse checkout)..."
+    curl -sSL https://raw.githubusercontent.com/meteora-pro/devboy-tools/main/.claude/skills/analyze-usage/scripts/install.sh | bash
+fi
+```
+
+The installer does a `git sparse-checkout` of `.claude/skills/analyze-usage/`
+only — no full repo clone, no Cargo build. Requires `uv` for running
+Python (https://docs.astral.sh/uv/).
+
+The installer is idempotent: re-running it just refreshes to the latest
+`main` (or pin via `REF=v0.22.0 curl ... | bash`).
+
+### 2. Begin a trace for this report
+
+```bash
+result=$(devboy trace begin --skill analyze-usage)
+SESSION_DIR=$(echo "$result" | jq -r .session_dir)
+SESSION_ID=$(echo "$result" | jq -r .session_id)
+```
+
+This skill is traceable — `devboy-retro` will see when it ran and how
+long it took.
+
+### 3. Resolve the period
+
+Parse the user's intent into ISO dates and a granularity:
+
+| User says | `--from` | `--to` | `--period` |
+|-----------|----------|--------|------------|
+| "за прошлую неделю" / "last week" | Monday of previous ISO week | Sunday of previous ISO week | `weekly` |
+| "за этот месяц" / "this month" | 1st of current month | today | `monthly` |
+| "за апрель" / "April" | first day of April | last day of April | `monthly` |
+| "за квартал" / "Q1" / "за 3 месяца" | start month | end month | `both` |
+| explicit dates given | use them verbatim | | as requested |
+
+If the user did not specify a format, default to `text` for terminal
+output. Prefer `html` with `--open` when the user explicitly asks for a
+"graphic" / "красивый" / "в браузере" report.
+
+### 4. Run the period report
+
+```bash
+"$SKILL_DIR/bin/analyze-usage" period \
+    --from "$FROM" --to "$TO" --period "$PERIOD" \
+    --format "$FORMAT" \
+    ${OUT:+--out "$OUT"} \
+    ${OUT_DIR:+--out-dir "$OUT_DIR"} \
+    ${OPEN:+--open}
+```
+
+Available `--format` values:
+
+| Format     | Output destination                            |
+|------------|----------------------------------------------|
+| `text`     | stdout (default)                             |
+| `markdown` | use with `--out FILE.md` for Slack/GitHub    |
+| `html`     | use with `--out FILE.html` (or auto `/tmp/`) |
+| `all`      | writes `.txt`+`.md`+`.html` into `--out-dir` |
+
+For long quarters wallclock-heavy reports, prefer `--out-dir /tmp/<label>`
+and `--format all` so the user has all three artefacts at once.
+
+### 5. Drill-down on a specific session (if requested)
+
+If the user names a session ID prefix (e.g. *"посмотри сессию 2c052d83"*):
+
+```bash
+"$SKILL_DIR/bin/analyze-usage" session 2c052d83
+```
+
+Output: biome / archetype / rhythm / first 5 prompts / bash subcategory mix
++ subagent count.
+
+### 6. (Optional) Generate parquet bundles for further analysis
+
+Only if the user wants raw data for ad-hoc queries:
+
+```bash
+"$SKILL_DIR/bin/analyze-usage" pipeline --since 2026-04-01
+```
+
+This runs all 10 extractors sequentially (~4-5 minutes on a full
+corpus) and writes:
+
+- `outputs/raw/*.parquet`  — original UUIDs/paths/branches (owner-only)
+- `outputs/anon/*.parquet` — anonymized version, shareable
+- `outputs/llm/*.parquet`  — Tier 2 LLM-augmented (filled by the agent
+  in step 7)
+
+After regenerating, **always audit anon before sharing**:
+
+```bash
+"$SKILL_DIR/bin/analyze-usage" audit
+# exits 1 if any raw UUID / abs path / bash command / branch / mcp slug
+# leaks into anon parquet
+```
+
+### 7. Tier 2: LLM-augmented narratives (if the user wants them)
+
+Tier 1 (extractors) is pure stat — deterministic, anonymizable. Tier 2
+narratives require the agent itself to read the raw jsonl and write
+back a summary. The skill never calls an external LLM.
+
+To enqueue Whales/Sharks/Dolphins for narrative:
+
+```bash
+"$SKILL_DIR/bin/analyze-usage" llm-queue
+# writes outputs/llm/_queue.jsonl with one row per session
+```
+
+Then iterate the queue, read each session's jsonl, summarize (≤200
+words: name, phases, what was created, pivots, finale), and append rows
+to `outputs/llm/session_names.parquet`. The full schema is documented
+in `extract_llm_session_names.py`.
+
+### 8. End the trace
+
+```bash
+devboy trace end \
+    --session-dir "$SESSION_DIR" --session-id "$SESSION_ID" \
+    --skill analyze-usage \
+    --outcome "$OUTCOME" \
+    --summary "<period>: <N> sessions, <M> +LOC, CFR <X>"
+```
+
+## Success criteria
+
+- The user receives a digest in the requested format (default: terminal text).
+- Numbers reconcile: `+LOC = sum across sessions`, `True CFR = prod_fix /
+  feat`, biome counts add up to total session count.
+- HTML output renders standalone — no external CSS/JS, opens offline.
+- `audit` exits 0 after every `pipeline` regeneration before any sharing.
+- Tier 2 narratives, if requested, are appended (not overwriting) to
+  `outputs/llm/session_names.parquet`.
+
+## Guardrails
+
+- **Never share `outputs/raw/`** — it contains real UUIDs, file paths,
+  branch names, prompt tokens. Only `outputs/anon/` is shareable, and
+  only after `audit` passes.
+- **Tier 1 must remain deterministic.** If you find yourself wanting an
+  LLM call inside an `extract_*.py`, that's a Tier 2 feature — put it in
+  `extract_llm_*.py` instead.
+- **Don't write to `~/.claude/projects/`** — that's the source data,
+  read-only.
+- The backend is `uv run`-based. If `uv` is missing, the installer warns
+  but still copies the files; the user must install `uv` separately
+  (https://docs.astral.sh/uv/).
+
+## Non-goals
+
+- This skill does **not** post the report anywhere. Pipe output into
+  `devboy-notify` (category 5) if you need delivery.
+- It does **not** call external LLM APIs. Tier 2 enrichment runs
+  agent-side.
+- It does **not** modify session jsonls. Source data stays untouched.
+- It does **not** analyse long-term trends — that's `devboy-retro`.
+
+## Concepts reference
+
+A full glossary (biome thresholds, archetype rules, rhythm classifier,
+stack heuristics, bash subcategory regexes, DORA proxy formulas,
+scaling-law findings) lives next to the backend at
+`~/.claude/skills/analyze-usage/GLOSSARY.md` after install.
+
+The architecture (extractor list, library API, anonymization contract,
+extension guide for new metrics) is in
+`~/.claude/skills/analyze-usage/SKILL.md`.
+
+## Examples
+
+```bash
+# Quick weekly digest:
+analyze-usage period --from 2026-04-23 --to 2026-04-30 --period weekly
+
+# Quarter, all formats, open HTML in browser:
+analyze-usage period --from 2026-02-01 --to 2026-04-30 --period both \
+    --format all --out-dir /tmp/q1_2026 --open
+
+# Drill into one Whale:
+analyze-usage session 2c052d83
+
+# Generate parquet bundles + audit:
+analyze-usage pipeline --since 2026-04-01
+analyze-usage audit
+```


### PR DESCRIPTION
## Summary

Builds on the AU-01 scaffold (#215) and ships the **complete `analyze-usage` skill**:

- 10 Tier-1 extractors (biome / archetype / outputs / compacts / growth / subagents / gaps / topics / burst_classes / parallelism) emitting `outputs/raw/*.parquet` + `outputs/anon/*.parquet`
- 1 Tier-2 stub (`extract_llm_session_names.py`) — queues sessions for narrative summarisation by the agent into `outputs/llm/*.parquet`
- **Graphic period digest** (`period_report.py`) with metaphors — aquarium of biomes 🐋🦈🐬🐟🦐🦠, archetype bars (8 classes ⚙️🔬🌐🛠📝🔍🏗💬), rhythm, stack palette, DORA radar (CFR + lead time + pushes), friction (compacts/pivots/subagents). Four output formats: **terminal / markdown / html / all**, plus `--open` to auto-launch HTML in a browser
- **Standalone CLI** (`bin/analyze-usage`) with subcommands `period / pipeline / session / audit / patterns / report / test`
- **Anon audit** (`pattern_detector.py --audit-anon`) — recursive leak scanner over every anon parquet (raw UUIDs, abs paths, raw bash commands, raw branches, raw MCP slugs). Real outputs: 11 files scanned, 0 leaks
- **28 tests** (`tests/run_all.sh`): 11 classifier / 10 stats / 1 full extractor smoke on synthetic fixture / 6 audit-anon
- **Docs**: README (user quick-start) · GLOSSARY (every concept with code links) · SKILL.md (architecture) · root README section pointing to the skill

## How to use it

```bash
# repo-local (already cloned):
.claude/skills/analyze-usage/bin/analyze-usage period \
    --from 2026-04-01 --to 2026-04-30 --format html --open

# or without cloning the whole repo:
curl -sSL https://raw.githubusercontent.com/meteora-pro/devboy-tools/main/.claude/skills/analyze-usage/scripts/install.sh | bash
```

When Claude Code is active in this repo, the skill auto-activates on phrases like *"weekly digest"*, *"DORA"*, *"когда сессия стала китом"*, *"drill into session 2c052d83"*.

## Architecture

Three-tier outputs:

| Tier | Path | Reproducible offline? | Anonymizable? |
|------|------|----------------------|---------------|
| Tests | `tests/` | ✓ deterministic | n/a |
| 1 (stat) | `outputs/raw/` | ✓ | ✓ → `outputs/anon/` |
| 2 (LLM) | `outputs/llm/` | ✗ (needs agent) | partial |

Tier 1 stays deterministic (same input → same parquet). Tier 2 is enriched by the agent — `extract_llm_*.py` produces a queue, agent consumes & writes back.

## Test plan

- [ ] `bash .claude/skills/analyze-usage/tests/run_all.sh` — all 28 tests green
- [ ] `.claude/skills/analyze-usage/bin/analyze-usage period --from 2026-04-23 --to 2026-04-30 --period weekly --format all --out-dir /tmp/au-test` — produces `report.{txt,md,html}`
- [ ] `.claude/skills/analyze-usage/bin/analyze-usage pipeline` — generates 11 parquet pairs in `outputs/raw/` + `outputs/anon/` (~4–5 min on full corpus)
- [ ] `.claude/skills/analyze-usage/bin/analyze-usage audit` — exits 0 with "no leaks found"
- [ ] `CLAUDE_PROJECTS_ROOT=/tmp/foo .claude/skills/analyze-usage/bin/analyze-usage period --from 2026-01-01 --to 2026-12-31` — env override works
- [ ] `bash .claude/skills/analyze-usage/scripts/install.sh` (in a clean dir) — sparse-checkout installer fetches just the skill into `~/.claude/skills/analyze-usage/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)