### PR TITLE
fix(analyze-usage): count MCP-mediated MR/PR/issue creates (closes #235)

### DIFF
--- a/.claude/skills/analyze-usage/scripts/extract_outputs.py
+++ b/.claude/skills/analyze-usage/scripts/extract_outputs.py
@@ -42,17 +42,23 @@ RX_BRANCH = re.compile(
 )
 RX_ISSUE = re.compile(r"(DEV-\d+|CU-[\w]+|JIRA-\d+|GH-\d+|#\d+)", re.I)
 
-# MCP-mediated MR/PR/issue creation tool names. Anchored on `_request$` /
-# `_issue$` so we don't match the comment / discussion variants
-# (`*_merge_request_comment`, `*_pull_request_review_comment`,
-# `*_issue_comment`) — those are counted as comments, not creates.
+# MCP-mediated MR/PR/issue creation tool names. The create regexes anchor
+# on `_merge_request$` / `_pull_request$` / `_issue$` (the full bare
+# nouns), so a sibling tool whose name extends past the create noun —
+# `..._merge_request_comment`, `..._pull_request_review_comment`,
+# `..._issue_comment` — does not overmatch as a create. Those comment
+# variants are caught by `RX_MCP_COMMENT` below and counted as comments.
 # Captures `create`, `open`, `submit` verbs to cover GitHub/GitLab/Jira
 # server naming conventions (issue #235).
 RX_MCP_MR_CREATE = re.compile(r"^mcp__.*__(create|open|submit)_merge_request$")
 RX_MCP_PR_CREATE = re.compile(r"^mcp__.*__(create|open|submit)_pull_request$")
 RX_MCP_ISSUE_CREATE = re.compile(r"^mcp__.*__(create|open|submit)_issue$")
+# Comment / discussion variants. The optional `_review` segment also
+# catches `pull_request_review_comment` (GitHub's inline-review comments)
+# so they roll up alongside top-level PR/MR/issue comments.
 RX_MCP_COMMENT = re.compile(
-    r"^mcp__.*__(create|add|post)_(merge_request|pull_request|issue)_comment$"
+    r"^mcp__.*__(create|add|post)_"
+    r"(merge_request|pull_request(_review)?|issue)_comment$"
 )
 
 

--- a/.claude/skills/analyze-usage/scripts/extract_outputs.py
+++ b/.claude/skills/analyze-usage/scripts/extract_outputs.py
@@ -42,6 +42,19 @@ RX_BRANCH = re.compile(
 )
 RX_ISSUE = re.compile(r"(DEV-\d+|CU-[\w]+|JIRA-\d+|GH-\d+|#\d+)", re.I)
 
+# MCP-mediated MR/PR/issue creation tool names. Anchored on `_request$` /
+# `_issue$` so we don't match the comment / discussion variants
+# (`*_merge_request_comment`, `*_pull_request_review_comment`,
+# `*_issue_comment`) — those are counted as comments, not creates.
+# Captures `create`, `open`, `submit` verbs to cover GitHub/GitLab/Jira
+# server naming conventions (issue #235).
+RX_MCP_MR_CREATE = re.compile(r"^mcp__.*__(create|open|submit)_merge_request$")
+RX_MCP_PR_CREATE = re.compile(r"^mcp__.*__(create|open|submit)_pull_request$")
+RX_MCP_ISSUE_CREATE = re.compile(r"^mcp__.*__(create|open|submit)_issue$")
+RX_MCP_COMMENT = re.compile(
+    r"^mcp__.*__(create|add|post)_(merge_request|pull_request|issue)_comment$"
+)
+
 
 def _extract_msgs(cmd: str) -> list[str]:
     out = []
@@ -114,6 +127,22 @@ def _aggregate(events) -> dict:
                         rem = ol or 1
                     a["lines_added"] += add
                     a["lines_removed"] += rem
+            elif n.startswith("mcp__"):
+                # Issue #235: MCP tool calls (mcp__<server>__create_*)
+                # were never counted toward pr_create / mr_create /
+                # issue_create / comments — only the Bash CLI variants
+                # (`gh pr create` / `glab mr create`) below were. For
+                # devboy users whose MR/PR workflow runs through MCP
+                # this drops the entire category, so DORA radar PR/MR
+                # counts come out as zero.
+                if RX_MCP_MR_CREATE.match(n):
+                    a["mr_create"] += 1
+                elif RX_MCP_PR_CREATE.match(n):
+                    a["pr_create"] += 1
+                elif RX_MCP_ISSUE_CREATE.match(n):
+                    a["issue_create"] += 1
+                elif RX_MCP_COMMENT.match(n):
+                    a["comments"] += 1
             elif n == "Bash":
                 cmd = inp.get("command", "") or ""
                 if "git push" in cmd:

--- a/.claude/skills/analyze-usage/scripts/period_report.py
+++ b/.claude/skills/analyze-usage/scripts/period_report.py
@@ -196,9 +196,11 @@ def parse_all(root: Path, since: datetime | None = None, until: datetime | None 
                                     # Issue #235: also count MCP-mediated
                                     # MR/PR creation toward the same
                                     # `pr_create`/`mr_create` totals as
-                                    # the Bash CLI variants above. Anchored
-                                    # `_request$` so we don't double-count
-                                    # comment / discussion variants.
+                                    # the Bash CLI variants above. The
+                                    # regexes anchor on `_merge_request$`
+                                    # / `_pull_request$` so a sibling
+                                    # `_..._comment` tool name doesn't
+                                    # overmatch as a create.
                                     if RX_MCP_MR_CREATE.match(name):
                                         sd["mr_create"] += 1
                                     elif RX_MCP_PR_CREATE.match(name):

--- a/.claude/skills/analyze-usage/scripts/period_report.py
+++ b/.claude/skills/analyze-usage/scripts/period_report.py
@@ -59,6 +59,10 @@ RX_HEREDOC_MSG = re.compile(
     re.DOTALL,
 )
 
+# Issue #235 — keep these in lockstep with extract_outputs.py.
+RX_MCP_MR_CREATE = re.compile(r"^mcp__.*__(create|open|submit)_merge_request$")
+RX_MCP_PR_CREATE = re.compile(r"^mcp__.*__(create|open|submit)_pull_request$")
+
 
 def _extract_msgs(cmd: str) -> list[str]:
     out = []
@@ -189,6 +193,16 @@ def parse_all(root: Path, since: datetime | None = None, until: datetime | None 
                                     sd["sub"] += 1
                                 elif name.startswith("mcp__"):
                                     sd["mcp"] += 1
+                                    # Issue #235: also count MCP-mediated
+                                    # MR/PR creation toward the same
+                                    # `pr_create`/`mr_create` totals as
+                                    # the Bash CLI variants above. Anchored
+                                    # `_request$` so we don't double-count
+                                    # comment / discussion variants.
+                                    if RX_MCP_MR_CREATE.match(name):
+                                        sd["mr_create"] += 1
+                                    elif RX_MCP_PR_CREATE.match(name):
+                                        sd["pr_create"] += 1
                         elif typ == "user":
                             is_meta = m.get("isMeta", False)
                             ctype = ""

--- a/.claude/skills/analyze-usage/tests/test_outputs_mcp.py
+++ b/.claude/skills/analyze-usage/tests/test_outputs_mcp.py
@@ -1,0 +1,125 @@
+"""Issue #235 — MCP-mediated MR/PR/issue creation must count toward
+`mr_create` / `pr_create` / `issue_create` / `comments` aggregates.
+
+Regression: only Bash-CLI variants (`gh pr create` / `glab mr create`)
+were counted, so any session that used `mcp__<server>__create_*`
+silently produced 0 PR/MR creates and the DORA radar undercounted.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_SKILL = _HERE.parent
+sys.path.insert(0, str(_SKILL))
+sys.path.insert(0, str(_SKILL / "scripts"))
+
+from extract_outputs import _aggregate  # noqa: E402
+
+
+@dataclass
+class _Ev:
+    """Minimal stand-in for the real `Event` ABC the parser yields —
+    `_aggregate` only reads `.type` and `.tool_uses`."""
+
+    type: str
+    tool_uses: list[dict]
+
+
+def _tool(name: str, **input_kw) -> dict:
+    return {"name": name, "input": input_kw}
+
+
+def test_mcp_mr_create_counted():
+    events = [
+        _Ev("assistant", [_tool("mcp__devboy-prod__create_merge_request",
+                                title="ship", source_branch="feat/x")]),
+        _Ev("assistant", [_tool("mcp__dev-boy-shiftgears__create_merge_request",
+                                title="x")]),
+        _Ev("assistant", [_tool("mcp__some__open_merge_request", title="y")]),
+        _Ev("assistant", [_tool("mcp__some__submit_merge_request", title="z")]),
+    ]
+    agg = _aggregate(events)
+    assert agg["mr_create"] == 4, agg
+    assert agg["pr_create"] == 0, agg
+
+
+def test_mcp_pr_create_counted():
+    events = [
+        _Ev("assistant", [_tool("mcp__github__create_pull_request",
+                                title="x", body="y")]),
+        _Ev("assistant", [_tool("mcp__gh-internal__open_pull_request",
+                                title="z")]),
+    ]
+    agg = _aggregate(events)
+    assert agg["pr_create"] == 2, agg
+    assert agg["mr_create"] == 0, agg
+
+
+def test_mcp_issue_create_counted():
+    events = [
+        _Ev("assistant", [_tool("mcp__jira__create_issue", summary="bug")]),
+        _Ev("assistant", [_tool("mcp__github__open_issue", title="bug")]),
+    ]
+    agg = _aggregate(events)
+    assert agg["issue_create"] == 2, agg
+
+
+def test_mcp_comment_variants_counted():
+    events = [
+        _Ev("assistant", [_tool("mcp__devboy-prod__create_merge_request_comment",
+                                body="lgtm")]),
+        _Ev("assistant", [_tool("mcp__github__create_pull_request_comment",
+                                body="nit")]),
+        _Ev("assistant", [_tool("mcp__jira__create_issue_comment", body="t")]),
+        _Ev("assistant", [_tool("mcp__github__add_pull_request_comment",
+                                body="x")]),
+    ]
+    agg = _aggregate(events)
+    assert agg["comments"] == 4, agg
+    # Comments must NOT be miscounted as creates — anchor regression.
+    assert agg["mr_create"] == 0, agg
+    assert agg["pr_create"] == 0, agg
+
+
+def test_anchor_does_not_overmatch_comment_variants():
+    """Critical regression guard for the regex anchor: MR/PR creation
+    regexes end with `$_request$`, so a `..._merge_request_comment` tool
+    must NOT increment `mr_create`."""
+    events = [
+        _Ev("assistant", [_tool("mcp__x__create_merge_request_comment", body="x")]),
+        _Ev("assistant", [_tool("mcp__x__open_pull_request_review_comment", body="y")]),
+    ]
+    agg = _aggregate(events)
+    assert agg["mr_create"] == 0, "anchor failure — comment counted as MR"
+    assert agg["pr_create"] == 0, "anchor failure — comment counted as PR"
+
+
+def test_bash_cli_still_counted():
+    """Pre-#235 behaviour preserved — Bash CLI still increments."""
+    events = [
+        _Ev("assistant", [_tool("Bash", command="gh pr create --title x")]),
+        _Ev("assistant", [_tool("Bash", command="glab mr create --title y")]),
+        _Ev("assistant", [_tool("Bash", command="gh issue create --title z")]),
+        _Ev("assistant", [_tool("Bash", command="gh pr comment 12 --body x")]),
+        _Ev("assistant", [_tool("Bash", command="glab mr note 4 --message y")]),
+    ]
+    agg = _aggregate(events)
+    assert agg["pr_create"] == 1, agg
+    assert agg["mr_create"] == 1, agg
+    assert agg["issue_create"] == 1, agg
+    assert agg["comments"] == 2, agg
+
+
+def test_mixed_bash_and_mcp_summed():
+    events = [
+        _Ev("assistant", [_tool("Bash", command="gh pr create --title cli")]),
+        _Ev("assistant", [_tool("mcp__github__create_pull_request", title="mcp")]),
+        _Ev("assistant", [_tool("mcp__devboy__create_merge_request", title="m")]),
+        _Ev("assistant", [_tool("Bash", command="glab mr create --title cli")]),
+    ]
+    agg = _aggregate(events)
+    assert agg["pr_create"] == 2, agg
+    assert agg["mr_create"] == 2, agg

--- a/.claude/skills/analyze-usage/tests/test_outputs_mcp.py
+++ b/.claude/skills/analyze-usage/tests/test_outputs_mcp.py
@@ -76,21 +76,26 @@ def test_mcp_comment_variants_counted():
         _Ev("assistant", [_tool("mcp__jira__create_issue_comment", body="t")]),
         _Ev("assistant", [_tool("mcp__github__add_pull_request_comment",
                                 body="x")]),
+        # GitHub's inline-review comments end in `_pull_request_review_comment`;
+        # they're still discussion comments and should roll up here.
+        _Ev("assistant", [_tool("mcp__github__create_pull_request_review_comment",
+                                body="inline")]),
     ]
     agg = _aggregate(events)
-    assert agg["comments"] == 4, agg
+    assert agg["comments"] == 5, agg
     # Comments must NOT be miscounted as creates — anchor regression.
     assert agg["mr_create"] == 0, agg
     assert agg["pr_create"] == 0, agg
 
 
 def test_anchor_does_not_overmatch_comment_variants():
-    """Critical regression guard for the regex anchor: MR/PR creation
-    regexes end with `$_request$`, so a `..._merge_request_comment` tool
-    must NOT increment `mr_create`."""
+    """Critical regression guard for the create regexes. They anchor on
+    `_merge_request$` / `_pull_request$` (the bare nouns), so a sibling
+    tool whose name extends past the create noun must NOT increment
+    `mr_create` / `pr_create`."""
     events = [
         _Ev("assistant", [_tool("mcp__x__create_merge_request_comment", body="x")]),
-        _Ev("assistant", [_tool("mcp__x__open_pull_request_review_comment", body="y")]),
+        _Ev("assistant", [_tool("mcp__x__create_pull_request_review_comment", body="y")]),
     ]
     agg = _aggregate(events)
     assert agg["mr_create"] == 0, "anchor failure — comment counted as MR"


### PR DESCRIPTION
## Summary

Closes #235. `analyze-usage` only matched the Bash CLI variants (`gh pr create` / `glab mr create`) when computing per-session `pr_create` / `mr_create` / `issue_create` / `comments`. MCP-mediated calls — `mcp__<server>__create_merge_request` and friends — were never counted, so for devboy users the DORA radar PR/MR row came out as 0 / wildly undercounted.

Reproduced via `docs/research/data/paper3_followup_edges.csv` in the repo, which contains real `mcp__pd16dd1__create_merge_request` events that the old code silently ignored.

## Fix

- **`.claude/skills/analyze-usage/scripts/extract_outputs.py`** — new `RX_MCP_{MR,PR,ISSUE}_CREATE` and `RX_MCP_COMMENT` regexes anchored on `_request$` / `_issue$` / `_comment$` (so we don't double-count `_merge_request_comment` as both a comment and a create). Inserted as a new `elif n.startswith("mcp__")` branch in `_aggregate`'s tool_use loop.
- **`.claude/skills/analyze-usage/scripts/period_report.py`** — same regexes (kept as module-level constants with a "keep in lockstep" comment), wired into the existing `elif name.startswith("mcp__")` clause so the per-session aggregator agrees with the parquet extractor.

## Test plan

7 new tests in `.claude/skills/analyze-usage/tests/test_outputs_mcp.py`:

- [x] `test_mcp_mr_create_counted` — 4 MCP MR creates increment `mr_create`, not `pr_create`.
- [x] `test_mcp_pr_create_counted` — symmetrical for PR (incl. `open_pull_request`).
- [x] `test_mcp_issue_create_counted` — issue creation tools.
- [x] `test_mcp_comment_variants_counted` — `_comment` family increments `comments` only.
- [x] **`test_anchor_does_not_overmatch_comment_variants`** — critical regression guard: a `_merge_request_comment` tool must NOT be counted as `mr_create`.
- [x] `test_bash_cli_still_counted` — pre-#235 Bash behaviour preserved.
- [x] `test_mixed_bash_and_mcp_summed` — Bash + MCP creates from the same session both counted.

`uv run --with pytest --with pyarrow>=15 python3 -m pytest tests/` — 35/35 pass (28 pre-existing + 7 new).

## Impact

- DORA radar PR/MR row in the period report becomes accurate for users whose workflow goes through devboy / GitHub MCP / GitLab MCP servers.
- Lead-time and review-fix classifications that key off MR-creation timestamps stop missing events.
- True CFR (`prod_fix / feat`) is unaffected (does not depend on MR count); downstream patterns in `pattern_detector.py` that check MR presence (e.g. `feature_with_debug`) get correct input.

## Out of scope

The bigger UX work — metric explainer hints in the report sections + a one-line / one-paragraph "share" block for monthly digests — is a follow-up. This PR keeps the scope tight to fixing the data integrity bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)