### PR TITLE
feat(security): wrap every secret in SecretString end-to-end (#225)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,41 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  secrets-discipline:
+    name: Secrets discipline
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Guard against secrets sneaking back in as plain `String`.
+      # Every credential in non-test source under `crates/` must be carried
+      # as `secrecy::SecretString` (or a wrapper that redacts on `Debug` and
+      # zeroizes on drop) — see ADR-019. Tests are exempt because their
+      # fixtures pre-wrap literals at the field boundary.
+      #
+      # The CLI binary `crates/devboy-cli/src/main.rs` is also exempt
+      # because clap value parsers operate on `String` at the user-input
+      # boundary; that string is wrapped in `SecretString` immediately on
+      # use and never persisted back as a plaintext field.
+      - name: Forbid plain String for known secret field names
+        run: |
+          set -euo pipefail
+          # Field names that must never be `String` / `Option<String>`.
+          PATTERN='(\b(token|api_key|password|secret|client_secret|access_token|refresh_token|bearer_token)\b)\s*:\s*(Option<)?\s*String'
+          if grep -RInE \
+                --include='*.rs' \
+                --exclude-dir=target \
+                --exclude-dir=tests \
+                --exclude='*test*.rs' \
+                --exclude='main.rs' \
+                "$PATTERN" crates/ \
+              | grep -v '^[^:]*:[0-9]*: *//' \
+              | tee /tmp/leaks.txt; then
+            if [ -s /tmp/leaks.txt ]; then
+              echo "::error::Plain String secrets detected. Wrap them in secrecy::SecretString (see ADR-019)."
+              exit 1
+            fi
+          fi
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,19 @@ jobs:
           set -euo pipefail
           # Field names that must never be `String` / `Option<String>`.
           PATTERN='(\b(token|api_key|password|secret|client_secret|access_token|refresh_token|bearer_token)\b)\s*:\s*(Option<)?\s*String'
+          # Path-level exemption: `crates/devboy-cli/src/main.rs` (CLI input
+          # boundary; see header comment). A blanket `--exclude='main.rs'`
+          # would also exempt other binaries (e.g. `crates/llm-eval/src/main.rs`)
+          # — undesired. Filter the exact path post-grep instead.
+          CLI_MAIN='crates/devboy-cli/src/main.rs'
           if grep -RInE \
                 --include='*.rs' \
                 --exclude-dir=target \
                 --exclude-dir=tests \
                 --exclude='*test*.rs' \
-                --exclude='main.rs' \
                 "$PATTERN" crates/ \
               | grep -v '^[^:]*:[0-9]*: *//' \
+              | grep -v "^${CLI_MAIN}:" \
               | tee /tmp/leaks.txt; then
             if [ -s /tmp/leaks.txt ]; then
               echo "::error::Plain String secrets detected. Wrap them in secrecy::SecretString (see ADR-019)."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,9 @@ sha2 = "0.10"
 sentry = { version = "0.35", default-features = false, features = ["rustls", "reqwest", "tracing", "panic", "backtrace", "contexts"] }
 sentry-tracing = "0.35"
 
+# Secrets (in-process secret protection: redacted Debug, zeroize on drop)
+secrecy = { version = "0.10", features = ["serde"] }
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/crates/devboy-cli/Cargo.toml
+++ b/crates/devboy-cli/Cargo.toml
@@ -48,6 +48,7 @@ dirs.workspace = true
 flate2 = "1.1"
 tar = "0.4"
 zip = "8.4"
+secrecy.workspace = true
 sentry = { workspace = true, optional = true }
 sentry-tracing = { workspace = true, optional = true }
 

--- a/crates/devboy-cli/src/doctor/checks/credentials.rs
+++ b/crates/devboy-cli/src/doctor/checks/credentials.rs
@@ -4,6 +4,7 @@ use crate::doctor::checks::{
 use crate::doctor::{CheckResult, CheckStatus, DiagnosticCheck, DiagnosticContext};
 use async_trait::async_trait;
 use devboy_core::ContextConfig;
+use secrecy::ExposeSecret;
 use serde_json::json;
 
 pub struct GitHubTokenCheck;
@@ -53,7 +54,7 @@ impl CredentialSpec {
 
         match resolve_secret(ctx, Some(&active.name), self.provider) {
             Ok(Some(secret)) => {
-                let format = (self.validator)(&secret.value);
+                let format = (self.validator)(secret.value.expose_secret());
                 let status = match format {
                     TokenFormat::Recognized => CheckStatus::Pass,
                     TokenFormat::Suspicious(_) => CheckStatus::Warning,
@@ -444,6 +445,7 @@ mod tests {
         JiraConfig,
     };
     use devboy_storage::{CredentialStore, MemoryStore};
+    use secrecy::SecretString;
     use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -452,11 +454,11 @@ mod tests {
     struct FailingStore;
 
     impl CredentialStore for FailingStore {
-        fn store(&self, _key: &str, _value: &str) -> devboy_core::Result<()> {
+        fn store(&self, _key: &str, _value: &SecretString) -> devboy_core::Result<()> {
             Err(Error::Storage("store failed".to_string()))
         }
 
-        fn get(&self, _key: &str) -> devboy_core::Result<Option<String>> {
+        fn get(&self, _key: &str) -> devboy_core::Result<Option<SecretString>> {
             Err(Error::Storage("credential backend unavailable".to_string()))
         }
 

--- a/crates/devboy-cli/src/doctor/checks/environment.rs
+++ b/crates/devboy-cli/src/doctor/checks/environment.rs
@@ -159,6 +159,7 @@ mod tests {
     use super::*;
     use devboy_core::{Config, Error};
     use devboy_storage::{CredentialStore, MemoryStore};
+    use secrecy::SecretString;
     use std::path::PathBuf;
     use std::sync::Arc;
 
@@ -166,11 +167,11 @@ mod tests {
     struct FailingStore;
 
     impl CredentialStore for FailingStore {
-        fn store(&self, _key: &str, _value: &str) -> devboy_core::Result<()> {
+        fn store(&self, _key: &str, _value: &SecretString) -> devboy_core::Result<()> {
             Err(Error::Storage("store failed".to_string()))
         }
 
-        fn get(&self, _key: &str) -> devboy_core::Result<Option<String>> {
+        fn get(&self, _key: &str) -> devboy_core::Result<Option<SecretString>> {
             Err(Error::Storage("store unavailable".to_string()))
         }
 

--- a/crates/devboy-cli/src/doctor/checks/mod.rs
+++ b/crates/devboy-cli/src/doctor/checks/mod.rs
@@ -7,6 +7,7 @@ pub mod proxy;
 
 use crate::doctor::DiagnosticContext;
 use devboy_core::{Config, ContextConfig};
+use secrecy::SecretString;
 
 pub(super) const DEFAULT_CONTEXT_NAME: &str = Config::DEFAULT_CONTEXT_NAME;
 
@@ -20,7 +21,7 @@ pub(super) struct ActiveProviderContext {
 pub(super) struct ResolvedSecret {
     pub key: String,
     pub source: &'static str,
-    pub value: String,
+    pub value: SecretString,
 }
 
 pub(super) fn resolve_active_provider_context(config: &Config) -> Option<ActiveProviderContext> {
@@ -82,6 +83,7 @@ mod tests {
     use super::*;
     use devboy_core::{Config, ContextConfig, Error, GitHubConfig};
     use devboy_storage::{CredentialStore, MemoryStore};
+    use secrecy::ExposeSecret;
     use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -90,11 +92,11 @@ mod tests {
     struct FailingStore;
 
     impl CredentialStore for FailingStore {
-        fn store(&self, _key: &str, _value: &str) -> devboy_core::Result<()> {
+        fn store(&self, _key: &str, _value: &SecretString) -> devboy_core::Result<()> {
             Err(Error::Storage("store failed".to_string()))
         }
 
-        fn get(&self, _key: &str) -> devboy_core::Result<Option<String>> {
+        fn get(&self, _key: &str) -> devboy_core::Result<Option<SecretString>> {
             Err(Error::Storage("secret backend unavailable".to_string()))
         }
 
@@ -167,7 +169,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(context_secret.source, "context");
-        assert_eq!(context_secret.value, "context-secret");
+        assert_eq!(context_secret.value.expose_secret(), "context-secret");
 
         let global_ctx = context_with_store(
             Arc::new(MemoryStore::with_credentials([(
@@ -212,11 +214,11 @@ mod tests {
         }
 
         impl CredentialStore for ScopedFailingStore {
-            fn store(&self, key: &str, value: &str) -> devboy_core::Result<()> {
+            fn store(&self, key: &str, value: &SecretString) -> devboy_core::Result<()> {
                 self.inner.store(key, value)
             }
 
-            fn get(&self, key: &str) -> devboy_core::Result<Option<String>> {
+            fn get(&self, key: &str) -> devboy_core::Result<Option<SecretString>> {
                 if key.starts_with("contexts.") {
                     Err(Error::Storage("scoped key backend unavailable".to_string()))
                 } else {
@@ -244,7 +246,7 @@ mod tests {
             .unwrap();
         assert_eq!(resolved.source, "global");
         assert_eq!(resolved.key, "github.token");
-        assert_eq!(resolved.value, "ghp_from_env_var_fallback");
+        assert_eq!(resolved.value.expose_secret(), "ghp_from_env_var_fallback");
     }
 
     #[test]
@@ -257,11 +259,11 @@ mod tests {
         struct ScopedOnlyFails;
 
         impl CredentialStore for ScopedOnlyFails {
-            fn store(&self, _key: &str, _value: &str) -> devboy_core::Result<()> {
+            fn store(&self, _key: &str, _value: &SecretString) -> devboy_core::Result<()> {
                 Err(Error::Storage("store failed".into()))
             }
 
-            fn get(&self, key: &str) -> devboy_core::Result<Option<String>> {
+            fn get(&self, key: &str) -> devboy_core::Result<Option<SecretString>> {
                 if key.starts_with("contexts.") {
                     Err(Error::Storage("keychain unavailable".into()))
                 } else {

--- a/crates/devboy-cli/src/doctor/checks/providers.rs
+++ b/crates/devboy-cli/src/doctor/checks/providers.rs
@@ -7,6 +7,7 @@ use devboy_core::{
 };
 use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderMap, USER_AGENT};
 use reqwest::{Client, Method};
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use std::time::Duration;
@@ -432,8 +433,8 @@ async fn slack_connectivity(
     config: &SlackConfig,
     token: &str,
 ) -> Result<ConnectivityOutcome, String> {
-    let mut client =
-        devboy_slack::SlackClient::new(token).with_required_scopes(config.required_scopes.clone());
+    let mut client = devboy_slack::SlackClient::new(SecretString::from(token.to_string()))
+        .with_required_scopes(config.required_scopes.clone());
     if let Some(base_url) = &config.base_url {
         client = client.with_base_url(base_url);
     }
@@ -625,7 +626,7 @@ where
         }
     };
 
-    match connect(&provider_config, &secret.value).await {
+    match connect(&provider_config, secret.value.expose_secret()).await {
         Ok(outcome) => {
             let details = ctx.verbose.then(|| {
                 connectivity_details(provider, &active.name, &secret.key, secret.source, &outcome)
@@ -831,6 +832,7 @@ mod tests {
     use httpmock::Method::GET;
     use httpmock::MockServer;
     use reqwest::header::HeaderValue;
+    use secrecy::SecretString;
     use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -839,11 +841,11 @@ mod tests {
     struct FailingStore;
 
     impl CredentialStore for FailingStore {
-        fn store(&self, _key: &str, _value: &str) -> devboy_core::Result<()> {
+        fn store(&self, _key: &str, _value: &SecretString) -> devboy_core::Result<()> {
             Err(Error::Storage("store failed".to_string()))
         }
 
-        fn get(&self, _key: &str) -> devboy_core::Result<Option<String>> {
+        fn get(&self, _key: &str) -> devboy_core::Result<Option<SecretString>> {
             Err(Error::Storage("provider store unavailable".to_string()))
         }
 

--- a/crates/devboy-cli/src/doctor/checks/proxy.rs
+++ b/crates/devboy-cli/src/doctor/checks/proxy.rs
@@ -226,7 +226,7 @@ async fn probe_proxy_server(
     };
 
     let started = Instant::now();
-    let token_value = token.as_ref().map(|(_, value)| value.as_str());
+    let token_value = token.as_ref().map(|(_, value)| value);
     let mut client = match McpProxyClient::connect(
         &proxy.name,
         &proxy.url,
@@ -330,6 +330,7 @@ mod tests {
     use devboy_storage::{CredentialStore, MemoryStore};
     use httpmock::Method::POST;
     use httpmock::MockServer;
+    use secrecy::SecretString;
     use std::path::PathBuf;
     use std::sync::Arc;
 
@@ -337,11 +338,11 @@ mod tests {
     struct FailingStore;
 
     impl CredentialStore for FailingStore {
-        fn store(&self, _key: &str, _value: &str) -> devboy_core::Result<()> {
+        fn store(&self, _key: &str, _value: &SecretString) -> devboy_core::Result<()> {
             Err(Error::Storage("store failed".to_string()))
         }
 
-        fn get(&self, _key: &str) -> devboy_core::Result<Option<String>> {
+        fn get(&self, _key: &str) -> devboy_core::Result<Option<SecretString>> {
             Err(Error::Storage("proxy store unavailable".to_string()))
         }
 

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -36,6 +36,7 @@ use devboy_slack::SlackClient;
 use devboy_storage::{ChainStore, CredentialStore, wrap_with_cache};
 use dialoguer::{Confirm, Input, MultiSelect, Password};
 use doctor::{DoctorOptions, OutputFormat};
+use secrecy::{ExposeSecret, SecretString};
 use tracing_subscriber::EnvFilter;
 #[cfg(feature = "sentry")]
 use tracing_subscriber::prelude::*;
@@ -1285,8 +1286,9 @@ async fn handle_init_command(
     if !options.tokens.is_empty() {
         let store = get_credential_store_for_init();
         for (key, value) in &options.tokens {
+            let secret = SecretString::from(value.clone());
             store
-                .store(key, value)
+                .store(key, &secret)
                 .with_context(|| format!("Failed to store {} in keychain", key))?;
             println!("Stored {} in keychain", key);
         }
@@ -2244,8 +2246,9 @@ fn handle_config_command(command: ConfigCommands) -> Result<()> {
 
         ConfigCommands::SetSecret { key, value } => {
             let store = get_credential_store();
+            let secret = SecretString::from(value);
             store
-                .store(&key, &value)
+                .store(&key, &secret)
                 .context("Failed to store secret")?;
             println!("Secret {} stored in keychain", key);
         }
@@ -2286,7 +2289,7 @@ fn handle_config_command(command: ConfigCommands) -> Result<()> {
             // Then try keychain (supports arbitrary key formats like "proxy.name.field")
             let store = get_credential_store();
             if let Some(value) = store.get(&key).ok().flatten() {
-                println!("{} (from keychain)", mask_secret(&value));
+                println!("{} (from keychain)", mask_secret(value.expose_secret()));
                 return Ok(());
             }
 
@@ -2967,8 +2970,11 @@ async fn handle_mcp_command(no_config: bool) -> Result<()> {
 
         tokio::spawn(async move {
             // 1. Fetch and merge remote config
-            let merged_config =
-                devboy_core::remote_config::fetch_and_merge(bg_config, bg_token.as_deref()).await;
+            let merged_config = devboy_core::remote_config::fetch_and_merge(
+                bg_config,
+                bg_token.as_ref().map(|s| s.expose_secret()),
+            )
+            .await;
 
             // 2. Re-initialize Sentry if remote config provided a DSN
             #[cfg(feature = "sentry")]
@@ -3418,8 +3424,9 @@ fn handle_proxy_add(
     if let Some(token_value) = token {
         let key = final_token_key.as_ref().unwrap();
         let store = get_credential_store_for_init();
+        let secret = SecretString::from(token_value);
         store
-            .store(key, &token_value)
+            .store(key, &secret)
             .with_context(|| format!("Failed to store token in keychain as '{}'", key))?;
         println!("Stored token in keychain as '{}'", key);
     }
@@ -3475,7 +3482,7 @@ async fn build_proxy_manager(config: &Config, store: &dyn CredentialStore) -> Pr
             &proxy_cfg.name,
             &url,
             proxy_cfg.tool_prefix.as_deref(),
-            token.as_deref(),
+            token.as_ref(),
             &proxy_cfg.auth_type,
             transport,
         )
@@ -3903,7 +3910,7 @@ fn add_context_providers_from_env(
 
     if context.fireflies.is_some() {
         if let Some(token) = get_token_for_context(store, context_name, "fireflies") {
-            let client = devboy_fireflies::FirefliesClient::new(&token);
+            let client = devboy_fireflies::FirefliesClient::new(token);
             server.add_meeting_provider(Arc::new(client));
             tracing::info!("Added Fireflies provider to context '{}'", context_name);
             added = true;
@@ -3983,7 +3990,7 @@ async fn add_env_only_proxies_from_snapshot(
                 &proxy_name,
                 url,
                 None,
-                token.as_deref(),
+                token.as_ref(),
                 "bearer",
                 ProxyTransport::StreamableHttp,
             )
@@ -4009,7 +4016,7 @@ fn get_token_for_context(
     store: &dyn CredentialStore,
     context_name: &str,
     provider: &str,
-) -> Option<String> {
+) -> Option<SecretString> {
     let scoped_key = format!("contexts.{}.{}.token", context_name, provider);
     store
         .get(&scoped_key)
@@ -4137,7 +4144,7 @@ fn add_context_providers(
 
     if context.fireflies.is_some() {
         if let Some(token) = get_token_for_context(store, context_name, "fireflies") {
-            let client = devboy_fireflies::FirefliesClient::new(&token);
+            let client = devboy_fireflies::FirefliesClient::new(token);
             server.add_meeting_provider(Arc::new(client));
             tracing::info!("Added Fireflies provider to context '{}'", context_name);
             added = true;
@@ -4578,7 +4585,7 @@ async fn run_benchmark(
         println!("Note: No GITHUB_TOKEN set. Set it for higher rate limits.\n");
     }
 
-    let client = devboy_github::GitHubClient::new(owner, repo, &gh_token);
+    let client = devboy_github::GitHubClient::new(owner, repo, SecretString::from(gh_token));
 
     // Fetch issues
     println!("Fetching issues...");

--- a/crates/devboy-cli/tests/common/test_provider.rs
+++ b/crates/devboy-cli/tests/common/test_provider.rs
@@ -11,6 +11,7 @@ use devboy_core::{
     UpdateIssueInput, User,
 };
 use devboy_github::GitHubClient;
+use secrecy::SecretString;
 
 use super::api_result::ApiResult;
 use super::{FixtureProvider, TestMode};
@@ -44,7 +45,7 @@ impl TestProvider {
             let owner = env::var("GITHUB_OWNER").unwrap_or_else(|_| "meteora-pro".to_string());
             let repo = env::var("GITHUB_REPO").unwrap_or_else(|_| "devboy-tools".to_string());
 
-            token.map(|t| GitHubClient::new(&owner, &repo, t))
+            token.map(|t| GitHubClient::new(&owner, &repo, SecretString::from(t)))
         } else {
             None
         };

--- a/crates/devboy-cli/tests/credential_chain_test.rs
+++ b/crates/devboy-cli/tests/credential_chain_test.rs
@@ -9,6 +9,33 @@
 //! Uses `temp_env` for safe env var manipulation (thread-safe, automatic cleanup).
 
 use devboy_storage::{ChainStore, CredentialStore, EnvVarStore, MemoryStore};
+use secrecy::{ExposeSecret, SecretString};
+
+/// Compare an `Option<SecretString>` from a credential store against an
+/// expected plaintext — the integration tests pre-date `SecretString` and
+/// were written as `assert_eq!(result, Some("…".to_string()))`. The wrapper
+/// keeps the test bodies legible without reaching into the secret elsewhere.
+fn assert_secret_eq(actual: Option<SecretString>, expected: Option<&str>) {
+    match (actual, expected) {
+        (Some(secret), Some(want)) => {
+            assert_eq!(
+                secret.expose_secret(),
+                want,
+                "secret value did not match expected plaintext"
+            );
+        }
+        (None, None) => {}
+        (got, want) => panic!(
+            "expected Option<SecretString> presence={:?}, got presence={}",
+            want.is_some(),
+            got.is_some()
+        ),
+    }
+}
+
+fn secret(s: &str) -> SecretString {
+    SecretString::from(s.to_string())
+}
 
 // =============================================================================
 // EnvVarStore Integration Tests
@@ -22,7 +49,7 @@ fn test_env_var_store_prefixed_token() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("test.prefixed.myservice.token").unwrap();
-            assert_eq!(result, Some("test_prefixed_value".to_string()));
+            assert_secret_eq(result, Some("test_prefixed_value"));
         },
     );
 }
@@ -35,7 +62,7 @@ fn test_env_var_store_unprefixed_token() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("test.unprefixed.myservice.token").unwrap();
-            assert_eq!(result, Some("test_unprefixed_value".to_string()));
+            assert_secret_eq(result, Some("test_unprefixed_value"));
         },
     );
 }
@@ -45,7 +72,7 @@ fn test_env_var_store_gitlab_token() {
     temp_env::with_var("DEVBOY_TEST_GITLAB_INTEG_TOKEN", Some("glpat_test"), || {
         let store = EnvVarStore::new();
         let result = store.get("test.gitlab.integ.token").unwrap();
-        assert_eq!(result, Some("glpat_test".to_string()));
+        assert_secret_eq(result, Some("glpat_test"));
     });
 }
 
@@ -54,7 +81,7 @@ fn test_env_var_store_clickup_token() {
     temp_env::with_var("DEVBOY_TEST_CLICKUP_INTEG_TOKEN", Some("pk_test"), || {
         let store = EnvVarStore::new();
         let result = store.get("test.clickup.integ.token").unwrap();
-        assert_eq!(result, Some("pk_test".to_string()));
+        assert_secret_eq(result, Some("pk_test"));
     });
 }
 
@@ -66,7 +93,7 @@ fn test_env_var_store_jira_token() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("test.jira.integ.token").unwrap();
-            assert_eq!(result, Some("jira_api_token".to_string()));
+            assert_secret_eq(result, Some("jira_api_token"));
         },
     );
 }
@@ -81,7 +108,7 @@ fn test_env_var_store_context_scoped_token() {
             let result = store
                 .get("contexts.testdashboard.testprovider.token")
                 .unwrap();
-            assert_eq!(result, Some("ghp_dashboard".to_string()));
+            assert_secret_eq(result, Some("ghp_dashboard"));
         },
     );
 }
@@ -96,7 +123,7 @@ fn test_env_var_store_prefixed_has_priority_over_unprefixed() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("test.priority.service.token").unwrap();
-            assert_eq!(result, Some("prefixed_value".to_string()));
+            assert_secret_eq(result, Some("prefixed_value"));
         },
     );
 }
@@ -109,7 +136,7 @@ fn test_env_var_store_fallback_disabled() {
         || {
             let store = EnvVarStore::new().without_fallback();
             let result = store.get("test.fallback.disabled.service.token").unwrap();
-            assert_eq!(result, None);
+            assert_secret_eq(result, None);
         },
     );
 }
@@ -127,7 +154,7 @@ fn test_chain_store_env_var_priority_over_memory() {
         )]);
         let chain = ChainStore::new(vec![Box::new(EnvVarStore::new()), Box::new(memory)]);
         let result = chain.get("chain.integ.token").unwrap();
-        assert_eq!(result, Some("from_env".to_string()));
+        assert_secret_eq(result, Some("from_env"));
     });
 }
 
@@ -139,7 +166,7 @@ fn test_chain_store_fallback_to_memory() {
     )]);
     let chain = ChainStore::new(vec![Box::new(EnvVarStore::new()), Box::new(memory)]);
     let result = chain.get("chain.fallback.integ.token").unwrap();
-    assert_eq!(result, Some("from_memory".to_string()));
+    assert_secret_eq(result, Some("from_memory"));
 }
 
 #[test]
@@ -149,7 +176,7 @@ fn test_chain_store_not_found_in_any() {
         Box::new(MemoryStore::new()),
     ]);
     let result = chain.get("nonexistent.key.integration").unwrap();
-    assert_eq!(result, None);
+    assert_secret_eq(result, None);
 }
 
 #[test]
@@ -158,9 +185,11 @@ fn test_chain_store_write_to_memory() {
         Box::new(EnvVarStore::new()),
         Box::new(MemoryStore::new()),
     ]);
-    chain.store("test.write.key", "test_value").unwrap();
+    chain
+        .store("test.write.key", &secret("test_value"))
+        .unwrap();
     let result = chain.get("test.write.key").unwrap();
-    assert_eq!(result, Some("test_value".to_string()));
+    assert_secret_eq(result, Some("test_value"));
 }
 
 #[test]
@@ -168,12 +197,9 @@ fn test_chain_store_delete_from_memory() {
     let memory =
         MemoryStore::with_credentials([("delete.test.key".to_string(), "value".to_string())]);
     let chain = ChainStore::new(vec![Box::new(EnvVarStore::new()), Box::new(memory)]);
-    assert_eq!(
-        chain.get("delete.test.key").unwrap(),
-        Some("value".to_string())
-    );
+    assert_secret_eq(chain.get("delete.test.key").unwrap(), Some("value"));
     chain.delete("delete.test.key").unwrap();
-    assert_eq!(chain.get("delete.test.key").unwrap(), None);
+    assert_secret_eq(chain.get("delete.test.key").unwrap(), None);
 }
 
 #[test]
@@ -181,13 +207,10 @@ fn test_chain_store_ci_mode_no_keychain() {
     temp_env::with_var("DEVBOY_CI_MODE_TOKEN", Some("ci_value"), || {
         let chain = ChainStore::ci_chain();
         let result = chain.get("ci.mode.token").unwrap();
-        assert_eq!(result, Some("ci_value".to_string()));
+        assert_secret_eq(result, Some("ci_value"));
 
-        chain.store("ci.write.key", "written").unwrap();
-        assert_eq!(
-            chain.get("ci.write.key").unwrap(),
-            Some("written".to_string())
-        );
+        chain.store("ci.write.key", &secret("written")).unwrap();
+        assert_secret_eq(chain.get("ci.write.key").unwrap(), Some("written"));
     });
 }
 
@@ -200,7 +223,7 @@ fn test_default_chain_env_var_works() {
     temp_env::with_var("DEVBOY_DEFAULT_CHAIN_TEST", Some("env_value"), || {
         let chain = ChainStore::default_chain();
         let result = chain.get("default.chain.test").unwrap();
-        assert_eq!(result, Some("env_value".to_string()));
+        assert_secret_eq(result, Some("env_value"));
     });
 }
 
@@ -219,7 +242,7 @@ fn test_scenario_unprefixed_fallback() {
     temp_env::with_var("SCENARIO_GHA_TOKEN", Some("ghs_workflow_token"), || {
         let chain = ChainStore::default_chain();
         let result = chain.get("scenario.gha.token").unwrap();
-        assert_eq!(result, Some("ghs_workflow_token".to_string()));
+        assert_secret_eq(result, Some("ghs_workflow_token"));
     });
 }
 
@@ -231,7 +254,7 @@ fn test_scenario_prefixed_priority() {
         || {
             let chain = ChainStore::default_chain();
             let result = chain.get("scenario.docker.token").unwrap();
-            assert_eq!(result, Some("docker_secret".to_string()));
+            assert_secret_eq(result, Some("docker_secret"));
         },
     );
 }
@@ -246,18 +269,15 @@ fn test_multiple_contexts_scenario() {
         ],
         || {
             let chain = ChainStore::default_chain();
-            assert_eq!(
+            assert_secret_eq(
                 chain.get("contexts.testprod.testgh.token").unwrap(),
-                Some("ghp_prod".to_string())
+                Some("ghp_prod"),
             );
-            assert_eq!(
+            assert_secret_eq(
                 chain.get("contexts.testdev.testgh.token").unwrap(),
-                Some("ghp_dev".to_string())
+                Some("ghp_dev"),
             );
-            assert_eq!(
-                chain.get("testgh.token").unwrap(),
-                Some("ghp_default".to_string())
-            );
+            assert_secret_eq(chain.get("testgh.token").unwrap(), Some("ghp_default"));
         },
     );
 }
@@ -270,7 +290,7 @@ fn test_proxy_server_token_scenario() {
         || {
             let chain = ChainStore::default_chain();
             let result = chain.get("test-proxy-cloud.token").unwrap();
-            assert_eq!(result, Some("proxy_auth_token".to_string()));
+            assert_secret_eq(result, Some("proxy_auth_token"));
         },
     );
 }

--- a/crates/devboy-cli/tests/env_context_test.rs
+++ b/crates/devboy-cli/tests/env_context_test.rs
@@ -6,6 +6,33 @@
 //! Uses `temp_env` for safe env var manipulation (thread-safe, automatic cleanup).
 
 use devboy_storage::{ChainStore, CredentialStore, EnvVarStore};
+use secrecy::{ExposeSecret, SecretString};
+
+/// Compare an `Option<SecretString>` from a credential store against an
+/// expected plaintext. Pre-existing tests were written against `Option<String>`
+/// before the SecretString migration; the helper keeps the assertions
+/// readable without leaking the inner value elsewhere.
+fn assert_secret_eq(actual: Option<SecretString>, expected: Option<&str>) {
+    match (actual, expected) {
+        (Some(secret), Some(want)) => {
+            assert_eq!(
+                secret.expose_secret(),
+                want,
+                "secret value did not match expected plaintext"
+            );
+        }
+        (None, None) => {}
+        (got, want) => panic!(
+            "expected Option<SecretString> presence={:?}, got presence={}",
+            want.is_some(),
+            got.is_some()
+        ),
+    }
+}
+
+fn secret(s: &str) -> SecretString {
+    SecretString::from(s.to_string())
+}
 
 // =============================================================================
 // Context Token Resolution Tests
@@ -19,7 +46,7 @@ fn test_context_github_token_resolution() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("contexts.integ-prod.github.token").unwrap();
-            assert_eq!(result, Some("ghp_prod_token".to_string()));
+            assert_secret_eq(result, Some("ghp_prod_token"));
         },
     );
 }
@@ -32,7 +59,7 @@ fn test_context_gitlab_token_resolution() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("contexts.integ-staging.gitlab.token").unwrap();
-            assert_eq!(result, Some("glpat_staging".to_string()));
+            assert_secret_eq(result, Some("glpat_staging"));
         },
     );
 }
@@ -45,7 +72,7 @@ fn test_context_clickup_token_resolution() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("contexts.integ-tasks.clickup.token").unwrap();
-            assert_eq!(result, Some("pk_tasks_token".to_string()));
+            assert_secret_eq(result, Some("pk_tasks_token"));
         },
     );
 }
@@ -58,7 +85,7 @@ fn test_context_jira_token_resolution() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("contexts.integ-jira.jira.token").unwrap();
-            assert_eq!(result, Some("jira_token_123".to_string()));
+            assert_secret_eq(result, Some("jira_token_123"));
         },
     );
 }
@@ -75,7 +102,7 @@ fn test_context_with_underscores_in_name() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("contexts.my-cool-project.github.token").unwrap();
-            assert_eq!(result, Some("ghp_cool_project".to_string()));
+            assert_secret_eq(result, Some("ghp_cool_project"));
         },
     );
 }
@@ -88,7 +115,7 @@ fn test_context_single_word_name() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("contexts.prod.github.token").unwrap();
-            assert_eq!(result, Some("ghp_single_word".to_string()));
+            assert_secret_eq(result, Some("ghp_single_word"));
         },
     );
 }
@@ -110,9 +137,9 @@ fn test_context_specific_token_over_global() {
         || {
             let chain = ChainStore::ci_chain();
             let context_result = chain.get("contexts.integ-prio.github.token").unwrap();
-            assert_eq!(context_result, Some("ghp_context_specific".to_string()));
+            assert_secret_eq(context_result, Some("ghp_context_specific"));
             let global_result = chain.get("github.token").unwrap();
-            assert_eq!(global_result, Some("ghp_global".to_string()));
+            assert_secret_eq(global_result, Some("ghp_global"));
         },
     );
 }
@@ -127,9 +154,9 @@ fn test_fallback_to_global_token_when_no_context_specific() {
             let context_result = chain
                 .get("contexts.nonexistent.integ-fallback.github.token")
                 .unwrap();
-            assert_eq!(context_result, None);
+            assert_secret_eq(context_result, None);
             let global_result = chain.get("integ-fallback.github.token").unwrap();
-            assert_eq!(global_result, Some("ghp_global_only".to_string()));
+            assert_secret_eq(global_result, Some("ghp_global_only"));
         },
     );
 }
@@ -157,17 +184,17 @@ fn test_multiple_providers_in_context() {
         ],
         || {
             let store = EnvVarStore::new();
-            assert_eq!(
+            assert_secret_eq(
                 store.get("contexts.integ-multi.github.token").unwrap(),
-                Some("ghp_multi_context".to_string())
+                Some("ghp_multi_context"),
             );
-            assert_eq!(
+            assert_secret_eq(
                 store.get("contexts.integ-multi.gitlab.token").unwrap(),
-                Some("glpat_multi_context".to_string())
+                Some("glpat_multi_context"),
             );
-            assert_eq!(
+            assert_secret_eq(
                 store.get("contexts.integ-multi.clickup.token").unwrap(),
-                Some("pk_multi_context".to_string())
+                Some("pk_multi_context"),
             );
         },
     );
@@ -196,17 +223,17 @@ fn test_multiple_contexts_isolation() {
         ],
         || {
             let store = EnvVarStore::new();
-            assert_eq!(
+            assert_secret_eq(
                 store.get("contexts.integ-ctx-a.github.token").unwrap(),
-                Some("ghp_context_a".to_string())
+                Some("ghp_context_a"),
             );
-            assert_eq!(
+            assert_secret_eq(
                 store.get("contexts.integ-ctx-b.github.token").unwrap(),
-                Some("ghp_context_b".to_string())
+                Some("ghp_context_b"),
             );
-            assert_eq!(
+            assert_secret_eq(
                 store.get("contexts.integ-ctx-c.github.token").unwrap(),
-                Some("ghp_context_c".to_string())
+                Some("ghp_context_c"),
             );
         },
     );
@@ -224,7 +251,7 @@ fn test_ci_chain_context_tokens() {
         || {
             let chain = ChainStore::ci_chain();
             let result = chain.get("contexts.integ-ci.github.token").unwrap();
-            assert_eq!(result, Some("ghp_ci_context".to_string()));
+            assert_secret_eq(result, Some("ghp_ci_context"));
         },
     );
 }
@@ -233,10 +260,10 @@ fn test_ci_chain_context_tokens() {
 fn test_ci_chain_write_to_memory() {
     let chain = ChainStore::ci_chain();
     chain
-        .store("ci.context.test.key", "test_value")
+        .store("ci.context.test.key", &secret("test_value"))
         .expect("Should be able to write in CI chain");
     let result = chain.get("ci.context.test.key").unwrap();
-    assert_eq!(result, Some("test_value".to_string()));
+    assert_secret_eq(result, Some("test_value"));
 }
 
 // =============================================================================
@@ -251,7 +278,7 @@ fn test_double_underscore_in_env_var() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("contexts..github.token").unwrap();
-            assert_eq!(result, Some("double_underscore_value".to_string()));
+            assert_secret_eq(result, Some("double_underscore_value"));
         },
     );
 }
@@ -264,7 +291,7 @@ fn test_provider_name_in_context_name() {
         || {
             let store = EnvVarStore::new();
             let result = store.get("contexts.my-github-app.github.token").unwrap();
-            assert_eq!(result, Some("ghp_github_in_name".to_string()));
+            assert_secret_eq(result, Some("ghp_github_in_name"));
         },
     );
 }
@@ -275,7 +302,7 @@ fn test_nonexistent_context_returns_none() {
     let result = store
         .get("contexts.completely-nonexistent-ctx-12345.github.token")
         .unwrap();
-    assert_eq!(result, None);
+    assert_secret_eq(result, None);
 }
 
 // =============================================================================
@@ -297,13 +324,13 @@ fn test_scenario_docker_deployment() {
         ],
         || {
             let chain = ChainStore::ci_chain();
-            assert_eq!(
+            assert_secret_eq(
                 chain.get("contexts.integ-docker.github.token").unwrap(),
-                Some("ghp_docker".to_string())
+                Some("ghp_docker"),
             );
-            assert_eq!(
+            assert_secret_eq(
                 chain.get("contexts.integ-docker.gitlab.token").unwrap(),
-                Some("glpat_docker".to_string())
+                Some("glpat_docker"),
             );
         },
     );
@@ -324,15 +351,15 @@ fn test_scenario_kubernetes_secrets() {
         ],
         || {
             let chain = ChainStore::ci_chain();
-            assert_eq!(
+            assert_secret_eq(
                 chain.get("contexts.integ-k8s-prod.github.token").unwrap(),
-                Some("ghp_k8s".to_string())
+                Some("ghp_k8s"),
             );
-            assert_eq!(
+            assert_secret_eq(
                 chain
                     .get("contexts.integ-k8s-staging.github.token")
                     .unwrap(),
-                Some("ghp_k8s_staging".to_string())
+                Some("ghp_k8s_staging"),
             );
         },
     );
@@ -357,17 +384,17 @@ fn test_scenario_github_actions_matrix() {
         ],
         || {
             let chain = ChainStore::ci_chain();
-            assert_eq!(
+            assert_secret_eq(
                 chain.get("contexts.integ-gha-node16.github.token").unwrap(),
-                Some("ghp_node16".to_string())
+                Some("ghp_node16"),
             );
-            assert_eq!(
+            assert_secret_eq(
                 chain.get("contexts.integ-gha-node18.github.token").unwrap(),
-                Some("ghp_node18".to_string())
+                Some("ghp_node18"),
             );
-            assert_eq!(
+            assert_secret_eq(
                 chain.get("contexts.integ-gha-node20.github.token").unwrap(),
-                Some("ghp_node20".to_string())
+                Some("ghp_node20"),
             );
         },
     );

--- a/crates/devboy-core/src/config.rs
+++ b/crates/devboy-core/src/config.rs
@@ -475,7 +475,12 @@ fn default_true() -> bool {
 /// sample_rate = 1.0
 /// traces_sample_rate = 0.0
 /// ```
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+///
+/// `Debug` is implemented manually so the `dsn` (which contains an auth token
+/// in its userinfo segment) does not leak through `tracing::debug!` /
+/// `dbg!()` /  panic backtraces. Serialization preserves the value because
+/// the DSN must round-trip back to the on-disk TOML config.
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct SentryConfig {
     /// Sentry DSN endpoint. When empty, Sentry is disabled (no-op).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -492,6 +497,17 @@ pub struct SentryConfig {
     /// Performance tracing sample rate (0.0 - 1.0). Default: 0.0 (disabled).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub traces_sample_rate: Option<f32>,
+}
+
+impl std::fmt::Debug for SentryConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SentryConfig")
+            .field("dsn", &self.dsn.as_ref().map(|_| "<redacted>"))
+            .field("environment", &self.environment)
+            .field("sample_rate", &self.sample_rate)
+            .field("traces_sample_rate", &self.traces_sample_rate)
+            .finish()
+    }
 }
 
 /// Remote configuration endpoint settings.

--- a/crates/devboy-executor/Cargo.toml
+++ b/crates/devboy-executor/Cargo.toml
@@ -25,6 +25,7 @@ serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 base64 = "0.22"
+secrecy.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/devboy-executor/src/context.rs
+++ b/crates/devboy-executor/src/context.rs
@@ -1,3 +1,4 @@
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -54,11 +55,19 @@ pub enum SlackScope {
 }
 
 /// Authentication configuration for Confluence self-hosted.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+///
+/// **Note:** intentionally not `Serialize`/`Deserialize` — Confluence credentials
+/// are constructed in-process from the keychain. Cross-process transport would
+/// expose `password` / `token` via the wire format.
+#[derive(Debug, Clone)]
 pub enum ConfluenceAuthConfig {
-    BearerToken { token: String },
-    Basic { username: String, password: String },
+    BearerToken {
+        token: SecretString,
+    },
+    Basic {
+        username: String,
+        password: SecretString,
+    },
 }
 
 /// Provider connection configuration with typed scope.
@@ -66,62 +75,58 @@ pub enum ConfluenceAuthConfig {
 /// Each variant carries only the fields relevant to that provider.
 /// Scope is provider-specific — compiler prevents invalid combinations
 /// (e.g., GitLab Group scope on a GitHub provider).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// **Note:** intentionally not `Serialize`/`Deserialize`. Provider configs
+/// carry plaintext access tokens; serializing them to JSON would defeat the
+/// `SecretString` discipline. Construct provider configs in-process from
+/// `Config` + `CredentialStore` instead of round-tripping through transport.
+#[derive(Debug, Clone)]
 pub enum ProviderConfig {
     GitLab {
         base_url: String,
-        access_token: String,
+        access_token: SecretString,
         scope: GitLabScope,
-        #[serde(default)]
         extra: HashMap<String, serde_json::Value>,
     },
     GitHub {
         base_url: String,
-        access_token: String,
+        access_token: SecretString,
         scope: GitHubScope,
-        #[serde(default)]
         extra: HashMap<String, serde_json::Value>,
     },
     ClickUp {
-        access_token: String,
+        access_token: SecretString,
         scope: ClickUpScope,
-        #[serde(default)]
         extra: HashMap<String, serde_json::Value>,
     },
     Jira {
         base_url: String,
-        access_token: String,
+        access_token: SecretString,
         email: String,
         scope: JiraScope,
         /// Explicit flavor override. When set, skips auto-detection from URL.
         /// Important for proxy scenarios where URL doesn't reflect actual Jira deployment.
         flavor: Option<devboy_jira::JiraFlavor>,
-        #[serde(default)]
         extra: HashMap<String, serde_json::Value>,
     },
     Confluence {
         base_url: String,
         auth: ConfluenceAuthConfig,
         scope: ConfluenceScope,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
         api_version: Option<String>,
-        #[serde(default)]
         extra: HashMap<String, serde_json::Value>,
     },
     /// Fireflies.ai meeting notes provider.
     Fireflies {
-        api_key: String,
-        #[serde(default)]
+        api_key: SecretString,
         extra: HashMap<String, serde_json::Value>,
     },
     /// Slack messenger provider.
     Slack {
         base_url: String,
-        access_token: String,
+        access_token: SecretString,
         scope: SlackScope,
-        #[serde(default)]
         required_scopes: Vec<String>,
-        #[serde(default)]
         extra: HashMap<String, serde_json::Value>,
     },
     /// Fully dynamic variant for community/custom provider plugins.
@@ -186,26 +191,31 @@ impl ProviderMetadata {
 /// - `proxy` — optional proxy for self-hosted instances
 /// - `metadata` — optional provider metadata for dynamic enrichment
 /// - `extra` — cross-cutting concerns (tracing, feature flags, caller metadata)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// **Note:** intentionally not `Serialize`/`Deserialize` — `provider` carries
+/// `SecretString` access tokens that must not leak through wire formats.
+#[derive(Debug, Clone)]
 pub struct AdditionalContext {
     pub provider: ProviderConfig,
-    #[serde(default)]
     pub proxy: Option<ProxyConfig>,
-    #[serde(default)]
     pub metadata: Option<ProviderMetadata>,
-    #[serde(default)]
     pub extra: HashMap<String, serde_json::Value>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use secrecy::ExposeSecret;
+
+    fn token(s: &str) -> SecretString {
+        SecretString::from(s.to_string())
+    }
 
     #[test]
     fn test_provider_config_gitlab_project_scope() {
         let config = ProviderConfig::GitLab {
             base_url: "https://gitlab.com".into(),
-            access_token: "glpat-xxx".into(),
+            access_token: token("glpat-xxx"),
             scope: GitLabScope::Project { id: "12345".into() },
             extra: HashMap::new(),
         };
@@ -216,7 +226,7 @@ mod tests {
     fn test_provider_config_github_repo_scope() {
         let config = ProviderConfig::GitHub {
             base_url: "https://api.github.com".into(),
-            access_token: "ghp_xxx".into(),
+            access_token: token("ghp_xxx"),
             scope: GitHubScope::Repository {
                 owner: "meteora-pro".into(),
                 repo: "devboy-tools".into(),
@@ -240,7 +250,7 @@ mod tests {
         let config = ProviderConfig::Confluence {
             base_url: "https://wiki.example.com".into(),
             auth: ConfluenceAuthConfig::BearerToken {
-                token: "pat-token".into(),
+                token: token("pat-token"),
             },
             scope: ConfluenceScope::Space {
                 key: Some("ENG".into()),
@@ -252,123 +262,9 @@ mod tests {
     }
 
     #[test]
-    fn test_additional_context_serialization() {
-        let ctx = AdditionalContext {
-            provider: ProviderConfig::GitLab {
-                base_url: "https://gitlab.com".into(),
-                access_token: "token".into(),
-                scope: GitLabScope::Project { id: "123".into() },
-                extra: HashMap::new(),
-            },
-            proxy: None,
-            metadata: None,
-            extra: HashMap::new(),
-        };
-        let json = serde_json::to_string(&ctx).unwrap();
-        let deserialized: AdditionalContext = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.provider.provider_name(), "gitlab");
-    }
-
-    // --- ProxyConfig serde ---
-
-    #[test]
-    fn test_proxy_config_serialize_deserialize() {
-        let mut headers = HashMap::new();
-        headers.insert("X-Auth-Token".into(), "secret123".into());
-        headers.insert("X-Routing".into(), "internal".into());
-
-        let proxy = ProxyConfig {
-            url: "https://proxy.internal/jira".into(),
-            headers,
-        };
-
-        let json = serde_json::to_string(&proxy).unwrap();
-        let deserialized: ProxyConfig = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(deserialized.url, "https://proxy.internal/jira");
-        assert_eq!(deserialized.headers.len(), 2);
-        assert_eq!(deserialized.headers["X-Auth-Token"], "secret123");
-        assert_eq!(deserialized.headers["X-Routing"], "internal");
-    }
-
-    #[test]
-    fn test_proxy_config_empty_headers_default() {
-        let json = r#"{"url":"https://proxy.example.com"}"#;
-        let proxy: ProxyConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(proxy.url, "https://proxy.example.com");
-        assert!(proxy.headers.is_empty());
-    }
-
-    // --- JiraFlavor serde ---
-
-    #[test]
-    fn test_jira_flavor_serde_cloud() {
-        let config = ProviderConfig::Jira {
-            base_url: "https://test.atlassian.net".into(),
-            access_token: "tok".into(),
-            email: "a@b.com".into(),
-            scope: JiraScope::Project { key: "TST".into() },
-            flavor: Some(devboy_jira::JiraFlavor::Cloud),
-            extra: HashMap::new(),
-        };
-        let json = serde_json::to_string(&config).unwrap();
-        assert!(json.contains("\"cloud\""));
-
-        let deserialized: ProviderConfig = serde_json::from_str(&json).unwrap();
-        match deserialized {
-            ProviderConfig::Jira { flavor, .. } => {
-                assert_eq!(flavor, Some(devboy_jira::JiraFlavor::Cloud));
-            }
-            _ => panic!("expected Jira variant"),
-        }
-    }
-
-    #[test]
-    fn test_jira_flavor_serde_self_hosted() {
-        let config = ProviderConfig::Jira {
-            base_url: "https://jira.mycompany.com".into(),
-            access_token: "tok".into(),
-            email: "a@b.com".into(),
-            scope: JiraScope::Project { key: "INT".into() },
-            flavor: Some(devboy_jira::JiraFlavor::SelfHosted),
-            extra: HashMap::new(),
-        };
-        let json = serde_json::to_string(&config).unwrap();
-        assert!(json.contains("\"self_hosted\""));
-
-        let deserialized: ProviderConfig = serde_json::from_str(&json).unwrap();
-        match deserialized {
-            ProviderConfig::Jira { flavor, .. } => {
-                assert_eq!(flavor, Some(devboy_jira::JiraFlavor::SelfHosted));
-            }
-            _ => panic!("expected Jira variant"),
-        }
-    }
-
-    #[test]
-    fn test_jira_flavor_none_roundtrip() {
-        let config = ProviderConfig::Jira {
-            base_url: "https://jira.example.com".into(),
-            access_token: "tok".into(),
-            email: "a@b.com".into(),
-            scope: JiraScope::Project { key: "PRJ".into() },
-            flavor: None,
-            extra: HashMap::new(),
-        };
-        let json = serde_json::to_string(&config).unwrap();
-        let deserialized: ProviderConfig = serde_json::from_str(&json).unwrap();
-        match deserialized {
-            ProviderConfig::Jira { flavor, .. } => assert!(flavor.is_none()),
-            _ => panic!("expected Jira variant"),
-        }
-    }
-
-    // --- ProviderConfig provider_name for remaining variants ---
-
-    #[test]
     fn test_provider_name_clickup() {
         let config = ProviderConfig::ClickUp {
-            access_token: "pk_test".into(),
+            access_token: token("pk_test"),
             scope: ClickUpScope::List {
                 id: "list1".into(),
                 team_id: None,
@@ -382,53 +278,13 @@ mod tests {
     fn test_provider_name_jira() {
         let config = ProviderConfig::Jira {
             base_url: "https://jira.example.com".into(),
-            access_token: "tok".into(),
+            access_token: token("tok"),
             email: "a@b.com".into(),
             scope: JiraScope::Project { key: "X".into() },
             flavor: None,
             extra: HashMap::new(),
         };
         assert_eq!(config.provider_name(), "jira");
-    }
-
-    // --- AdditionalContext with proxy and metadata ---
-
-    #[test]
-    fn test_additional_context_with_proxy_roundtrip() {
-        let mut headers = HashMap::new();
-        headers.insert("Authorization".into(), "Bearer xyz".into());
-
-        let ctx = AdditionalContext {
-            provider: ProviderConfig::Jira {
-                base_url: "https://jira.example.com".into(),
-                access_token: "tok".into(),
-                email: "a@b.com".into(),
-                scope: JiraScope::Project { key: "PRJ".into() },
-                flavor: Some(devboy_jira::JiraFlavor::SelfHosted),
-                extra: HashMap::new(),
-            },
-            proxy: Some(ProxyConfig {
-                url: "https://proxy.internal".into(),
-                headers,
-            }),
-            metadata: Some(ProviderMetadata::new(serde_json::json!({"key": "value"}))),
-            extra: {
-                let mut m = HashMap::new();
-                m.insert("trace_id".into(), serde_json::json!("abc-123"));
-                m
-            },
-        };
-
-        let json = serde_json::to_string(&ctx).unwrap();
-        let deserialized: AdditionalContext = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(deserialized.provider.provider_name(), "jira");
-        assert!(deserialized.proxy.is_some());
-        let proxy = deserialized.proxy.unwrap();
-        assert_eq!(proxy.url, "https://proxy.internal");
-        assert_eq!(proxy.headers["Authorization"], "Bearer xyz");
-        assert!(deserialized.metadata.is_some());
-        assert_eq!(deserialized.extra["trace_id"], serde_json::json!("abc-123"));
     }
 
     #[test]
@@ -438,188 +294,52 @@ mod tests {
         assert_eq!(meta.data, data);
     }
 
-    // --- Scope variants serde ---
-
     #[test]
-    fn test_gitlab_scope_global_serde() {
-        let scope = GitLabScope::Global;
-        let json = serde_json::to_string(&scope).unwrap();
-        let deserialized: GitLabScope = serde_json::from_str(&json).unwrap();
-        assert!(matches!(deserialized, GitLabScope::Global));
-    }
-
-    #[test]
-    fn test_gitlab_scope_group_serde() {
-        let scope = GitLabScope::Group { id: "g42".into() };
-        let json = serde_json::to_string(&scope).unwrap();
-        let deserialized: GitLabScope = serde_json::from_str(&json).unwrap();
-        match deserialized {
-            GitLabScope::Group { id } => assert_eq!(id, "g42"),
-            _ => panic!("expected Group"),
-        }
-    }
-
-    #[test]
-    fn test_github_scope_organization_serde() {
-        let scope = GitHubScope::Organization {
-            name: "myorg".into(),
+    fn test_proxy_config_serialize_deserialize() {
+        // ProxyConfig still keeps Serialize/Deserialize because it carries no
+        // secrets; provider auth lives on `ProviderConfig::access_token` instead.
+        let mut headers = HashMap::new();
+        headers.insert("X-Routing".into(), "internal".into());
+        let proxy = ProxyConfig {
+            url: "https://proxy.internal/jira".into(),
+            headers,
         };
-        let json = serde_json::to_string(&scope).unwrap();
-        let deserialized: GitHubScope = serde_json::from_str(&json).unwrap();
-        match deserialized {
-            GitHubScope::Organization { name } => assert_eq!(name, "myorg"),
-            _ => panic!("expected Organization"),
-        }
+        let json = serde_json::to_string(&proxy).unwrap();
+        let deserialized: ProxyConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.url, "https://proxy.internal/jira");
+        assert_eq!(deserialized.headers["X-Routing"], "internal");
     }
 
     #[test]
-    fn test_github_scope_global_serde() {
-        let scope = GitHubScope::Global;
-        let json = serde_json::to_string(&scope).unwrap();
-        let deserialized: GitHubScope = serde_json::from_str(&json).unwrap();
-        assert!(matches!(deserialized, GitHubScope::Global));
-    }
-
-    #[test]
-    fn test_clickup_scope_list_with_team_id_serde() {
-        let scope = ClickUpScope::List {
-            id: "lst1".into(),
-            team_id: Some("team99".into()),
-        };
-        let json = serde_json::to_string(&scope).unwrap();
-        let deserialized: ClickUpScope = serde_json::from_str(&json).unwrap();
-        match deserialized {
-            ClickUpScope::List { id, team_id } => {
-                assert_eq!(id, "lst1");
-                assert_eq!(team_id, Some("team99".into()));
-            }
-        }
-    }
-
-    #[test]
-    fn test_clickup_scope_list_without_team_id_serde() {
-        let scope = ClickUpScope::List {
-            id: "lst2".into(),
-            team_id: None,
-        };
-        let json = serde_json::to_string(&scope).unwrap();
-        let deserialized: ClickUpScope = serde_json::from_str(&json).unwrap();
-        match deserialized {
-            ClickUpScope::List { id, team_id } => {
-                assert_eq!(id, "lst2");
-                assert!(team_id.is_none());
-            }
-        }
-    }
-
-    #[test]
-    fn test_jira_scope_multi_project_serde() {
-        let scope = JiraScope::MultiProject {
-            keys: vec!["AAA".into(), "BBB".into()],
-        };
-        let json = serde_json::to_string(&scope).unwrap();
-        let deserialized: JiraScope = serde_json::from_str(&json).unwrap();
-        match deserialized {
-            JiraScope::MultiProject { keys } => {
-                assert_eq!(keys, vec!["AAA".to_string(), "BBB".to_string()]);
-            }
-            _ => panic!("expected MultiProject"),
-        }
-    }
-
-    // --- ProviderConfig with extra fields ---
-
-    #[test]
-    fn test_provider_config_with_extra_fields() {
-        let mut extra = HashMap::new();
-        extra.insert("custom_key".into(), serde_json::json!("custom_value"));
-        extra.insert("numeric".into(), serde_json::json!(42));
-
+    fn test_provider_config_debug_redacts_access_token() {
         let config = ProviderConfig::GitLab {
             base_url: "https://gitlab.com".into(),
-            access_token: "tok".into(),
-            scope: GitLabScope::Project { id: "1".into() },
-            extra,
-        };
-
-        let json = serde_json::to_string(&config).unwrap();
-        let deserialized: ProviderConfig = serde_json::from_str(&json).unwrap();
-
-        match deserialized {
-            ProviderConfig::GitLab { extra, .. } => {
-                assert_eq!(extra["custom_key"], serde_json::json!("custom_value"));
-                assert_eq!(extra["numeric"], serde_json::json!(42));
-            }
-            _ => panic!("expected GitLab"),
-        }
-    }
-
-    #[test]
-    fn test_custom_provider_config_serde() {
-        let mut config_map = HashMap::new();
-        config_map.insert("endpoint".into(), serde_json::json!("https://custom.api"));
-        config_map.insert("api_key".into(), serde_json::json!("key123"));
-
-        let config = ProviderConfig::Custom {
-            name: "linear".into(),
-            config: config_map,
-        };
-
-        let json = serde_json::to_string(&config).unwrap();
-        let deserialized: ProviderConfig = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(deserialized.provider_name(), "linear");
-        match deserialized {
-            ProviderConfig::Custom { name, config } => {
-                assert_eq!(name, "linear");
-                assert_eq!(config["endpoint"], serde_json::json!("https://custom.api"));
-            }
-            _ => panic!("expected Custom"),
-        }
-    }
-
-    #[test]
-    fn test_confluence_provider_config_serde() {
-        let config = ProviderConfig::Confluence {
-            base_url: "https://wiki.example.com".into(),
-            auth: ConfluenceAuthConfig::Basic {
-                username: "dev@example.com".into(),
-                password: "secret".into(),
-            },
-            scope: ConfluenceScope::Space {
-                key: Some("ENG".into()),
-            },
-            api_version: Some("v1".into()),
+            access_token: token("super-secret-glpat"),
+            scope: GitLabScope::Project { id: "12345".into() },
             extra: HashMap::new(),
         };
+        let dbg = format!("{:?}", config);
+        assert!(
+            !dbg.contains("super-secret-glpat"),
+            "Debug must redact access_token, got: {dbg}"
+        );
+    }
 
-        let json = serde_json::to_string(&config).unwrap();
-        let deserialized: ProviderConfig = serde_json::from_str(&json).unwrap();
+    #[test]
+    fn test_confluence_auth_basic_password_redacted() {
+        let auth = ConfluenceAuthConfig::Basic {
+            username: "dev@example.com".into(),
+            password: token("super-secret-password"),
+        };
+        let dbg = format!("{:?}", auth);
+        assert!(
+            !dbg.contains("super-secret-password"),
+            "Basic password must not appear in Debug: {dbg}"
+        );
 
-        match deserialized {
-            ProviderConfig::Confluence {
-                base_url,
-                auth,
-                scope,
-                api_version,
-                ..
-            } => {
-                assert_eq!(base_url, "https://wiki.example.com");
-                assert_eq!(api_version.as_deref(), Some("v1"));
-                match auth {
-                    ConfluenceAuthConfig::Basic { username, password } => {
-                        assert_eq!(username, "dev@example.com");
-                        assert_eq!(password, "secret");
-                    }
-                    _ => panic!("expected Basic auth"),
-                }
-                match scope {
-                    ConfluenceScope::Space { key } => {
-                        assert_eq!(key.as_deref(), Some("ENG"));
-                    }
-                }
-            }
-            _ => panic!("expected Confluence"),
+        // Sanity check: SecretString itself round-trips via expose_secret().
+        if let ConfluenceAuthConfig::Basic { password, .. } = &auth {
+            assert_eq!(password.expose_secret(), "super-secret-password");
         }
     }
 }

--- a/crates/devboy-executor/src/factory.rs
+++ b/crates/devboy-executor/src/factory.rs
@@ -30,10 +30,18 @@ pub fn create_provider(
         } => match scope {
             GitLabScope::Project { id } => {
                 let client = if let Some(proxy) = proxy {
-                    devboy_gitlab::GitLabClient::with_base_url(&proxy.url, id, access_token)
-                        .with_proxy(proxy.headers.clone())
+                    devboy_gitlab::GitLabClient::with_base_url(
+                        &proxy.url,
+                        id,
+                        access_token.clone(),
+                    )
+                    .with_proxy(proxy.headers.clone())
                 } else {
-                    devboy_gitlab::GitLabClient::with_base_url(base_url, id, access_token)
+                    devboy_gitlab::GitLabClient::with_base_url(
+                        base_url,
+                        id,
+                        access_token.clone(),
+                    )
                 };
                 Ok(Box::new(client))
             }
@@ -53,9 +61,14 @@ pub fn create_provider(
             scope,
             ..
         } => match scope {
-            GitHubScope::Repository { owner, repo } => Ok(Box::new(
-                devboy_github::GitHubClient::with_base_url(base_url, owner, repo, access_token),
-            )),
+            GitHubScope::Repository { owner, repo } => {
+                Ok(Box::new(devboy_github::GitHubClient::with_base_url(
+                    base_url,
+                    owner,
+                    repo,
+                    access_token.clone(),
+                )))
+            }
             GitHubScope::Organization { name } => Err(Error::ProviderUnsupported {
                 provider: "github".into(),
                 operation: format!("organization scope (org: {name}) not yet implemented"),
@@ -72,7 +85,7 @@ pub fn create_provider(
             ..
         } => match scope {
             ClickUpScope::List { id, team_id } => {
-                let mut client = devboy_clickup::ClickUpClient::new(id, access_token);
+                let mut client = devboy_clickup::ClickUpClient::new(id, access_token.clone());
                 if let Some(tid) = team_id {
                     client = client.with_team_id(tid);
                 }
@@ -90,11 +103,16 @@ pub fn create_provider(
         } => match scope {
             JiraScope::Project { key } => {
                 let mut client = if let Some(proxy) = proxy {
-                    devboy_jira::JiraClient::new(&proxy.url, key, email, access_token)
-                        .with_proxy(proxy.headers.clone())
-                        .with_instance_url(base_url)
+                    devboy_jira::JiraClient::new(
+                        &proxy.url,
+                        key,
+                        email,
+                        access_token.clone(),
+                    )
+                    .with_proxy(proxy.headers.clone())
+                    .with_instance_url(base_url)
                 } else {
-                    devboy_jira::JiraClient::new(base_url, key, email, access_token)
+                    devboy_jira::JiraClient::new(base_url, key, email, access_token.clone())
                 };
                 if let Some(f) = flavor {
                     client = client.with_flavor(*f);
@@ -186,9 +204,9 @@ pub fn create_meeting_notes_provider(
     config: &ProviderConfig,
 ) -> Result<Box<dyn MeetingNotesProvider>> {
     match config {
-        ProviderConfig::Fireflies { api_key, .. } => {
-            Ok(Box::new(devboy_fireflies::FirefliesClient::new(api_key)))
-        }
+        ProviderConfig::Fireflies { api_key, .. } => Ok(Box::new(
+            devboy_fireflies::FirefliesClient::new(api_key.clone()),
+        )),
         other => Err(Error::ProviderUnsupported {
             provider: other.provider_name().into(),
             operation: "not a meeting notes provider".into(),
@@ -206,7 +224,7 @@ pub fn create_messenger_provider(config: &ProviderConfig) -> Result<Box<dyn Mess
             required_scopes,
             ..
         } => Ok(Box::new(
-            devboy_slack::SlackClient::new(access_token)
+            devboy_slack::SlackClient::new(access_token.clone())
                 .with_base_url(base_url)
                 .with_required_scopes(required_scopes.clone()),
         )),

--- a/crates/devboy-mcp/Cargo.toml
+++ b/crates/devboy-mcp/Cargo.toml
@@ -23,6 +23,7 @@ futures.workspace = true
 tokio-util = { version = "0.7", features = ["io"] }
 async-trait.workspace = true
 thiserror.workspace = true
+secrecy.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/devboy-mcp/src/proxy.rs
+++ b/crates/devboy-mcp/src/proxy.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use reqwest_eventsource::{Event, EventSource};
+use secrecy::{ExposeSecret, SecretString};
 use serde_json::Value;
 use tokio::sync::{Mutex, RwLock, oneshot};
 
@@ -60,7 +61,7 @@ impl McpProxyClient {
         name: &str,
         url: &str,
         tool_prefix: Option<&str>,
-        token: Option<&str>,
+        token: Option<&SecretString>,
         auth_type: &str,
         transport: ProxyTransport,
     ) -> devboy_core::Result<Self> {
@@ -68,12 +69,14 @@ impl McpProxyClient {
         if let Some(token) = token {
             match auth_type {
                 "bearer" => {
-                    let val = HeaderValue::from_str(&format!("Bearer {}", token))
-                        .map_err(|e| devboy_core::Error::Config(format!("Invalid token: {}", e)))?;
+                    let val = HeaderValue::from_str(&format!("Bearer {}", token.expose_secret()))
+                        .map_err(|e| {
+                        devboy_core::Error::Config(format!("Invalid token: {}", e))
+                    })?;
                     headers.insert(AUTHORIZATION, val);
                 }
                 "api_key" => {
-                    let val = HeaderValue::from_str(token)
+                    let val = HeaderValue::from_str(token.expose_secret())
                         .map_err(|e| devboy_core::Error::Config(format!("Invalid token: {}", e)))?;
                     headers.insert("X-API-Key", val);
                 }
@@ -660,6 +663,10 @@ mod tests {
     use crate::protocol::ToolResultContent;
     use httpmock::prelude::*;
 
+    fn token_secret(s: &str) -> SecretString {
+        SecretString::from(s.to_string())
+    }
+
     // =========================================================================
     // ProxyTransport
     // =========================================================================
@@ -757,11 +764,12 @@ mod tests {
         setup_mock_upstream(&server, sample_tools());
 
         let url = format!("{}/mcp", server.base_url());
+        let token = token_secret("my-token");
         let client = McpProxyClient::connect(
             "test-server",
             &url,
             None,
-            Some("my-token"),
+            Some(&token),
             "bearer",
             ProxyTransport::StreamableHttp,
         )
@@ -1129,11 +1137,12 @@ mod tests {
         });
 
         let url = format!("{}/mcp", server.base_url());
+        let token = token_secret("secret-token");
         McpProxyClient::connect(
             "test-server",
             &url,
             None,
-            Some("secret-token"),
+            Some(&token),
             "bearer",
             ProxyTransport::StreamableHttp,
         )
@@ -1164,11 +1173,12 @@ mod tests {
         });
 
         let url = format!("{}/mcp", server.base_url());
+        let token = token_secret("my-api-key");
         McpProxyClient::connect(
             "test-server",
             &url,
             None,
-            Some("my-api-key"),
+            Some(&token),
             "api_key",
             ProxyTransport::StreamableHttp,
         )
@@ -1331,11 +1341,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_connect_invalid_bearer_token() {
+        let token = token_secret("token-with-\x01-control-chars");
         let result = McpProxyClient::connect(
             "test-server",
             "http://localhost:1/mcp",
             None,
-            Some("token-with-\x01-control-chars"),
+            Some(&token),
             "bearer",
             ProxyTransport::StreamableHttp,
         )
@@ -1347,11 +1358,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_connect_invalid_api_key_token() {
+        let token = token_secret("key-with-\x01-control");
         let result = McpProxyClient::connect(
             "test-server",
             "http://localhost:1/mcp",
             None,
-            Some("key-with-\x01-control"),
+            Some(&token),
             "api_key",
             ProxyTransport::StreamableHttp,
         )
@@ -1432,11 +1444,12 @@ mod tests {
         });
 
         let url = format!("{}/sse", server.base_url());
+        let token = token_secret("sse-token");
         let result = McpProxyClient::connect(
             "sse-server",
             &url,
             None,
-            Some("sse-token"),
+            Some(&token),
             "bearer",
             ProxyTransport::Sse,
         )

--- a/crates/devboy-mcp/src/telemetry.rs
+++ b/crates/devboy-mcp/src/telemetry.rs
@@ -93,7 +93,7 @@ fn unix_now() -> u64 {
 /// Authentication credentials used when uploading batches.
 #[derive(Clone, Default)]
 pub struct TelemetryAuth {
-    pub bearer_token: Option<String>,
+    pub bearer_token: Option<secrecy::SecretString>,
 }
 
 /// Request body shape expected by the backend (documented for the future endpoint).
@@ -222,7 +222,8 @@ impl TelemetryUploader {
             .post(&self.endpoint)
             .header("content-type", "application/json");
         if let Some(token) = &self.auth.bearer_token {
-            req = req.header("authorization", format!("Bearer {}", token));
+            use secrecy::ExposeSecret;
+            req = req.header("authorization", format!("Bearer {}", token.expose_secret()));
         }
         let resp = req.json(batch).send().await.map_err(|e| {
             devboy_core::Error::Http(format!("telemetry upload to {}: {}", self.endpoint, e))

--- a/crates/devboy-storage/Cargo.toml
+++ b/crates/devboy-storage/Cargo.toml
@@ -14,6 +14,7 @@ serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 zeroize = { version = "1.8", features = ["derive"] }
+secrecy.workspace = true
 
 # Keychain access (platform-specific features)
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/devboy-storage/src/cache.rs
+++ b/crates/devboy-storage/src/cache.rs
@@ -11,8 +11,10 @@
 //! - TTL of `0` disables caching entirely (useful for high-security configurations).
 //! - `store()` / `delete()` on the wrapped store also invalidate the cache entry so we
 //!   do not serve stale secrets after rotation.
-//! - The cached value is wrapped in [`zeroize::Zeroizing`], ensuring the buffer is
-//!   scrubbed when the entry is evicted or the cache is dropped.
+//! - Cached values are held as [`secrecy::SecretString`], whose `Debug` impl
+//!   redacts the value and which zeroizes its buffer on drop — so eviction
+//!   and cache-drop scrub the in-memory copy without manual `Zeroizing`
+//!   wrappers.
 //! - The [`std::fmt::Debug`] impl never prints values.
 //!
 //! # Non-goals
@@ -25,7 +27,7 @@ use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
 use devboy_core::Result;
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::SecretString;
 
 use crate::CredentialStore;
 
@@ -94,7 +96,11 @@ impl<S: CredentialStore> CachedStore<S> {
         let entries = self.entries.read().ok()?;
         let entry = entries.get(key)?;
         if entry.is_fresh() {
-            Some(SecretString::from(entry.value.expose_secret().to_string()))
+            // Clone the SecretString directly — no `expose_secret()`
+            // call, no extra plaintext String allocation, and the
+            // returned value keeps the same zeroize-on-drop discipline
+            // as the cached entry.
+            Some(entry.value.clone())
         } else {
             None
         }
@@ -104,13 +110,7 @@ impl<S: CredentialStore> CachedStore<S> {
         let Ok(mut entries) = self.entries.write() else {
             return;
         };
-        entries.insert(
-            key.to_string(),
-            CachedEntry::new(
-                SecretString::from(value.expose_secret().to_string()),
-                self.ttl,
-            ),
-        );
+        entries.insert(key.to_string(), CachedEntry::new(value.clone(), self.ttl));
     }
 
     fn purge_expired_locked(&self) {
@@ -180,6 +180,7 @@ impl<S: CredentialStore> CredentialStore for CachedStore<S> {
 mod tests {
     use super::*;
     use crate::MemoryStore;
+    use secrecy::ExposeSecret;
     use std::thread;
 
     fn store_with_entry(k: &str, v: &str) -> MemoryStore {

--- a/crates/devboy-storage/src/cache.rs
+++ b/crates/devboy-storage/src/cache.rs
@@ -25,20 +25,20 @@ use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
 use devboy_core::Result;
-use zeroize::Zeroizing;
+use secrecy::{ExposeSecret, SecretString};
 
 use crate::CredentialStore;
 
-/// Entry in the cache — a zeroized buffer plus an expiry timestamp.
+/// Entry in the cache — a `SecretString` (zeroized on drop) plus an expiry timestamp.
 struct CachedEntry {
-    value: Zeroizing<String>,
+    value: SecretString,
     expires_at: Instant,
 }
 
 impl CachedEntry {
-    fn new(value: String, ttl: Duration) -> Self {
+    fn new(value: SecretString, ttl: Duration) -> Self {
         Self {
-            value: Zeroizing::new(value),
+            value,
             expires_at: Instant::now() + ttl,
         }
     }
@@ -90,23 +90,26 @@ impl<S: CredentialStore> CachedStore<S> {
         self.ttl.is_zero()
     }
 
-    fn lookup_fresh(&self, key: &str) -> Option<String> {
+    fn lookup_fresh(&self, key: &str) -> Option<SecretString> {
         let entries = self.entries.read().ok()?;
         let entry = entries.get(key)?;
         if entry.is_fresh() {
-            Some(entry.value.as_str().to_string())
+            Some(SecretString::from(entry.value.expose_secret().to_string()))
         } else {
             None
         }
     }
 
-    fn insert(&self, key: &str, value: &str) {
+    fn insert(&self, key: &str, value: &SecretString) {
         let Ok(mut entries) = self.entries.write() else {
             return;
         };
         entries.insert(
             key.to_string(),
-            CachedEntry::new(value.to_string(), self.ttl),
+            CachedEntry::new(
+                SecretString::from(value.expose_secret().to_string()),
+                self.ttl,
+            ),
         );
     }
 
@@ -131,13 +134,13 @@ impl<S: CredentialStore> std::fmt::Debug for CachedStore<S> {
 }
 
 impl<S: CredentialStore> CredentialStore for CachedStore<S> {
-    fn store(&self, key: &str, value: &str) -> Result<()> {
+    fn store(&self, key: &str, value: &SecretString) -> Result<()> {
         let res = self.inner.store(key, value);
         self.invalidate(key);
         res
     }
 
-    fn get(&self, key: &str) -> Result<Option<String>> {
+    fn get(&self, key: &str) -> Result<Option<SecretString>> {
         if self.caching_disabled() {
             return self.inner.get(key);
         }
@@ -183,6 +186,14 @@ mod tests {
         MemoryStore::with_credentials([(k.to_string(), v.to_string())])
     }
 
+    fn secret(s: &str) -> SecretString {
+        SecretString::from(s.to_string())
+    }
+
+    fn exposed(s: &Option<SecretString>) -> Option<&str> {
+        s.as_ref().map(|v| v.expose_secret())
+    }
+
     #[test]
     fn test_cache_hit_returns_value_without_hitting_inner() {
         // A MemoryStore whose credentials vanish after the first read would prove this,
@@ -191,7 +202,7 @@ mod tests {
         let cache = CachedStore::new(store_with_entry("a/b", "secret-A"), Duration::from_secs(60));
 
         // Prime
-        assert_eq!(cache.get("a/b").unwrap().as_deref(), Some("secret-A"));
+        assert_eq!(exposed(&cache.get("a/b").unwrap()), Some("secret-A"));
         // Debug does not leak the value
         let dbg = format!("{:?}", cache);
         assert!(dbg.contains("cached_entries: 1"));
@@ -205,16 +216,16 @@ mod tests {
             Duration::from_millis(50),
         );
 
-        assert_eq!(cache.get("a/b").unwrap().as_deref(), Some("secret-A"));
+        assert_eq!(exposed(&cache.get("a/b").unwrap()), Some("secret-A"));
         thread::sleep(Duration::from_millis(80));
         // Still finds it but now from the inner store (cache miss → fresh fetch).
-        assert_eq!(cache.get("a/b").unwrap().as_deref(), Some("secret-A"));
+        assert_eq!(exposed(&cache.get("a/b").unwrap()), Some("secret-A"));
     }
 
     #[test]
     fn test_cache_zero_ttl_disables_caching() {
         let cache = CachedStore::new(store_with_entry("a/b", "v"), Duration::ZERO);
-        assert_eq!(cache.get("a/b").unwrap().as_deref(), Some("v"));
+        assert_eq!(exposed(&cache.get("a/b").unwrap()), Some("v"));
 
         let dbg = format!("{:?}", cache);
         assert!(dbg.contains("cached_entries: 0"));
@@ -223,26 +234,26 @@ mod tests {
     #[test]
     fn test_store_invalidates_cache_entry() {
         let inner = MemoryStore::new();
-        inner.store("k", "v1").unwrap();
+        inner.store("k", &secret("v1")).unwrap();
 
         let cache = CachedStore::new(inner, Duration::from_secs(60));
-        assert_eq!(cache.get("k").unwrap().as_deref(), Some("v1"));
+        assert_eq!(exposed(&cache.get("k").unwrap()), Some("v1"));
 
         // Rotate through the cache — rotation must reach the inner store AND bust cache.
-        cache.store("k", "v2").unwrap();
-        assert_eq!(cache.get("k").unwrap().as_deref(), Some("v2"));
+        cache.store("k", &secret("v2")).unwrap();
+        assert_eq!(exposed(&cache.get("k").unwrap()), Some("v2"));
     }
 
     #[test]
     fn test_delete_invalidates_cache_entry() {
         let inner = MemoryStore::new();
-        inner.store("k", "v1").unwrap();
+        inner.store("k", &secret("v1")).unwrap();
         let cache = CachedStore::new(inner, Duration::from_secs(60));
 
-        assert_eq!(cache.get("k").unwrap().as_deref(), Some("v1"));
+        assert_eq!(exposed(&cache.get("k").unwrap()), Some("v1"));
 
         cache.delete("k").unwrap();
-        assert_eq!(cache.get("k").unwrap(), None);
+        assert!(cache.get("k").unwrap().is_none());
     }
 
     #[test]
@@ -252,14 +263,14 @@ mod tests {
         let inner = MemoryStore::new();
         let cache = CachedStore::new(inner, Duration::from_secs(60));
 
-        assert_eq!(cache.get("k").unwrap(), None);
+        assert!(cache.get("k").unwrap().is_none());
 
         // Populate inner directly (bypass cache)…
         // we need a &inner, but `cache` owns it — so reach through `invalidate_all` as a
         // proxy for "do not keep negative entries".
         // Simpler: set via cache.store(), which invalidates and then the lookup is fresh.
-        cache.store("k", "later").unwrap();
-        assert_eq!(cache.get("k").unwrap().as_deref(), Some("later"));
+        cache.store("k", &secret("later")).unwrap();
+        assert_eq!(exposed(&cache.get("k").unwrap()), Some("later"));
     }
 
     #[test]

--- a/crates/devboy-storage/src/lib.rs
+++ b/crates/devboy-storage/src/lib.rs
@@ -224,11 +224,28 @@ impl CredentialStore for KeychainStore {
 
 /// In-memory credential store for testing.
 ///
-/// This store keeps credentials in memory and is suitable for unit tests
-/// where you don't want to interact with the real OS keychain.
-#[derive(Debug, Default)]
+/// This store keeps credentials in memory wrapped in [`SecretString`]
+/// (zeroize-on-drop, redacted `Debug`) for unit tests that don't want
+/// to interact with the real OS keychain. The `Debug` impl shows the
+/// key set and a count, never the values, so accidentally logging a
+/// `MemoryStore` cannot leak plaintext.
+#[derive(Default)]
 pub struct MemoryStore {
-    credentials: std::sync::RwLock<std::collections::HashMap<String, String>>,
+    credentials: std::sync::RwLock<std::collections::HashMap<String, SecretString>>,
+}
+
+impl std::fmt::Debug for MemoryStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let creds = self.credentials.read();
+        let (count, keys) = match &creds {
+            Ok(map) => (map.len(), map.keys().cloned().collect::<Vec<_>>()),
+            Err(_) => (0, vec!["<lock-poisoned>".to_string()]),
+        };
+        f.debug_struct("MemoryStore")
+            .field("credentials", &format!("<{count} redacted secret(s)>"))
+            .field("keys", &keys)
+            .finish()
+    }
 }
 
 impl MemoryStore {
@@ -237,12 +254,16 @@ impl MemoryStore {
         Self::default()
     }
 
-    /// Create a store pre-populated with credentials.
+    /// Create a store pre-populated with credentials. Accepts plaintext
+    /// `(key, value)` pairs for test ergonomics; the values are wrapped
+    /// in [`SecretString`] before storage.
     pub fn with_credentials(credentials: impl IntoIterator<Item = (String, String)>) -> Self {
         let store = Self::new();
         {
             let mut creds = store.credentials.write().unwrap();
-            creds.extend(credentials);
+            for (k, v) in credentials {
+                creds.insert(k, SecretString::from(v));
+            }
         }
         store
     }
@@ -254,7 +275,10 @@ impl CredentialStore for MemoryStore {
             .credentials
             .write()
             .map_err(|e| Error::Storage(format!("Lock poisoned: {}", e)))?;
-        creds.insert(key.to_string(), value.expose_secret().to_string());
+        // Clone the SecretString directly — no `expose_secret()` call,
+        // no extra plaintext String allocation, and the cached value
+        // keeps the same zeroize-on-drop discipline as the input.
+        creds.insert(key.to_string(), value.clone());
         Ok(())
     }
 
@@ -263,7 +287,7 @@ impl CredentialStore for MemoryStore {
             .credentials
             .read()
             .map_err(|e| Error::Storage(format!("Lock poisoned: {}", e)))?;
-        Ok(creds.get(key).cloned().map(SecretString::from))
+        Ok(creds.get(key).cloned())
     }
 
     fn delete(&self, key: &str) -> Result<()> {

--- a/crates/devboy-storage/src/lib.rs
+++ b/crates/devboy-storage/src/lib.rs
@@ -35,6 +35,7 @@
 
 use devboy_core::{Error, Result};
 use keyring::Entry;
+use secrecy::{ExposeSecret, SecretString};
 use tracing::{debug, warn};
 
 pub mod cache;
@@ -52,13 +53,19 @@ pub trait CredentialStore: Send + Sync {
     /// Store a credential securely.
     ///
     /// The key should follow the convention: `{provider}.{credential_name}`
-    /// For example: `gitlab.token`, `github.token`, `jira.email`
-    fn store(&self, key: &str, value: &str) -> Result<()>;
+    /// For example: `gitlab.token`, `github.token`, `jira.email`.
+    ///
+    /// The value is taken as `&SecretString` so callers cannot accidentally
+    /// log or otherwise leak the plaintext on its way into storage.
+    fn store(&self, key: &str, value: &SecretString) -> Result<()>;
 
     /// Retrieve a stored credential.
     ///
-    /// Returns `Ok(None)` if the credential doesn't exist.
-    fn get(&self, key: &str) -> Result<Option<String>>;
+    /// Returns `Ok(None)` if the credential doesn't exist. The returned
+    /// `SecretString` redacts itself in `Debug` output and zeroizes the
+    /// buffer on drop — call `.expose_secret()` only at the boundary that
+    /// actually consumes the secret (HTTP header, etc.).
+    fn get(&self, key: &str) -> Result<Option<SecretString>>;
 
     /// Delete a stored credential.
     ///
@@ -131,7 +138,7 @@ impl Default for KeychainStore {
 }
 
 impl CredentialStore for KeychainStore {
-    fn store(&self, key: &str, value: &str) -> Result<()> {
+    fn store(&self, key: &str, value: &SecretString) -> Result<()> {
         debug!(key = key, "Storing credential in keychain");
 
         let entry = self.make_entry(key).map_err(|e| {
@@ -142,13 +149,13 @@ impl CredentialStore for KeychainStore {
         })?;
 
         entry
-            .set_password(value)
+            .set_password(value.expose_secret())
             .map_err(|e| Error::Storage(format!("Failed to store credential '{}': {}", key, e)))?;
 
         Ok(())
     }
 
-    fn get(&self, key: &str) -> Result<Option<String>> {
+    fn get(&self, key: &str) -> Result<Option<SecretString>> {
         debug!(key = key, "Retrieving credential from keychain");
 
         let entry = self.make_entry(key).map_err(|e| {
@@ -159,7 +166,7 @@ impl CredentialStore for KeychainStore {
         })?;
 
         match entry.get_password() {
-            Ok(password) => Ok(Some(password)),
+            Ok(password) => Ok(Some(SecretString::from(password))),
             Err(keyring::Error::NoEntry) => {
                 debug!(key = key, "Credential not found");
                 Ok(None)
@@ -242,21 +249,21 @@ impl MemoryStore {
 }
 
 impl CredentialStore for MemoryStore {
-    fn store(&self, key: &str, value: &str) -> Result<()> {
+    fn store(&self, key: &str, value: &SecretString) -> Result<()> {
         let mut creds = self
             .credentials
             .write()
             .map_err(|e| Error::Storage(format!("Lock poisoned: {}", e)))?;
-        creds.insert(key.to_string(), value.to_string());
+        creds.insert(key.to_string(), value.expose_secret().to_string());
         Ok(())
     }
 
-    fn get(&self, key: &str) -> Result<Option<String>> {
+    fn get(&self, key: &str) -> Result<Option<SecretString>> {
         let creds = self
             .credentials
             .read()
             .map_err(|e| Error::Storage(format!("Lock poisoned: {}", e)))?;
-        Ok(creds.get(key).cloned())
+        Ok(creds.get(key).cloned().map(SecretString::from))
     }
 
     fn delete(&self, key: &str) -> Result<()> {
@@ -399,19 +406,19 @@ impl Default for EnvVarStore {
 }
 
 impl CredentialStore for EnvVarStore {
-    fn store(&self, _key: &str, _value: &str) -> Result<()> {
+    fn store(&self, _key: &str, _value: &SecretString) -> Result<()> {
         Err(Error::Storage(
             "EnvVarStore is read-only. Use OS keychain or set environment variables directly."
                 .to_string(),
         ))
     }
 
-    fn get(&self, key: &str) -> Result<Option<String>> {
+    fn get(&self, key: &str) -> Result<Option<SecretString>> {
         // Try prefixed first (e.g., DEVBOY_GITHUB_TOKEN)
         let prefixed = self.prefixed_env_name(key);
         if let Ok(value) = (self.env_reader)(&prefixed) {
             debug!(key = key, env_var = %prefixed, "Found credential in environment variable");
-            return Ok(Some(value));
+            return Ok(Some(SecretString::from(value)));
         }
 
         // Fallback to unprefixed (e.g., GITHUB_TOKEN)
@@ -419,7 +426,7 @@ impl CredentialStore for EnvVarStore {
             let unprefixed = self.unprefixed_env_name(key);
             if let Ok(value) = (self.env_reader)(&unprefixed) {
                 debug!(key = key, env_var = %unprefixed, "Found credential in environment variable (unprefixed)");
-                return Ok(Some(value));
+                return Ok(Some(SecretString::from(value)));
             }
         }
 
@@ -528,7 +535,7 @@ impl std::fmt::Debug for ChainStore {
 }
 
 impl CredentialStore for ChainStore {
-    fn store(&self, key: &str, value: &str) -> Result<()> {
+    fn store(&self, key: &str, value: &SecretString) -> Result<()> {
         // Try each writable and available store in order
         let mut last_error: Option<Error> = None;
         for store in &self.stores {
@@ -547,7 +554,7 @@ impl CredentialStore for ChainStore {
         }))
     }
 
-    fn get(&self, key: &str) -> Result<Option<String>> {
+    fn get(&self, key: &str) -> Result<Option<SecretString>> {
         // Try each store in order, tracking errors
         let mut last_error: Option<Error> = None;
         for store in &self.stores {
@@ -656,16 +663,24 @@ pub fn email_key(provider: &str) -> String {
 mod tests {
     use super::*;
 
+    fn secret(s: &str) -> SecretString {
+        SecretString::from(s.to_string())
+    }
+
+    fn exposed(s: &Option<SecretString>) -> Option<&str> {
+        s.as_ref().map(|v| v.expose_secret())
+    }
+
     #[test]
     fn test_memory_store_basic() {
         let store = MemoryStore::new();
 
         // Store
-        store.store("test/key", "test-value").unwrap();
+        store.store("test/key", &secret("test-value")).unwrap();
 
         // Get
         let value = store.get("test/key").unwrap();
-        assert_eq!(value, Some("test-value".to_string()));
+        assert_eq!(exposed(&value), Some("test-value"));
 
         // Exists
         assert!(store.exists("test/key"));
@@ -674,7 +689,7 @@ mod tests {
         // Delete
         store.delete("test/key").unwrap();
         let value = store.get("test/key").unwrap();
-        assert_eq!(value, None);
+        assert!(value.is_none());
 
         // Delete non-existent (should not error)
         store.delete("nonexistent").unwrap();
@@ -688,12 +703,12 @@ mod tests {
         ]);
 
         assert_eq!(
-            store.get("gitlab/token").unwrap(),
-            Some("glpat-xxx".to_string())
+            exposed(&store.get("gitlab/token").unwrap()),
+            Some("glpat-xxx")
         );
         assert_eq!(
-            store.get("github/token").unwrap(),
-            Some("ghp-yyy".to_string())
+            exposed(&store.get("github/token").unwrap()),
+            Some("ghp-yyy")
         );
     }
 
@@ -716,7 +731,7 @@ mod tests {
         store.delete("nonexistent/key").unwrap();
 
         // Verify it's still not there
-        assert_eq!(store.get("nonexistent/key").unwrap(), None);
+        assert!(store.get("nonexistent/key").unwrap().is_none());
     }
 
     #[test]
@@ -725,7 +740,7 @@ mod tests {
 
         assert!(!store.exists("test/key"));
 
-        store.store("test/key", "value").unwrap();
+        store.store("test/key", &secret("value")).unwrap();
         assert!(store.exists("test/key"));
 
         store.delete("test/key").unwrap();
@@ -736,11 +751,11 @@ mod tests {
     fn test_memory_store_overwrite() {
         let store = MemoryStore::new();
 
-        store.store("test/key", "value1").unwrap();
-        assert_eq!(store.get("test/key").unwrap(), Some("value1".to_string()));
+        store.store("test/key", &secret("value1")).unwrap();
+        assert_eq!(exposed(&store.get("test/key").unwrap()), Some("value1"));
 
-        store.store("test/key", "value2").unwrap();
-        assert_eq!(store.get("test/key").unwrap(), Some("value2".to_string()));
+        store.store("test/key", &secret("value2")).unwrap();
+        assert_eq!(exposed(&store.get("test/key").unwrap()), Some("value2"));
     }
 
     #[test]
@@ -748,7 +763,7 @@ mod tests {
         // Test the default exists() impl from the trait
         let store = MemoryStore::new();
 
-        store.store("key1", "val1").unwrap();
+        store.store("key1", &secret("val1")).unwrap();
 
         // CredentialStore::exists uses the default impl calling get()
         assert!(CredentialStore::exists(&store, "key1"));
@@ -852,7 +867,7 @@ mod tests {
         let store = EnvVarStore::new().with_env_reader(mock_env_reader);
 
         let result = store.get("test.token").unwrap();
-        assert_eq!(result, Some("prefixed-value".to_string()));
+        assert_eq!(exposed(&result), Some("prefixed-value"));
     }
 
     #[test]
@@ -860,7 +875,7 @@ mod tests {
         let store = EnvVarStore::new().with_env_reader(mock_env_reader);
 
         let result = store.get("test.fallback.token").unwrap();
-        assert_eq!(result, Some("unprefixed-value".to_string()));
+        assert_eq!(exposed(&result), Some("unprefixed-value"));
     }
 
     #[test]
@@ -868,7 +883,7 @@ mod tests {
         let store = EnvVarStore::new().with_env_reader(mock_env_reader);
 
         let result = store.get("test.priority.token").unwrap();
-        assert_eq!(result, Some("prefixed".to_string()));
+        assert_eq!(exposed(&result), Some("prefixed"));
     }
 
     #[test]
@@ -880,7 +895,7 @@ mod tests {
         // Should NOT find it because fallback is disabled
         // (TEST_NO_FALLBACK_TOKEN exists but only as unprefixed)
         let result = store.get("test.no.fallback.token").unwrap();
-        assert_eq!(result, None);
+        assert!(result.is_none());
     }
 
     #[test]
@@ -888,7 +903,7 @@ mod tests {
         let store = EnvVarStore::new().with_env_reader(mock_env_reader);
 
         let result = store.get("nonexistent.key.that.does.not.exist").unwrap();
-        assert_eq!(result, None);
+        assert!(result.is_none());
     }
 
     #[test]
@@ -897,7 +912,7 @@ mod tests {
 
         assert!(!store.is_writable());
 
-        let store_result = store.store("test.key", "value");
+        let store_result = store.store("test.key", &secret("value"));
         assert!(store_result.is_err());
 
         let delete_result = store.delete("test.key");
@@ -946,13 +961,13 @@ mod tests {
         let chain = ChainStore::new(vec![Box::new(store1), Box::new(store2)]);
 
         // key1 should come from first store
-        assert_eq!(chain.get("key1").unwrap(), Some("value1".to_string()));
+        assert_eq!(exposed(&chain.get("key1").unwrap()), Some("value1"));
 
         // key2 should come from second store (not in first)
-        assert_eq!(chain.get("key2").unwrap(), Some("value2".to_string()));
+        assert_eq!(exposed(&chain.get("key2").unwrap()), Some("value2"));
 
         // key3 not found in either
-        assert_eq!(chain.get("key3").unwrap(), None);
+        assert!(chain.get("key3").unwrap().is_none());
     }
 
     #[test]
@@ -964,13 +979,10 @@ mod tests {
         ]);
 
         // Should store to MemoryStore (first writable)
-        chain.store("test.key", "test-value").unwrap();
+        chain.store("test.key", &secret("test-value")).unwrap();
 
         // Should retrieve from chain
-        assert_eq!(
-            chain.get("test.key").unwrap(),
-            Some("test-value".to_string())
-        );
+        assert_eq!(exposed(&chain.get("test.key").unwrap()), Some("test-value"));
     }
 
     #[test]
@@ -978,7 +990,7 @@ mod tests {
         // Chain with only read-only stores
         let chain = ChainStore::new(vec![Box::new(EnvVarStore::new())]);
 
-        let result = chain.store("test.key", "value");
+        let result = chain.store("test.key", &secret("value"));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("No writable"));
     }
@@ -989,8 +1001,8 @@ mod tests {
         let store2 = MemoryStore::new();
 
         // Store in both
-        store1.store("key", "val1").unwrap();
-        store2.store("key", "val2").unwrap();
+        store1.store("key", &secret("val1")).unwrap();
+        store2.store("key", &secret("val2")).unwrap();
 
         let chain = ChainStore::new(vec![Box::new(store1), Box::new(store2)]);
 
@@ -998,7 +1010,7 @@ mod tests {
         chain.delete("key").unwrap();
 
         // Neither should have the key now
-        assert_eq!(chain.get("key").unwrap(), None);
+        assert!(chain.get("key").unwrap().is_none());
     }
 
     #[test]
@@ -1041,8 +1053,8 @@ mod tests {
 
         // Env var should win
         assert_eq!(
-            chain.get("chain.test.token").unwrap(),
-            Some("from-env".to_string())
+            exposed(&chain.get("chain.test.token").unwrap()),
+            Some("from-env")
         );
     }
 
@@ -1059,8 +1071,8 @@ mod tests {
 
         // Should fall back to memory
         assert_eq!(
-            chain.get("fallback.test.token").unwrap(),
-            Some("from-memory".to_string())
+            exposed(&chain.get("fallback.test.token").unwrap()),
+            Some("from-memory")
         );
     }
 
@@ -1094,7 +1106,7 @@ mod tests {
     fn test_wrap_with_cache_zero_ttl_is_passthrough() {
         let inner = MemoryStore::with_credentials([("k".to_string(), "v".to_string())]);
         let store = wrap_with_cache(inner, 0);
-        assert_eq!(store.get("k").unwrap().as_deref(), Some("v"));
+        assert_eq!(exposed(&store.get("k").unwrap()), Some("v"));
     }
 
     #[test]
@@ -1102,9 +1114,9 @@ mod tests {
         let inner = MemoryStore::with_credentials([("k".to_string(), "v1".to_string())]);
         let store = wrap_with_cache(inner, 60);
 
-        assert_eq!(store.get("k").unwrap().as_deref(), Some("v1"));
+        assert_eq!(exposed(&store.get("k").unwrap()), Some("v1"));
 
         // Second call returns the same value — cached or not, semantics are identical.
-        assert_eq!(store.get("k").unwrap().as_deref(), Some("v1"));
+        assert_eq!(exposed(&store.get("k").unwrap()), Some("v1"));
     }
 }

--- a/crates/llm-eval/Cargo.toml
+++ b/crates/llm-eval/Cargo.toml
@@ -12,6 +12,7 @@ anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
+secrecy.workspace = true
 
 [lints]
 workspace = true

--- a/crates/llm-eval/src/main.rs
+++ b/crates/llm-eval/src/main.rs
@@ -26,6 +26,7 @@ use std::io::{self, Write as IoWrite};
 use std::time::Instant;
 
 use anyhow::{Context, Result};
+use secrecy::{ExposeSecret, SecretString};
 use serde_json::{Value, json};
 
 use devboy_format_pipeline::strategy::{
@@ -46,7 +47,7 @@ struct ModelConfig {
     /// OpenAI-compatible base URL (without /chat/completions suffix)
     pub base_url: String,
     /// API key
-    pub api_key: String,
+    pub api_key: SecretString,
     /// Model ID sent in the request
     pub model_id: String,
     /// Max tokens to generate in response
@@ -117,7 +118,7 @@ fn load_model_configs(dotenv: &std::collections::HashMap<String, String>) -> Vec
         configs.push(ModelConfig {
             name: "kimi".into(),
             base_url: getv!("KIMI_BASE_URL", "https://api.moonshot.cn/v1"),
-            api_key: kimi_key,
+            api_key: SecretString::from(kimi_key),
             model_id: getv!("KIMI_MODEL", "moonshot-v1-32k"),
             max_tokens: 64,
             is_ollama: false,
@@ -130,7 +131,7 @@ fn load_model_configs(dotenv: &std::collections::HashMap<String, String>) -> Vec
         configs.push(ModelConfig {
             name: "glm".into(),
             base_url: getv!("ZHIPU_BASE_URL", "https://open.bigmodel.cn/api/paas/v4"),
-            api_key: zhipu_key,
+            api_key: SecretString::from(zhipu_key),
             model_id: getv!("ZHIPU_MODEL", "glm-4-flash"),
             max_tokens: 64,
             is_ollama: false,
@@ -151,7 +152,7 @@ fn load_model_configs(dotenv: &std::collections::HashMap<String, String>) -> Vec
             configs.push(ModelConfig {
                 name: ollama_short_name(model_id),
                 base_url: ollama_url.clone(),
-                api_key: "ollama".into(),
+                api_key: SecretString::from("ollama".to_string()),
                 model_id: model_id.to_string(),
                 max_tokens: 4096,
                 is_ollama: true,
@@ -164,7 +165,7 @@ fn load_model_configs(dotenv: &std::collections::HashMap<String, String>) -> Vec
             configs.push(ModelConfig {
                 name: ollama_short_name(&gemma_model),
                 base_url: ollama_url.clone(),
-                api_key: "ollama".into(),
+                api_key: SecretString::from("ollama".to_string()),
                 model_id: gemma_model,
                 max_tokens: 4096,
                 is_ollama: true,
@@ -176,7 +177,7 @@ fn load_model_configs(dotenv: &std::collections::HashMap<String, String>) -> Vec
             configs.push(ModelConfig {
                 name: ollama_short_name(&gptoss_model),
                 base_url: ollama_url,
-                api_key: "ollama".into(),
+                api_key: SecretString::from("ollama".to_string()),
                 model_id: gptoss_model,
                 max_tokens: 4096,
                 is_ollama: true,
@@ -366,7 +367,7 @@ fn call_llm(
     let start = Instant::now();
     let resp = client
         .post(&url)
-        .bearer_auth(&config.api_key)
+        .bearer_auth(config.api_key.expose_secret())
         .json(&body)
         .send()
         .context("HTTP request failed")?;

--- a/crates/plugins/api/clickup/Cargo.toml
+++ b/crates/plugins/api/clickup/Cargo.toml
@@ -15,6 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+secrecy.workspace = true
 urlencoding = "2"
 
 [dev-dependencies]

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -7,6 +7,7 @@ use devboy_core::{
     PipelineProvider, Provider, ProviderResult, Result, SortInfo, SortOrder, UpdateIssueInput,
     User,
 };
+use secrecy::{ExposeSecret, SecretString};
 use tracing::{debug, warn};
 
 use crate::DEFAULT_CLICKUP_URL;
@@ -29,13 +30,13 @@ pub struct ClickUpClient {
     base_url: String,
     list_id: String,
     team_id: Option<String>,
-    token: String,
+    token: SecretString,
     client: reqwest::Client,
 }
 
 impl ClickUpClient {
     /// Create a new ClickUp client.
-    pub fn new(list_id: impl Into<String>, token: impl Into<String>) -> Self {
+    pub fn new(list_id: impl Into<String>, token: SecretString) -> Self {
         Self::with_base_url(DEFAULT_CLICKUP_URL, list_id, token)
     }
 
@@ -43,13 +44,13 @@ impl ClickUpClient {
     pub fn with_base_url(
         base_url: impl Into<String>,
         list_id: impl Into<String>,
-        token: impl Into<String>,
+        token: SecretString,
     ) -> Self {
         Self {
             base_url: base_url.into().trim_end_matches('/').to_string(),
             list_id: list_id.into(),
             team_id: None,
-            token: token.into(),
+            token,
             client: reqwest::Client::builder()
                 .user_agent("devboy-tools")
                 .build()
@@ -67,7 +68,7 @@ impl ClickUpClient {
     fn request(&self, method: reqwest::Method, url: &str) -> reqwest::RequestBuilder {
         self.client
             .request(method, url)
-            .header("Authorization", &self.token)
+            .header("Authorization", self.token.expose_secret())
             .header("Content-Type", "application/json")
     }
 
@@ -1141,7 +1142,7 @@ impl IssueProvider for ClickUpClient {
         let response = self
             .client
             .post(&url)
-            .header("Authorization", &self.token)
+            .header("Authorization", self.token.expose_secret())
             .multipart(form)
             .send()
             .await
@@ -1204,7 +1205,7 @@ impl IssueProvider for ClickUpClient {
         let response = self
             .client
             .get(download_url)
-            .header("Authorization", &self.token)
+            .header("Authorization", self.token.expose_secret())
             .send()
             .await
             .map_err(|e| Error::Http(e.to_string()))?;
@@ -1443,6 +1444,10 @@ mod tests {
     use crate::types::{ClickUpStatus, ClickUpTag};
     use devboy_core::{CreateCommentInput, MrFilter};
 
+    fn token(s: &str) -> SecretString {
+        SecretString::from(s.to_string())
+    }
+
     #[test]
     fn test_epoch_ms_to_iso8601() {
         // 2024-01-01T00:00:00Z = 1704067200000 ms
@@ -1470,7 +1475,7 @@ mod tests {
     #[test]
     fn test_task_url_cu_prefix() {
         let client =
-            ClickUpClient::with_base_url("https://api.clickup.com/api/v2", "12345", "token");
+            ClickUpClient::with_base_url("https://api.clickup.com/api/v2", "12345", token("token"));
         let url = client.task_url("CU-abc123").unwrap();
         assert_eq!(url, "https://api.clickup.com/api/v2/task/abc123");
     }
@@ -1478,7 +1483,7 @@ mod tests {
     #[test]
     fn test_task_url_custom_id_with_team() {
         let client =
-            ClickUpClient::with_base_url("https://api.clickup.com/api/v2", "12345", "token")
+            ClickUpClient::with_base_url("https://api.clickup.com/api/v2", "12345", token("token"))
                 .with_team_id("9876");
         let url = client.task_url("DEV-42").unwrap();
         assert_eq!(
@@ -1490,7 +1495,7 @@ mod tests {
     #[test]
     fn test_task_url_custom_id_without_team() {
         let client =
-            ClickUpClient::with_base_url("https://api.clickup.com/api/v2", "12345", "token");
+            ClickUpClient::with_base_url("https://api.clickup.com/api/v2", "12345", token("token"));
         let result = client.task_url("DEV-42");
         assert!(result.is_err());
     }
@@ -1762,7 +1767,7 @@ mod tests {
     #[test]
     fn test_clickup_asset_capabilities() {
         let client =
-            ClickUpClient::with_base_url("https://api.clickup.com/api/v2", "12345", "token");
+            ClickUpClient::with_base_url("https://api.clickup.com/api/v2", "12345", token("token"));
         let caps = client.asset_capabilities();
         assert!(caps.issue.upload);
         assert!(caps.issue.download);
@@ -1830,27 +1835,30 @@ mod tests {
     #[test]
     fn test_api_url() {
         let client =
-            ClickUpClient::with_base_url("https://api.clickup.com/api/v2", "12345", "token");
+            ClickUpClient::with_base_url("https://api.clickup.com/api/v2", "12345", token("token"));
         assert_eq!(client.base_url, "https://api.clickup.com/api/v2");
         assert_eq!(client.list_id, "12345");
     }
 
     #[test]
     fn test_api_url_strips_trailing_slash() {
-        let client =
-            ClickUpClient::with_base_url("https://api.clickup.com/api/v2/", "12345", "token");
+        let client = ClickUpClient::with_base_url(
+            "https://api.clickup.com/api/v2/",
+            "12345",
+            token("token"),
+        );
         assert_eq!(client.base_url, "https://api.clickup.com/api/v2");
     }
 
     #[test]
     fn test_with_team_id() {
-        let client = ClickUpClient::new("12345", "token").with_team_id("9876");
+        let client = ClickUpClient::new("12345", token("token")).with_team_id("9876");
         assert_eq!(client.team_id, Some("9876".to_string()));
     }
 
     #[test]
     fn test_provider_name() {
-        let client = ClickUpClient::new("12345", "token");
+        let client = ClickUpClient::new("12345", token("token"));
         assert_eq!(IssueProvider::provider_name(&client), "clickup");
         assert_eq!(MergeRequestProvider::provider_name(&client), "clickup");
     }
@@ -2174,11 +2182,11 @@ mod tests {
         use httpmock::prelude::*;
 
         fn create_test_client(server: &MockServer) -> ClickUpClient {
-            ClickUpClient::with_base_url(server.base_url(), "12345", "pk_test_token")
+            ClickUpClient::with_base_url(server.base_url(), "12345", token("pk_test_token"))
         }
 
         fn create_test_client_with_team(server: &MockServer) -> ClickUpClient {
-            ClickUpClient::with_base_url(server.base_url(), "12345", "pk_test_token")
+            ClickUpClient::with_base_url(server.base_url(), "12345", token("pk_test_token"))
                 .with_team_id("9876")
         }
 
@@ -2398,7 +2406,7 @@ mod tests {
         #[tokio::test]
         async fn test_get_issues_limit_zero() {
             // No server needed — should return immediately without making API calls
-            let client = ClickUpClient::new("12345", "token");
+            let client = ClickUpClient::new("12345", token("token"));
             let issues = client
                 .get_issues(IssueFilter {
                     limit: Some(0),
@@ -2522,7 +2530,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_get_issue_custom_id_without_team_fails() {
-            let client = ClickUpClient::new("12345", "token");
+            let client = ClickUpClient::new("12345", token("token"));
             let result = client.get_issue("DEV-42").await;
             assert!(result.is_err());
         }
@@ -2968,7 +2976,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_mr_methods_unsupported() {
-            let client = ClickUpClient::new("12345", "token");
+            let client = ClickUpClient::new("12345", token("token"));
 
             let result = client.get_merge_requests(MrFilter::default()).await;
             assert!(matches!(

--- a/crates/plugins/api/confluence/Cargo.toml
+++ b/crates/plugins/api/confluence/Cargo.toml
@@ -15,6 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+secrecy.workspace = true
 
 [dev-dependencies]
 httpmock.workspace = true

--- a/crates/plugins/api/confluence/src/client.rs
+++ b/crates/plugins/api/confluence/src/client.rs
@@ -8,17 +8,21 @@ use devboy_core::{
 };
 use reqwest::RequestBuilder;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use crate::DEFAULT_CONFLUENCE_API_PATH;
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub enum ConfluenceAuth {
     None,
-    BearerToken(String),
-    Basic { username: String, password: String },
+    BearerToken(SecretString),
+    Basic {
+        username: String,
+        password: SecretString,
+    },
 }
 
 impl fmt::Debug for ConfluenceAuth {
@@ -31,6 +35,21 @@ impl fmt::Debug for ConfluenceAuth {
                 .field("username", username)
                 .field("password", &"<redacted>")
                 .finish(),
+        }
+    }
+}
+
+impl ConfluenceAuth {
+    /// Build a bearer-token auth from any string-like input.
+    pub fn bearer(token: impl Into<String>) -> Self {
+        Self::BearerToken(SecretString::from(token.into()))
+    }
+
+    /// Build a basic-auth pair from username and password strings.
+    pub fn basic(username: impl Into<String>, password: impl Into<String>) -> Self {
+        Self::Basic {
+            username: username.into(),
+            password: SecretString::from(password.into()),
         }
     }
 }
@@ -256,9 +275,9 @@ impl ConfluenceClient {
 
         match &self.auth {
             ConfluenceAuth::None => request,
-            ConfluenceAuth::BearerToken(token) => request.bearer_auth(token),
+            ConfluenceAuth::BearerToken(token) => request.bearer_auth(token.expose_secret()),
             ConfluenceAuth::Basic { username, password } => {
-                request.basic_auth(username, Some(password))
+                request.basic_auth(username, Some(password.expose_secret()))
             }
         }
     }
@@ -1833,10 +1852,8 @@ mod tests {
 
     #[tokio::test]
     async fn rest_api_url_normalizes_base_url() {
-        let client = ConfluenceClient::new(
-            "https://wiki.example.com/",
-            ConfluenceAuth::BearerToken("token".into()),
-        );
+        let client =
+            ConfluenceClient::new("https://wiki.example.com/", ConfluenceAuth::bearer("token"));
 
         assert_eq!(
             client.rest_api_url("content"),
@@ -1846,11 +1863,9 @@ mod tests {
 
     #[tokio::test]
     async fn rest_api_url_honors_v2_api_version() {
-        let client = ConfluenceClient::new(
-            "https://wiki.example.com/",
-            ConfluenceAuth::BearerToken("token".into()),
-        )
-        .with_api_version(Some("v2"));
+        let client =
+            ConfluenceClient::new("https://wiki.example.com/", ConfluenceAuth::bearer("token"))
+                .with_api_version(Some("v2"));
 
         assert_eq!(
             client.space_api_url("space"),
@@ -1878,11 +1893,9 @@ mod tests {
                 .body(r#"{"results":[],"start":0,"limit":100,"size":0,"_links":{}}"#);
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        )
-        .with_api_version(Some("v2"));
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"))
+                .with_api_version(Some("v2"));
 
         let response = client.get_spaces().await.unwrap();
 
@@ -1903,10 +1916,8 @@ mod tests {
                 .body(r#"{"ok":true}"#);
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let response: EchoResponse = client.get_json("content").await.unwrap();
 
         mock.assert();
@@ -1931,10 +1942,7 @@ mod tests {
 
         let client = ConfluenceClient::new(
             server.base_url(),
-            ConfluenceAuth::Basic {
-                username: "user@example.com".into(),
-                password: "password".into(),
-            },
+            ConfluenceAuth::basic("user@example.com", "password"),
         );
         let response: EchoResponse = client
             .post_json(
@@ -1966,11 +1974,9 @@ mod tests {
         let mut headers = HashMap::new();
         headers.insert("x-proxy-auth".into(), "secret".into());
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        )
-        .with_proxy(headers);
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"))
+                .with_proxy(headers);
         let response: EchoResponse = client.get_json("content").await.unwrap();
 
         mock.assert();
@@ -2009,10 +2015,8 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let result = client.get_spaces().await.unwrap();
 
         mock.assert();
@@ -2069,11 +2073,9 @@ mod tests {
                 .body(r#"{"results":[],"start":0,"limit":25,"size":0,"_links":{}}"#);
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        )
-        .with_api_version(Some("v2"));
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"))
+                .with_api_version(Some("v2"));
         let result = client
             .list_pages(ListPagesParams {
                 space_key: "ENG".into(),
@@ -2117,11 +2119,9 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        )
-        .with_api_version(Some("v2"));
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"))
+                .with_api_version(Some("v2"));
         let result = client
             .list_pages(ListPagesParams {
                 space_key: "ENG".into(),
@@ -2179,10 +2179,8 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let result = client
             .list_pages(ListPagesParams {
                 space_key: "ENG".into(),
@@ -2242,10 +2240,8 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let result = client
             .list_pages(ListPagesParams {
                 space_key: "ENG".into(),
@@ -2306,10 +2302,8 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let result = client
             .list_pages(ListPagesParams {
                 space_key: "ENG".into(),
@@ -2375,10 +2369,8 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let page = client.get_page("42").await.unwrap();
 
         mock.assert();
@@ -2463,11 +2455,9 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        )
-        .with_api_version(Some("v2"));
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"))
+                .with_api_version(Some("v2"));
         let page = client.get_page("42").await.unwrap();
 
         space_mock.assert();
@@ -2529,11 +2519,9 @@ mod tests {
             then.status(401).body("unauthorized");
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        )
-        .with_api_version(Some("v2"));
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"))
+                .with_api_version(Some("v2"));
         let error = client.get_page("42").await.unwrap_err();
 
         space_mock.assert();
@@ -2579,10 +2567,8 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let page = client
             .create_page(CreatePageParams {
                 space_key: "ENG".into(),
@@ -2646,10 +2632,8 @@ mod tests {
                 .body("[]");
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let page = client
             .create_page(CreatePageParams {
                 space_key: "ENG".into(),
@@ -2713,11 +2697,9 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        )
-        .with_api_version(Some("v2"));
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"))
+                .with_api_version(Some("v2"));
         let page = client
             .create_page(CreatePageParams {
                 space_key: "ENG".into(),
@@ -2800,10 +2782,8 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let page = client
             .update_page(UpdatePageParams {
                 page_id: "42".into(),
@@ -2893,11 +2873,9 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        )
-        .with_api_version(Some("v2"));
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"))
+                .with_api_version(Some("v2"));
         let page = client
             .update_page(UpdatePageParams {
                 page_id: "42".into(),
@@ -2947,10 +2925,8 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let error = client
             .update_page(UpdatePageParams {
                 page_id: "42".into(),
@@ -3046,10 +3022,8 @@ mod tests {
                 .body("[]");
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let page = client
             .update_page(UpdatePageParams {
                 page_id: "42".into(),
@@ -3133,10 +3107,8 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let result = client
             .search(SearchKbParams {
                 query: "architecture".into(),
@@ -3204,10 +3176,8 @@ mod tests {
                 );
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let first = client
             .search(SearchKbParams {
                 query: r#"label = "adr""#.into(),
@@ -3261,10 +3231,8 @@ mod tests {
                 .body(r#"{"results":[],"start":0,"limit":5,"size":0,"_links":{}}"#);
         });
 
-        let client = ConfluenceClient::new(
-            server.base_url(),
-            ConfluenceAuth::BearerToken("secret-token".into()),
-        );
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"));
         let result = client
             .search(SearchKbParams {
                 query: "R&D?x=y+z".into(),

--- a/crates/plugins/api/fireflies/Cargo.toml
+++ b/crates/plugins/api/fireflies/Cargo.toml
@@ -12,6 +12,7 @@ serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 chrono = "0.4"
+secrecy.workspace = true
 
 [dev-dependencies]
 httpmock.workspace = true

--- a/crates/plugins/api/fireflies/src/client.rs
+++ b/crates/plugins/api/fireflies/src/client.rs
@@ -5,6 +5,7 @@ use devboy_core::{
     Error, MeetingFilter, MeetingNote, MeetingNotesProvider, MeetingSpeaker, MeetingTranscript,
     ProviderResult, Result, TranscriptSentence,
 };
+use secrecy::{ExposeSecret, SecretString};
 use serde_json::{Value, json};
 use tracing::debug;
 
@@ -77,15 +78,15 @@ query GetTranscript($transcriptId: String!) {
 
 /// Fireflies.ai API client.
 pub struct FirefliesClient {
-    api_key: String,
+    api_key: SecretString,
     api_url: String,
     http: reqwest::Client,
 }
 
 impl FirefliesClient {
-    pub fn new(api_key: &str) -> Self {
+    pub fn new(api_key: SecretString) -> Self {
         Self {
-            api_key: api_key.to_string(),
+            api_key,
             api_url: FIREFLIES_API_URL.to_string(),
             http: reqwest::Client::new(),
         }
@@ -114,7 +115,10 @@ impl FirefliesClient {
         let response = self
             .http
             .post(&self.api_url)
-            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.api_key.expose_secret()),
+            )
             .header("Content-Type", "application/json")
             .json(&body)
             .send()
@@ -398,6 +402,10 @@ fn parse_array_or_string(value: &Value) -> Vec<String> {
 mod tests {
     use super::*;
 
+    fn key(s: &str) -> SecretString {
+        SecretString::from(s.to_string())
+    }
+
     #[test]
     fn test_parse_array_or_string_with_array() {
         let val = json!(["item1", "item2", "item3"]);
@@ -576,13 +584,13 @@ mod tests {
 
     #[test]
     fn test_fireflies_client_new() {
-        let client = FirefliesClient::new("test-key");
+        let client = FirefliesClient::new(key("test-key"));
         assert_eq!(client.provider_name(), "fireflies");
     }
 
     #[test]
     fn test_with_api_url_overrides_endpoint() {
-        let client = FirefliesClient::new("k").with_api_url("http://localhost:1234/gql");
+        let client = FirefliesClient::new(key("k")).with_api_url("http://localhost:1234/gql");
         assert_eq!(client.api_url, "http://localhost:1234/gql");
     }
 
@@ -594,8 +602,12 @@ mod tests {
         use super::*;
         use httpmock::prelude::*;
 
+        fn key(s: &str) -> SecretString {
+            SecretString::from(s.to_string())
+        }
+
         fn mock_client(server: &MockServer) -> FirefliesClient {
-            FirefliesClient::new("test-token").with_api_url(server.url("/gql"))
+            FirefliesClient::new(key("test-token")).with_api_url(server.url("/gql"))
         }
 
         #[tokio::test]

--- a/crates/plugins/api/github/Cargo.toml
+++ b/crates/plugins/api/github/Cargo.toml
@@ -15,6 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+secrecy.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 regex = "1"
 urlencoding = "2"

--- a/crates/plugins/api/github/src/client.rs
+++ b/crates/plugins/api/github/src/client.rs
@@ -9,6 +9,7 @@ use devboy_core::{
     PipelineStage, PipelineStatus, PipelineSummary, Provider, ProviderResult, Result,
     UpdateIssueInput, UpdateMergeRequestInput, User, parse_markdown_attachments,
 };
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use tracing::{debug, warn};
 
@@ -24,17 +25,13 @@ pub struct GitHubClient {
     base_url: String,
     owner: String,
     repo: String,
-    token: String,
+    token: SecretString,
     client: reqwest::Client,
 }
 
 impl GitHubClient {
     /// Create a new GitHub client.
-    pub fn new(
-        owner: impl Into<String>,
-        repo: impl Into<String>,
-        token: impl Into<String>,
-    ) -> Self {
+    pub fn new(owner: impl Into<String>, repo: impl Into<String>, token: SecretString) -> Self {
         Self::with_base_url(DEFAULT_GITHUB_URL, owner, repo, token)
     }
 
@@ -43,13 +40,13 @@ impl GitHubClient {
         base_url: impl Into<String>,
         owner: impl Into<String>,
         repo: impl Into<String>,
-        token: impl Into<String>,
+        token: SecretString,
     ) -> Self {
         Self {
             base_url: base_url.into().trim_end_matches('/').to_string(),
             owner: owner.into(),
             repo: repo.into(),
-            token: token.into(),
+            token,
             client: reqwest::Client::builder()
                 .user_agent("devboy-tools")
                 .build()
@@ -65,8 +62,9 @@ impl GitHubClient {
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28");
 
-        if !self.token.is_empty() {
-            builder = builder.header("Authorization", format!("Bearer {}", self.token));
+        let token = self.token.expose_secret();
+        if !token.is_empty() {
+            builder = builder.header("Authorization", format!("Bearer {}", token));
         }
 
         builder
@@ -897,7 +895,7 @@ const GITHUB_TRUSTED_HOSTS: &[&str] = &[
 async fn download_github_url(
     client: &reqwest::Client,
     base_url: &str,
-    token: &str,
+    token: &SecretString,
     url: &str,
 ) -> Result<Vec<u8>> {
     let needs_auth = is_github_api_host(base_url, url);
@@ -905,8 +903,9 @@ async fn download_github_url(
         .get(url)
         .header("Accept", "application/octet-stream")
         .header("User-Agent", "devboy-tools");
-    if needs_auth && !token.is_empty() {
-        request = request.header("Authorization", format!("Bearer {token}"));
+    let token_value = token.expose_secret();
+    if needs_auth && !token_value.is_empty() {
+        request = request.header("Authorization", format!("Bearer {token_value}"));
     } else if !is_github_trusted_host(base_url, url) {
         tracing::warn!(
             url,
@@ -2034,10 +2033,14 @@ mod tests {
         assert_eq!(pr.state, "closed");
     }
 
+    fn token(s: &str) -> SecretString {
+        SecretString::from(s.to_string())
+    }
+
     #[test]
     fn test_repo_url() {
         let client =
-            GitHubClient::with_base_url("https://api.github.com", "owner", "repo", "token");
+            GitHubClient::with_base_url("https://api.github.com", "owner", "repo", token("token"));
         assert_eq!(
             client.repo_url("/issues"),
             "https://api.github.com/repos/owner/repo/issues"
@@ -2051,7 +2054,7 @@ mod tests {
     #[test]
     fn test_repo_url_strips_trailing_slash() {
         let client =
-            GitHubClient::with_base_url("https://api.github.com/", "owner", "repo", "token");
+            GitHubClient::with_base_url("https://api.github.com/", "owner", "repo", token("token"));
         assert_eq!(
             client.repo_url("/issues"),
             "https://api.github.com/repos/owner/repo/issues"
@@ -2060,7 +2063,7 @@ mod tests {
 
     #[test]
     fn test_provider_name() {
-        let client = GitHubClient::new("owner", "repo", "token");
+        let client = GitHubClient::new("owner", "repo", token("token"));
         assert_eq!(IssueProvider::provider_name(&client), "github");
         assert_eq!(MergeRequestProvider::provider_name(&client), "github");
     }
@@ -2074,7 +2077,7 @@ mod tests {
         use httpmock::prelude::*;
 
         fn create_test_client(server: &MockServer) -> GitHubClient {
-            GitHubClient::with_base_url(server.base_url(), "owner", "repo", "test-token")
+            GitHubClient::with_base_url(server.base_url(), "owner", "repo", token("test-token"))
         }
 
         fn sample_issue_json() -> serde_json::Value {

--- a/crates/plugins/api/gitlab/Cargo.toml
+++ b/crates/plugins/api/gitlab/Cargo.toml
@@ -15,6 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+secrecy.workspace = true
 regex = "1"
 urlencoding = "2"
 

--- a/crates/plugins/api/gitlab/src/client.rs
+++ b/crates/plugins/api/gitlab/src/client.rs
@@ -9,6 +9,7 @@ use devboy_core::{
     PipelineStage, PipelineStatus, PipelineSummary, Provider, ProviderResult, Result,
     UpdateIssueInput, User, parse_markdown_attachments,
 };
+use secrecy::{ExposeSecret, SecretString};
 use tracing::{debug, warn};
 
 use crate::DEFAULT_GITLAB_URL;
@@ -22,14 +23,14 @@ use crate::types::{
 pub struct GitLabClient {
     base_url: String,
     project_id: String,
-    token: String,
+    token: SecretString,
     proxy_headers: Option<std::collections::HashMap<String, String>>,
     client: reqwest::Client,
 }
 
 impl GitLabClient {
     /// Create a new GitLab client.
-    pub fn new(project_id: impl Into<String>, token: impl Into<String>) -> Self {
+    pub fn new(project_id: impl Into<String>, token: SecretString) -> Self {
         Self::with_base_url(DEFAULT_GITLAB_URL, project_id, token)
     }
 
@@ -37,12 +38,12 @@ impl GitLabClient {
     pub fn with_base_url(
         base_url: impl Into<String>,
         project_id: impl Into<String>,
-        token: impl Into<String>,
+        token: SecretString,
     ) -> Self {
         Self {
             base_url: base_url.into().trim_end_matches('/').to_string(),
             project_id: project_id.into(),
-            token: token.into(),
+            token,
             proxy_headers: None,
             client: reqwest::Client::new(),
         }
@@ -67,7 +68,7 @@ impl GitLabClient {
                 req = req.header(key.as_str(), value.as_str());
             }
         } else {
-            req = req.header("PRIVATE-TOKEN", &self.token);
+            req = req.header("PRIVATE-TOKEN", self.token.expose_secret());
         }
         req
     }
@@ -1922,8 +1923,12 @@ mod tests {
         use super::*;
         use httpmock::prelude::*;
 
+        fn token(s: &str) -> SecretString {
+            SecretString::from(s.to_string())
+        }
+
         fn create_test_client(server: &MockServer) -> GitLabClient {
-            GitLabClient::with_base_url(server.base_url(), "123", "test-token")
+            GitLabClient::with_base_url(server.base_url(), "123", token("test-token"))
         }
 
         #[tokio::test]

--- a/crates/plugins/api/jira/Cargo.toml
+++ b/crates/plugins/api/jira/Cargo.toml
@@ -15,6 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+secrecy.workspace = true
 
 [dev-dependencies]
 httpmock.workspace = true

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -25,6 +25,7 @@ use devboy_core::{
     StructureForest, StructureNode, StructureRowValues, StructureValues, StructureView,
     StructureViewColumn, UpdateIssueInput, User,
 };
+use secrecy::{ExposeSecret, SecretString};
 use tracing::{debug, warn};
 
 use crate::types::{
@@ -56,7 +57,7 @@ pub struct JiraClient {
     instance_url: String,
     project_key: String,
     email: String,
-    token: String,
+    token: SecretString,
     flavor: JiraFlavor,
     proxy_headers: Option<std::collections::HashMap<String, String>>,
     client: reqwest::Client,
@@ -68,7 +69,7 @@ impl JiraClient {
         url: impl Into<String>,
         project_key: impl Into<String>,
         email: impl Into<String>,
-        token: impl Into<String>,
+        token: SecretString,
     ) -> Self {
         let url = url.into();
         let flavor = detect_flavor(&url);
@@ -79,7 +80,7 @@ impl JiraClient {
             instance_url: instance,
             project_key: project_key.into(),
             email: email.into(),
-            token: token.into(),
+            token,
             flavor,
             proxy_headers: None,
             client: reqwest::Client::builder()
@@ -124,7 +125,7 @@ impl JiraClient {
         base_url: impl Into<String>,
         project_key: impl Into<String>,
         email: impl Into<String>,
-        token: impl Into<String>,
+        token: SecretString,
         flavor: bool, // true = Cloud, false = SelfHosted
     ) -> Self {
         let url = base_url.into().trim_end_matches('/').to_string();
@@ -133,7 +134,7 @@ impl JiraClient {
             base_url: url,
             project_key: project_key.into(),
             email: email.into(),
-            token: token.into(),
+            token,
             flavor: if flavor {
                 JiraFlavor::Cloud
             } else {
@@ -170,15 +171,17 @@ impl JiraClient {
         } else {
             builder = match self.flavor {
                 JiraFlavor::Cloud => {
-                    let credentials = base64_encode(&format!("{}:{}", self.email, self.token));
+                    let token_value = self.token.expose_secret();
+                    let credentials = base64_encode(&format!("{}:{}", self.email, token_value));
                     builder.header("Authorization", format!("Basic {}", credentials))
                 }
                 JiraFlavor::SelfHosted => {
-                    if self.token.contains(':') {
-                        let credentials = base64_encode(&self.token);
+                    let token_value = self.token.expose_secret();
+                    if token_value.contains(':') {
+                        let credentials = base64_encode(token_value);
                         builder.header("Authorization", format!("Basic {}", credentials))
                     } else {
-                        builder.header("Authorization", format!("Bearer {}", self.token))
+                        builder.header("Authorization", format!("Bearer {}", token_value))
                     }
                 }
             };
@@ -2627,6 +2630,10 @@ mod tests {
     use crate::types::*;
     use devboy_core::{CreateCommentInput, MrFilter};
 
+    fn token(s: &str) -> SecretString {
+        SecretString::from(s.to_string())
+    }
+
     // =========================================================================
     // Structure error mapping tests
     // =========================================================================
@@ -2847,7 +2854,7 @@ mod tests {
             "http://localhost",
             "PROJ",
             "user@example.com",
-            "api-token-123",
+            token("api-token-123"),
             true,
         );
         // Cloud uses Basic auth with email:token
@@ -2869,7 +2876,7 @@ mod tests {
             "http://localhost",
             "PROJ",
             "user@example.com",
-            "personal-access-token",
+            token("personal-access-token"),
             false,
         );
         let req = client.request(reqwest::Method::GET, "http://localhost/test");
@@ -2889,7 +2896,7 @@ mod tests {
             "http://localhost",
             "PROJ",
             "user@example.com",
-            "user:password",
+            token("user:password"),
             false,
         );
         let expected = base64_encode("user:password");
@@ -3301,7 +3308,7 @@ mod tests {
             "http://localhost",
             "PROJ",
             "user@example.com",
-            "token",
+            token("token"),
             false,
         );
         assert_eq!(IssueProvider::provider_name(&client), "jira");
@@ -3386,12 +3393,16 @@ mod tests {
         use super::*;
         use httpmock::prelude::*;
 
+        fn token(s: &str) -> SecretString {
+            SecretString::from(s.to_string())
+        }
+
         fn create_self_hosted_client(server: &MockServer) -> JiraClient {
             JiraClient::with_base_url(
                 server.base_url(),
                 "PROJ",
                 "user@example.com",
-                "pat-token",
+                token("pat-token"),
                 false,
             )
         }
@@ -3401,7 +3412,7 @@ mod tests {
                 server.base_url(),
                 "PROJ",
                 "user@example.com",
-                "api-token",
+                token("api-token"),
                 true,
             )
         }
@@ -4831,7 +4842,7 @@ mod tests {
                 "http://localhost",
                 "PROJ",
                 "user@example.com",
-                "token",
+                token("token"),
                 false,
             );
 
@@ -5978,6 +5989,10 @@ mod tests {
         use devboy_core::StructureRowItem;
         use httpmock::prelude::*;
 
+        fn token(s: &str) -> SecretString {
+            SecretString::from(s.to_string())
+        }
+
         fn create_client(server: &MockServer) -> JiraClient {
             // with_base_url sets base_url WITHOUT /rest/api/N,
             // but Structure uses instance_url. Adjust:
@@ -5987,7 +6002,7 @@ mod tests {
                 server.base_url(),
                 "PROJ",
                 "user@example.com",
-                "token",
+                token("token"),
                 false,
             )
         }
@@ -6530,12 +6545,16 @@ mod tests {
         use super::*;
         use httpmock::prelude::*;
 
+        fn token(s: &str) -> SecretString {
+            SecretString::from(s.to_string())
+        }
+
         fn create_client(server: &MockServer) -> JiraClient {
             JiraClient::with_base_url(
                 server.base_url(),
                 "PROJ",
                 "user@example.com",
-                "token",
+                token("token"),
                 false,
             )
         }

--- a/crates/plugins/api/slack/Cargo.toml
+++ b/crates/plugins/api/slack/Cargo.toml
@@ -15,6 +15,7 @@ serde_json.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 tokio.workspace = true
+secrecy.workspace = true
 
 [dev-dependencies]
 httpmock.workspace = true

--- a/crates/plugins/api/slack/src/client.rs
+++ b/crates/plugins/api/slack/src/client.rs
@@ -11,6 +11,7 @@ use devboy_core::{
     SendMessageParams,
 };
 use reqwest::header::HeaderMap;
+use secrecy::{ExposeSecret, SecretString};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock};
@@ -33,7 +34,7 @@ pub struct SlackAuthInfo {
 
 #[derive(Clone)]
 pub struct SlackClient {
-    token: String,
+    token: SecretString,
     base_url: String,
     http: reqwest::Client,
     required_scopes: Vec<String>,
@@ -232,9 +233,9 @@ struct SlackRichAttachment {
 }
 
 impl SlackClient {
-    pub fn new(token: impl Into<String>) -> Self {
+    pub fn new(token: SecretString) -> Self {
         Self {
-            token: token.into(),
+            token,
             base_url: DEFAULT_SLACK_API_URL.to_string(),
             http: reqwest::Client::new(),
             required_scopes: devboy_core::default_slack_required_scopes(),
@@ -337,7 +338,7 @@ impl SlackClient {
             let response = self
                 .http
                 .post(&url)
-                .bearer_auth(&self.token)
+                .bearer_auth(self.token.expose_secret())
                 .form(params)
                 .send()
                 .await
@@ -1283,6 +1284,10 @@ mod tests {
     use httpmock::Method::POST;
     use httpmock::MockServer;
 
+    fn token(s: &str) -> SecretString {
+        SecretString::from(s.to_string())
+    }
+
     #[tokio::test]
     async fn auth_info_reads_identity_and_scopes() {
         let server = MockServer::start();
@@ -1304,7 +1309,7 @@ mod tests {
                 }));
         });
 
-        let info = SlackClient::new("xoxb-test")
+        let info = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .auth_info()
             .await
@@ -1330,7 +1335,7 @@ mod tests {
                 }));
         });
 
-        let error = SlackClient::new("xoxb-test")
+        let error = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .ensure_healthy()
             .await
@@ -1360,7 +1365,7 @@ mod tests {
             }));
         });
 
-        let result = SlackClient::new("xoxb-test")
+        let result = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .get_chats(GetChatsParams::default())
             .await
@@ -1418,7 +1423,7 @@ mod tests {
             }));
         });
 
-        let result = SlackClient::new("xoxb-test")
+        let result = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .get_messages(GetMessagesParams {
                 chat_id: "C123".to_string(),
@@ -1467,7 +1472,7 @@ mod tests {
             }));
         });
 
-        let result = SlackClient::new("xoxb-test")
+        let result = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .send_message(SendMessageParams {
                 chat_id: "C123".to_string(),
@@ -1500,7 +1505,7 @@ mod tests {
             }));
         });
 
-        let result = SlackClient::new("xoxb-test")
+        let result = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .send_message(SendMessageParams {
                 chat_id: "C123".to_string(),
@@ -1519,7 +1524,7 @@ mod tests {
 
     #[tokio::test]
     async fn send_message_rejects_attachments() {
-        let err = SlackClient::new("xoxb-test")
+        let err = SlackClient::new(token("xoxb-test"))
             .send_message(SendMessageParams {
                 chat_id: "C123".to_string(),
                 text: "reply message".to_string(),
@@ -1578,7 +1583,7 @@ mod tests {
             }));
         });
 
-        let client = SlackClient::new("xoxb-test").with_base_url(server.base_url());
+        let client = SlackClient::new(token("xoxb-test")).with_base_url(server.base_url());
         let result = client
             .get_messages(GetMessagesParams {
                 chat_id: "C123".to_string(),
@@ -1599,7 +1604,7 @@ mod tests {
 
     #[test]
     fn client_configuration_helpers_update_settings() {
-        let client = SlackClient::new("xoxb-test")
+        let client = SlackClient::new(token("xoxb-test"))
             .with_base_url("https://slack.example.test/")
             .with_required_scopes(vec!["search:read".to_string(), "chat:write".to_string()]);
 
@@ -1621,7 +1626,7 @@ mod tests {
             }));
         });
 
-        let error = SlackClient::new("xoxb-test")
+        let error = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .auth_info()
             .await
@@ -1641,7 +1646,7 @@ mod tests {
             }));
         });
 
-        let error = SlackClient::new("xoxb-test")
+        let error = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .auth_info()
             .await
@@ -1658,7 +1663,7 @@ mod tests {
             then.status(429).header("retry-after", "7");
         });
 
-        let error = SlackClient::new("xoxb-test")
+        let error = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .auth_info()
             .await
@@ -1674,7 +1679,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_messages_rejects_empty_query() {
-        let error = SlackClient::new("xoxb-test")
+        let error = SlackClient::new(token("xoxb-test"))
             .search_messages(SearchMessagesParams {
                 query: "   ".to_string(),
                 ..SearchMessagesParams::default()
@@ -1714,7 +1719,7 @@ mod tests {
             }));
         });
 
-        let client = SlackClient::new("xoxb-test").with_base_url(server.base_url());
+        let client = SlackClient::new(token("xoxb-test")).with_base_url(server.base_url());
         let first = client
             .search_messages(SearchMessagesParams {
                 query: "needle".to_string(),
@@ -1759,7 +1764,7 @@ mod tests {
             }));
         });
 
-        let client = SlackClient::new("xoxb-test").with_base_url(server.base_url());
+        let client = SlackClient::new(token("xoxb-test")).with_base_url(server.base_url());
         let first = client
             .search_messages(SearchMessagesParams {
                 chat_id: Some("C1".to_string()),
@@ -2142,7 +2147,7 @@ mod tests {
             }));
         });
 
-        let user = SlackClient::new("xoxb-test")
+        let user = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .get_user_profile("U1")
             .await
@@ -2167,7 +2172,7 @@ mod tests {
             }));
         });
 
-        let result = SlackClient::new("xoxb-test")
+        let result = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .lookup_user_by_email("missing@example.com")
             .await
@@ -2197,7 +2202,7 @@ mod tests {
             }));
         });
 
-        let user = SlackClient::new("xoxb-test")
+        let user = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .lookup_user_by_email("bob@example.com")
             .await
@@ -2222,7 +2227,7 @@ mod tests {
             }));
         });
 
-        let err = SlackClient::new("xoxb-test")
+        let err = SlackClient::new(token("xoxb-test"))
             .with_base_url(server.base_url())
             .lookup_user_by_email("alice@example.com")
             .await

--- a/docs/architecture/adr/ADR-019-secret-string-discipline.md
+++ b/docs/architecture/adr/ADR-019-secret-string-discipline.md
@@ -1,0 +1,196 @@
+---
+id: ADR-019
+title: Secrets carry SecretString end-to-end
+status: accepted
+date: 2026-05-02
+deciders: ["meteora-pro/devboy-tools maintainers"]
+tags: ["security", "core", "storage", "providers"]
+supersedes: null
+superseded_by: null
+---
+
+# ADR-019: Secrets carry SecretString end-to-end
+
+## Status
+
+**accepted**
+
+## Context
+
+Plain `String` for a secret leaks through several routes that no amount of
+discipline at the call site can fully close:
+
+- **`Debug` derives.** A stray `tracing::debug!("client = {:?}", client)` puts
+  the token in the log. Several provider clients used `derive(Debug)` on
+  structs whose token field was just `String`.
+- **Memory dumps and core files.** Plain `String` heap allocations stay live
+  until the allocator overwrites them. `SecretBox` (the type behind
+  `SecretString`) calls `Zeroize::zeroize` on `Drop`.
+- **Snapshot or fixture serialization.** `serde_json::to_string(&config)`
+  happily emits the plaintext. Several test fixtures and a few real call
+  paths went through `serde_json` round-trips with secrets in the struct.
+- **`.clone()` proliferation.** Each clone is another copy of the secret on
+  the heap. Wrapping the secret prompts the question "should I really be
+  cloning this here?" instead of doing it implicitly.
+
+The previous discipline relied on `#[serde(skip_serializing)]` on individual
+fields and reviewer attention. That worked but is fragile: a new contributor
+adding a struct that "just holds a token" doesn't necessarily know the rule.
+Issue #225 was filed after PR #212 review surfaced one such drift in the
+Confluence client.
+
+## Decision
+
+> **Decision:** Every secret in `crates/` is carried as
+> `secrecy::SecretString` (or a wrapper that redacts on `Debug` and zeroizes
+> on `Drop`) end-to-end — from `CredentialStore::get` to the HTTP call site.
+> The plaintext is exposed only through `.expose_secret()` at the smallest
+> possible scope.
+
+Specifically:
+
+- **Storage** — `CredentialStore::get` returns `Option<SecretString>`,
+  `CredentialStore::store` accepts `&SecretString`. The keychain wrapper, the
+  env-var wrapper, the in-memory cache (`CachedStore`) and `ChainStore` all
+  preserve the type end-to-end.
+- **Provider clients** — every `Client::new` constructor takes the token by
+  value as `SecretString`. The internal field is `SecretString`. Auth
+  headers / `bearer_auth` / `basic_auth` calls invoke `.expose_secret()`
+  inline; no helper holds the plaintext.
+- **Executor context** — `ProviderConfig` variants store
+  `access_token: SecretString`, `api_key: SecretString`,
+  `password: SecretString`. `ConfluenceAuthConfig::{BearerToken, Basic}`
+  carry `SecretString` for token / password.
+- **MCP proxy** — `McpProxyClient::connect` takes `Option<&SecretString>`.
+- **Telemetry** — `TelemetryAuth::bearer_token` is `Option<SecretString>`.
+- **`AdditionalContext` / `ProviderConfig`** — these structs intentionally
+  drop their previous `Serialize` / `Deserialize` derives. They carry
+  plaintext access tokens; serializing them to JSON would defeat the
+  discipline. Construct provider configs in-process from `Config` plus
+  `CredentialStore`, never round-trip through a transport.
+- **`SentryConfig.dsn`** — kept as `Option<String>` because the on-disk TOML
+  config must round-trip the value. The `Debug` impl is hand-written to
+  redact the DSN; the userinfo segment of a Sentry DSN is the auth token.
+
+A CI gate (`secrets-discipline` job in `.github/workflows/ci.yml`) greps for
+`(token|api_key|password|secret|client_secret|access_token|refresh_token|bearer_token):\s*(Option<)?\s*String`
+in non-test source under `crates/` and fails the build if any match exists.
+The CLI binary `crates/devboy-cli/src/main.rs` is exempted because clap value
+parsers operate on `String` at the user-input boundary; that string is
+wrapped in `SecretString` immediately on use and never persisted as a
+plaintext field. Tests are exempted because their fixtures pre-wrap the
+literal at the field boundary.
+
+## Consequences
+
+### Positive
+
+- ✅ `Debug` of every config struct redacts secrets — every previous
+  hand-rolled `Debug` in provider clients now collapses into the standard
+  `derive(Debug)` because the inner `SecretString` does the right thing.
+- ✅ `serde_json::to_string` of a `ProviderConfig` is a compile error
+  (no `Serialize` impl) instead of a silent leak through the wire format.
+- ✅ Heap buffers holding tokens are zeroized on drop — meaningful for
+  memory-dump and core-file forensics.
+- ✅ Clone is explicit (`access_token.clone()` in `factory.rs`) — every
+  duplicate of the secret is visible in code review.
+- ✅ A single CI grep gate prevents drift; the rule is enforced rather than
+  remembered.
+
+### Negative
+
+- ❌ One ~50 KB dependency (`secrecy = "0.10"`) added to the workspace.
+- ❌ One `.expose_secret()` call at every HTTP call site (6 provider
+  clients, MCP proxy, telemetry uploader, Sentry DSN init).
+- ❌ `ProviderConfig` and `AdditionalContext` lost their `Serialize` /
+  `Deserialize` impls. If a future feature needs to serialize them across
+  process boundaries, a wrapper that explicitly opts in to serialization
+  has to be introduced (and reviewed against this ADR).
+
+### Risks
+
+- ⚠️ **Drift via new struct.** A contributor adds `MyProviderClient` with
+  `token: String`, the CI grep gate catches it.
+- ⚠️ **`.expose_secret()` in the wrong place.** The token must not be
+  copied into a `String` for logging or constructing intermediate values.
+  Mitigation: `.expose_secret()` returns `&str`, so the natural usage is
+  `format!("Bearer {}", token.expose_secret())` inline at the call site.
+  Code review checks for `expose_secret().to_string()` patterns — those
+  are usually a smell.
+- ⚠️ **TOML config still stores DSN in plaintext.** `SentryConfig.dsn`
+  stays `Option<String>` because `secrecy::SecretBox<str>` does not
+  implement `serde::Serialize` (the inner `str` is unsized and is not
+  `SerializableSecret`). The hand-written `Debug` impl redacts it, but
+  on-disk config files still contain the DSN literally — that's the same
+  exposure surface as any other dotfile under `~/.devboy/`.
+
+## Alternatives Considered
+
+### Alternative 1: Keep `String`, document the convention
+
+**Description:** Stay with plain `String` and rely on
+`#[serde(skip_serializing)]` plus reviewer attention to keep tokens out of
+logs and serialized output.
+
+**Why rejected:** This was the prior state. PR #212 review showed it had
+silently regressed in several places. The discipline lasts only as long as
+every reviewer remembers it on every PR.
+
+### Alternative 2: Custom newtype that implements `SerializableSecret`
+
+**Description:** Define `SerializableSecretString` as a wrapper around
+`SecretBox<SecretInner>` where `SecretInner: SerializableSecret`. This would
+let `ProviderConfig` keep `Serialize` / `Deserialize` and still carry the
+secret type-safely.
+
+**Why rejected:** Cross-process serialization of `ProviderConfig` is not a
+production code path today (only test fixtures used to round-trip it).
+Adding the wrapper would create a parallel "secret-but-serializable" type
+that downstream code would copy from instead of reaching for the standard
+`SecretString`. If the need ever arises, the wrapper can be introduced as a
+separate decision; right now removing the unused `Serialize` derive is
+cleaner.
+
+### Alternative 3: Use `zeroize::Zeroizing<String>` directly
+
+**Description:** Avoid the `secrecy` dependency entirely; use
+`Zeroizing<String>` so the heap buffer is wiped on drop, and rely on
+discipline to keep `Debug` clean.
+
+**Why rejected:** `Zeroizing<String>` does **not** redact `Debug` — it
+prints the inner value verbatim. The Debug-redaction property is the more
+valuable half of the discipline; losing it for a smaller dependency
+surface area is the wrong trade.
+
+## Implementation
+
+- **Issues:** [#225](https://github.com/meteora-pro/devboy-tools/issues/225)
+- **PR:** to be filed against `meteora-pro/devboy-tools`
+- **Code:**
+  - `crates/devboy-storage/src/lib.rs` — `CredentialStore` trait
+  - `crates/devboy-storage/src/cache.rs` — `CachedStore`
+  - `crates/devboy-executor/src/context.rs` — `ProviderConfig`,
+    `ConfluenceAuthConfig`, `AdditionalContext`
+  - `crates/plugins/api/{github,gitlab,clickup,jira,confluence,fireflies,slack}/src/client.rs`
+  - `crates/devboy-mcp/src/proxy.rs` — `McpProxyClient::connect`
+  - `crates/devboy-mcp/src/telemetry.rs` — `TelemetryAuth`
+  - `crates/devboy-core/src/config.rs` — `SentryConfig` Debug impl
+  - `crates/llm-eval/src/main.rs` — `ModelConfig.api_key`
+  - `.github/workflows/ci.yml` — `secrets-discipline` job
+
+## References
+
+- [`secrecy` crate documentation](https://docs.rs/secrecy/)
+- [`zeroize` crate documentation](https://docs.rs/zeroize/)
+- [Original PR #212 review comment](https://github.com/meteora-pro/devboy-tools/pull/212#discussion_r3172347974) — the trigger for issue #225
+- [ADR-005: Credential storage](./ADR-005-credential-storage.md) — describes
+  where secrets *live* (keychain + env vars); this ADR describes how
+  secrets are *typed in transit* through the process
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-02 | meteora-pro/devboy-tools | Initial version |

--- a/docs/architecture/adr/INDEX.md
+++ b/docs/architecture/adr/INDEX.md
@@ -20,6 +20,7 @@ This directory holds Architecture Decision Records (ADRs) for `devboy-tools`. Ea
 | [016](./ADR-016-skills-language-adaptation.md) | Skills language adaptation | proposed | Skills (deferred) |
 | [017](./ADR-017-agent-detection-and-onboard.md) | Agent detection and `devboy onboard` command | proposed | Onboarding, Skills |
 | [018](./ADR-018-plugin-distribution.md) | Distribution as Claude Code and Codex plugins with agent-driven bootstrap | proposed | Distribution, Onboarding |
+| [019](./ADR-019-secret-string-discipline.md) | Secrets carry `SecretString` end-to-end | accepted | Security, Storage, Providers |
 
 **Number gaps** (006, 008, 009, 011) are intentional. Those numbers are reserved for decisions that are not in scope for this project.
 


### PR DESCRIPTION
## Summary

Closes #225. Replaces plain `String` with `secrecy::SecretString` for every credential carried inside the process — storage trait, provider clients, executor context, MCP proxy, telemetry uploader, llm-eval. `SentryConfig.dsn` keeps its serde shape but gets a manual `Debug` impl that redacts the DSN. Adds a CI grep gate (`secrets-discipline` job) and ADR-019 so the rule is enforced rather than remembered.

## Why

- `Debug` derives leaked tokens through stray `tracing::debug!`.
- Heap buffers stayed live until the allocator overwrote them — `SecretBox` zeroizes on drop.
- `serde_json::to_string(&config)` happily emitted plaintext.
- The previous discipline relied on `#[serde(skip_serializing)]` plus reviewer attention, which had silently regressed across multiple provider clients (PR #212 review surfaced the latest example).

## Layered changes

- **`crates/devboy-storage`** — `CredentialStore::get` returns `Option<SecretString>`; `store` takes `&SecretString`. `KeychainStore`, `MemoryStore`, `EnvVarStore`, `ChainStore`, and `CachedStore` all preserve the type. Cache replaces `Zeroizing<String>` with `SecretString`.
- **Provider clients** (`github`, `gitlab`, `clickup`, `jira`, `confluence`, `fireflies`, `slack`) — every `Client::new` constructor now takes `SecretString`; the internal field is `SecretString`; auth headers call `.expose_secret()` inline. `ConfluenceAuth` gains `bearer()` / `basic()` builders so call sites stay ergonomic.
- **`devboy-executor`** — `ProviderConfig` variants and `ConfluenceAuthConfig` carry `SecretString`. `ProviderConfig`, `AdditionalContext`, and `ConfluenceAuthConfig` intentionally **drop their `Serialize`/`Deserialize` derives** — these structs hold plaintext access tokens with no production serialization path; tests that round-tripped them through `serde_json` are replaced with Debug-redaction assertions. `factory.rs` clones the secret at the seam where a provider client takes ownership.
- **`devboy-mcp`** — `McpProxyClient::connect` takes `Option<&SecretString>`; `TelemetryAuth.bearer_token` is `Option<SecretString>`.
- **`devboy-cli`** — `doctor/checks` adapts; `resolve_secret` returns `ResolvedSecret { value: SecretString }`; provider connectivity helpers expose the secret only at the HTTP boundary; `get_token_for_context` returns `Option<SecretString>`. Integration tests gain an `assert_secret_eq` helper so the comparisons stay readable. Clap-arg fields keep `Option<String>` because the user-input boundary is `String`; that string is wrapped in `SecretString` immediately on use and never persisted.
- **`llm-eval`** — `ModelConfig.api_key` becomes `SecretString` (eval-only binary, but follows the same rule for consistency).
- **`devboy-core/config.rs`** — `SentryConfig` keeps `dsn: Option<String>` (must round-trip through on-disk TOML) but gets a hand-written `Debug` impl that redacts the DSN, since the userinfo segment is the auth key.
- **`Cargo.toml`** — adds `secrecy = "0.10"` with the `serde` feature to the workspace.
- **`.github/workflows/ci.yml`** — new `secrets-discipline` job greps for `(token|api_key|password|secret|client_secret|access_token|refresh_token|bearer_token)\s*:\s*(Option<)?\s*String` in non-test source under `crates/` and fails on any match. `crates/devboy-cli/src/main.rs` is exempted (clap input boundary). Tests are exempted (fixtures pre-wrap at the field boundary).
- **`docs/architecture/adr/ADR-019-secret-string-discipline.md`** — accepted ADR with full rationale, carve-outs, and rejected alternatives.

## Verification

- `cargo build --workspace` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` — **2113 tests pass, 0 failures**.
- New Debug-redaction tests confirm that `format!("{:?}", ProviderConfig::GitLab { access_token: …, … })` and `format!("{:?}", ConfluenceAuthConfig::Basic { password: …, … })` do not contain the plaintext secret.
- CI grep gate verified locally: pattern matches none of the non-test sources after the migration.

## Out of scope

- Encrypting tokens at rest in the OS keychain — keychain already handles that.
- Rotating tokens / fingerprint-based revocation.
- Migrating away from PAT / API key auth altogether (OAuth, OIDC).
- Cross-process serialization of `ProviderConfig` — if a future feature needs it, ADR-019 calls out that a wrapper opting in to serialization must be added as a separate decision.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Local check that `secrets-discipline` CI grep gate finds no leaks
- [ ] CI passes on this PR