### PR TITLE
fix(jira): pass parent key into create_issue payload (closes #214)

### DIFF
--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -1704,7 +1704,7 @@ impl IssueProvider for JiraClient {
                 priority,
                 assignee,
                 components,
-                parent: input.parent.map(|key| ProjectKey { key }),
+                parent: input.parent.map(|key| crate::types::IssueKeyRef { key }),
             },
         };
 

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -1704,6 +1704,7 @@ impl IssueProvider for JiraClient {
                 priority,
                 assignee,
                 components,
+                parent: input.parent.map(|key| ProjectKey { key }),
             },
         };
 
@@ -4095,6 +4096,98 @@ mod tests {
             assert_eq!(issue.key, "jira#PROJ-11");
         }
 
+        /// Issue #214 — sub-task creation requires `fields.parent.key`
+        /// in the payload; the API returns 400 otherwise. The
+        /// `CreateIssueInput.parent` field must round-trip into the body.
+        #[tokio::test]
+        async fn test_create_issue_subtask_includes_parent_in_payload() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(POST).path("/issue").is_true(|req| {
+                    let body = String::from_utf8_lossy(req.body().as_ref());
+                    body.contains("\"parent\":{\"key\":\"PROJ-1\"}")
+                        && body.contains("\"name\":\"Sub-task\"")
+                });
+                then.status(201).json_body(serde_json::json!({
+                    "id": "10010",
+                    "key": "PROJ-10"
+                }));
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/issue/PROJ-10");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "10010",
+                    "key": "PROJ-10",
+                    "fields": {
+                        "summary": "Sub task work",
+                        "status": {"name": "Open"},
+                        "labels": [],
+                        "created": "2024-01-06T10:00:00.000+0000"
+                    }
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let issue = client
+                .create_issue(CreateIssueInput {
+                    title: "Sub task work".to_string(),
+                    issue_type: Some("Sub-task".to_string()),
+                    parent: Some("PROJ-1".to_string()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+
+            assert_eq!(issue.key, "jira#PROJ-10");
+        }
+
+        /// Without a parent, the body must not include `"parent"` — Jira
+        /// rejects empty `parent` objects, and we don't want to emit a
+        /// dangling field for non-sub-task issue types.
+        #[tokio::test]
+        async fn test_create_issue_without_parent_omits_field() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(POST).path("/issue").is_true(|req| {
+                    let body = String::from_utf8_lossy(req.body().as_ref());
+                    !body.contains("\"parent\"")
+                });
+                then.status(201).json_body(serde_json::json!({
+                    "id": "10011",
+                    "key": "PROJ-11"
+                }));
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/issue/PROJ-11");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "10011",
+                    "key": "PROJ-11",
+                    "fields": {
+                        "summary": "Plain task",
+                        "status": {"name": "Open"},
+                        "labels": [],
+                        "created": "2024-01-06T10:00:00.000+0000"
+                    }
+                }));
+            });
+
+            let client = create_self_hosted_client(&server);
+            let issue = client
+                .create_issue(CreateIssueInput {
+                    title: "Plain task".to_string(),
+                    parent: None,
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+
+            assert_eq!(issue.key, "jira#PROJ-11");
+        }
+
         /// Issue #197 — update_issue with components replaces them.
         /// `Some(vec![])` clears; `None` does not touch (handled upstream).
         #[tokio::test]
@@ -5089,6 +5182,7 @@ mod tests {
                     priority: None,
                     assignee: None,
                     components: None,
+                    parent: None,
                 },
             };
 
@@ -5118,6 +5212,7 @@ mod tests {
                     priority: None,
                     assignee: None,
                     components: None,
+                    parent: None,
                 },
             };
 
@@ -5143,6 +5238,7 @@ mod tests {
                     priority: None,
                     assignee: None,
                     components: None,
+                    parent: None,
                 },
             };
 

--- a/crates/plugins/api/jira/src/types.rs
+++ b/crates/plugins/api/jira/src/types.rs
@@ -291,8 +291,10 @@ pub struct CreateIssueFields {
     /// sub-task or any "is_subtask" hierarchical type — the API rejects
     /// the request with a 400 otherwise (issue #214). Serialised as
     /// `{ "key": "PROJ-1" }`, matching Jira's `fields.parent` shape.
+    /// Uses [`IssueKeyRef`] (not [`ProjectKey`]) because the value is an
+    /// **issue** key (e.g. `PROJ-1`), not a project key (e.g. `PROJ`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parent: Option<ProjectKey>,
+    pub parent: Option<IssueKeyRef>,
 }
 
 /// Component reference used in create/update issue payloads (issue #197).

--- a/crates/plugins/api/jira/src/types.rs
+++ b/crates/plugins/api/jira/src/types.rs
@@ -287,6 +287,12 @@ pub struct CreateIssueFields {
     /// Components (issue #197).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub components: Option<Vec<ComponentRef>>,
+    /// Parent issue reference. Required by Jira when `issuetype` is a
+    /// sub-task or any "is_subtask" hierarchical type — the API rejects
+    /// the request with a 400 otherwise (issue #214). Serialised as
+    /// `{ "key": "PROJ-1" }`, matching Jira's `fields.parent` shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<ProjectKey>,
 }
 
 /// Component reference used in create/update issue payloads (issue #197).


### PR DESCRIPTION
## Summary

Closes #214. Sub-task creation in Jira required `fields.parent.key` in the payload; without it the API returned 400 with "Issue type is a sub-task but parent issue key or id not specified".

The MCP `create_issue` tool already accepted a `parent` argument (with `parentId` alias) and the executor forwarded it into `CreateIssueInput.parent` in the core trait — but the Jira-side `CreateIssueFields` struct had no `parent` field, so the value was silently dropped before serialisation.

## Fix

- `crates/plugins/api/jira/src/types.rs` — add `parent: Option<ProjectKey>` to `CreateIssueFields` (`skip_serializing_if = None`, serialises as `{ "key": "PROJ-1" }`).
- `crates/plugins/api/jira/src/client.rs:1693` — populate it from `input.parent`.
- 3 pre-existing test fixtures that construct `CreateIssueFields` directly now also pass `parent: None`.

## Test plan

- [x] New `test_create_issue_subtask_includes_parent_in_payload` — body contains `"parent":{"key":"PROJ-1"}` when issue_type=Sub-task and parent=Some("PROJ-1").
- [x] New `test_create_issue_without_parent_omits_field` — regular task creation does NOT emit `"parent"` (no stray empty field for non-sub-task cases).
- [x] 6 pre-existing create_issue tests still pass.
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features`, full `cargo test --workspace` — green.

## Out of scope (follow-up)

- The Jira metadata enricher (`crates/plugins/api/jira/src/metadata.rs:217`) explicitly **filters sub-task types out** of the `issuetype` enum surfaced to the agent (`.filter(|t| !t.subtask)`). After this fix, sub-task creation works once the agent supplies the right `issueType` string — but the schema still doesn't advertise sub-task types as valid choices. Worth a separate PR.
- Tool-layer pre-validation: when `issue_type` matches a known sub-task type and `parent` is `None`, return a clearer error before hitting Jira (instead of forwarding the API 400). Not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)