### PR TITLE
release: 0.23.0 — analyze-usage skill + devboy onboard / agents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/meteora-pro/devboy-tools"


### PR DESCRIPTION
Bumps workspace version `0.22.0 → 0.23.0` and triggers the npm + GitHub release pipeline once tagged.

## Headline features

- **`devboy onboard` + `devboy agents list`** (#218, closes #217) — auto-detect the AI agent the user actively uses (Claude / Copilot / Codex / Kimi / Cursor / Gemini / Antigravity, cross-platform), pick a primary by recency × volume score, install a profile-specific skill bundle (`dev` / `pm` / `oncall`). ADR-017 documents the design.
- **`analyze-usage` skill** (#216, closes #215) — first two-part skill in the catalogue: thin Markdown baseline embedded in the binary + heavier Python backend (~1 MB, sparse-checked-out via curl on first use). Produces graphic monthly / weekly digests with biome aquariums, archetype bars, DORA radar, friction markers, plus shareable anonymised parquet bundles.

## Behind the scenes

- New `devboy-core::agents` module: `AgentDetector` trait, score formula with `pick_primary`, registry, fs helpers. **89 unit tests** on the agents stack; **codecov/patch ≥ 95%** on the patch.
- 232 unit tests pass workspace-wide.
- `RUSTFLAGS=-Dwarnings` enforced; workspace policy is `unsafe_code = "forbid"`. Cross-platform CI (macOS x86/ARM, Linux x86/ARM, Windows MSVC) green.

## Documentation

- Root README rewritten end-to-end (#219): research-driven framing, 60-second install path, four papers surfaced with per-paper headlines (avg 69% on `get_issues` per call, 3.3× p₁ on power-law data, Pearson r = −0.280 between thin context and follow-up enrichment).
- ADR-017 added to the index.

## What's *not* in this release

- Docs site rework (#220 / PR #221) — renders README at the site root, surfaces papers and ADRs in the sidebar, adds Slack integration page. Stacked PR open; lands in 0.23.1 or 0.24.
- Install targets for Copilot / Gemini / Antigravity inside `devboy_skills::Agent` — those agents detect cleanly but `onboard` prints the bundle plan and skips the write step.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p devboy-core --lib agents::` — 66 pass on macOS arm64
- [x] CI on the parent feature PRs green across all 14 checks
- [ ] After merge: tag `v0.23.0`, release pipeline produces 5 platform binaries + npm packages
- [ ] After tag: `npm install -g @devboy-tools/cli@0.23.0` resolves the right binary

## Tag command (after merge)

```bash
git checkout main && git pull
git tag -a v0.23.0 -m "0.23.0"
git push origin v0.23.0
```

Tag triggers `.github/workflows/release.yml` which builds the 5 platform binaries, fills in the `npm/` package versions automatically (`steps.version.outputs.value` from `${GITHUB_REF_NAME#v}`), and publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)