### PR TITLE
docs(adr): ADR-020 secret manifest + ADR-021 external sources

### DIFF
--- a/docs/architecture/adr/ADR-020-secret-manifest-and-alias-resolution.md
+++ b/docs/architecture/adr/ADR-020-secret-manifest-and-alias-resolution.md
@@ -1,0 +1,504 @@
+---
+id: ADR-020
+title: Secret manifest, path convention, and alias resolution
+status: proposed
+date: 2026-05-06
+deciders: ["Andrei Mazniak"]
+tags: ["security", "secrets", "manifest", "core"]
+supersedes: null
+superseded_by: null
+---
+
+# ADR-020: Secret manifest, path convention, and alias resolution
+
+## Status
+
+**proposed**
+
+## Context
+
+[ADR-005](./ADR-005-credential-storage.md) decided **where** a secret lives:
+the OS keychain, with an environment-variable fallback for CI and headless
+hosts. [ADR-019](./ADR-019-secret-string-discipline.md) decided **how** a
+secret is typed in transit through the process: `secrecy::SecretString`
+end-to-end, redacted on `Debug`, zeroized on `Drop`.
+
+Neither of those addresses how a secret is **declared**, **discovered**,
+**referenced**, or **validated**. In practice this leaves several real
+problems on the table:
+
+- **No discoverability.** A token sits in the keychain under a key like
+  `gitlab.token`. Nobody but the person who entered it knows what it is for,
+  how to obtain a fresh one, what format it should have, when it expires, or
+  which providers in the codebase actually consume it.
+- **No project-level "map of required secrets".** A new contributor cloning
+  a repo cannot answer "which credentials do I need to set up to make this
+  project work?" without reading source code or asking a teammate.
+- **Plaintext still leaks through human-driven routes.** Even with
+  `SecretString` inside the process, the secret value is still typed into
+  shell prompts, pasted into agent chat windows, exported into shell
+  rc-files, and committed to `.env` files. Any of those flows ends up in
+  shell history, terminal scrollback, agent transcripts, or git history.
+- **No validation.** A typo in a token is detected only on the first real
+  HTTP call that uses it; the failure mode is a generic 401 from a
+  third-party API, not "the value you stored doesn't match the expected
+  format for this provider".
+- **No expiry tracking.** Personal access tokens commonly expire after
+  90 days. Nothing in the current system warns the user before that
+  happens.
+- **No boundary between contexts.** If an agent operates in `context A`
+  but asks for a credential that "logically" belongs to `context B`, the
+  request succeeds silently as long as the keychain entry exists. There
+  is no manifest of "what `context A` is allowed to ask for".
+- **No way for an agent to ask for a missing secret without seeing
+  values.** A coding agent working on a repo can detect "this provider
+  isn't configured" only by failing. It cannot proactively ask the user
+  to provision a named secret without the agent itself becoming a
+  potential leak surface.
+
+This ADR introduces a layer **above** the credential store: a manifest of
+known secrets with metadata, a strict naming convention, an alias-based
+referencing scheme, and a validation framework. The credential store
+defined by ADR-005 stays where it is — this ADR adds discovery,
+declaration, and resolution discipline on top of it.
+
+External secret sources (1Password CLI, HashiCorp Vault, AWS Secrets
+Manager, an env-only store for CI, etc.) are out of scope here and are
+the subject of [ADR-021](./ADR-021-external-secret-sources.md).
+
+### Threat model (explicit)
+
+This ADR protects against **accidental** secret leakage by humans, by
+agents acting in good faith, and by routine tooling:
+
+- Plaintext values in agent transcripts, configuration files, shell
+  history, terminal scrollback, `ps` output, crash dumps, log files, or
+  committed `.env` files.
+- A teammate accidentally pasting a value from one context into a
+  configuration that belongs to another.
+- Drift between "what the project needs" and "what is actually
+  provisioned on this machine".
+
+This ADR explicitly does **not** claim isolation against a malicious or
+compromised agent. An agent that can run a shell can always
+`echo $SOMETHING`, dump `/proc/self/environ`, or read any file the user
+can read. Full isolation requires running the agent in a sandboxed
+process and is out of scope.
+
+## Decision
+
+> **Decision:** A secret in `devboy-tools` has a fixed name (its **path**)
+> drawn from a single global namespace, declared in a project-level
+> **manifest** that is committed to source, with metadata kept in a global
+> **index**. Code, configuration, and command lines reference a secret by
+> its path through the alias form `@secret:<path>`; values are resolved
+> on demand through the existing credential store and never stored
+> alongside the reference.
+
+The decision has six parts.
+
+### 1. A single global flat namespace
+
+All secrets known to `devboy-tools` share one flat key space. There is no
+per-context namespace, no per-project namespace, no nesting of stores.
+Two contexts that need different values for "the same kind of credential"
+**must** declare different paths — for example
+`team/gitlab/token-deploy` and `client-acme/gitlab/token-deploy`.
+
+The motivation is reuse: a personal token (`personal/github/pat`) is
+typed once and referenced from every project that needs it, without the
+user having to maintain N copies in N keychain entries.
+
+The trade-off — that any process running as the user can read any path
+in the namespace — is the same boundary that already exists in the OS
+keychain (ADR-005). This ADR does not weaken it; the soft enforcement
+described in section 7 strengthens it for agent-mediated access.
+
+### 2. Hard path convention
+
+A path is a `/`-separated sequence of **segments**. The validator rejects
+a path that does not match all of the following:
+
+- Minimum **three** segments. The shape is `<scope>/<provider>/<purpose>`.
+  Two-segment paths (`gitlab/token`) are intentionally not allowed —
+  they have no scope and silently encourage cross-context reuse of
+  credentials that should be distinct.
+- Each segment matches `[a-z][a-z0-9-]*`. Lowercase, kebab-case, no
+  dots, no underscores, no slashes inside a segment.
+- The first segment is the **scope**. It is open-ended (not a fixed
+  enum), but conventional values are `team`, `personal`,
+  `client-<short-name>`, and `sandbox`. Tooling lints unknown scopes
+  but does not reject them.
+- Two prefixes are **reserved** by the framework and rejected from
+  user-facing paths:
+  - `__*` — internal use (for example, source authentication
+    credentials, see ADR-021). Hidden by default in `secrets list`.
+  - `_test/*` — paths used by the test suite. Production code refuses
+    to read them.
+
+Examples of valid paths:
+
+```
+team/gitlab/token-deploy
+team/openai/api-key
+personal/github/pat
+personal/anthropic/api-key
+client-acme/jira/api-key
+sandbox/example-provider/token
+```
+
+Examples that are rejected:
+
+```
+gitlab.token              # too few segments, dot separator
+GitLab/Token              # not lowercase, not kebab-case
+team/gitlab               # too few segments
+team//gitlab/token        # empty segment
+__sources/vault-a/token   # reserved prefix in user-facing context
+```
+
+The convention is enforced as a **hard error** — at manifest load time,
+at resolver lookup time, and in the CLI. The reasoning is that an
+inconsistent namespace silently degrades into "every project invents
+its own pattern", which is the situation this ADR is designed to fix.
+
+### 3. Global index (`~/.devboy/secrets/index.toml`)
+
+The global index holds **metadata, never values**. It is a TOML file
+under `~/.devboy/secrets/index.toml`. Each entry is keyed by path and
+carries:
+
+```toml
+[secret."team/gitlab/token-deploy"]
+description       = "Deploy token for the team GitLab; used by CI mirrors and devboy plugins"
+retrieval_hint    = "https://gitlab.example.internal/-/profile/personal_access_tokens"
+format_regex      = "^glpat-[A-Za-z0-9_-]{20,}$"
+default_gate      = "auto"        # auto | confirm | touchid
+expires_at        = "2026-08-01"  # optional, populated by validation if upstream exposes it
+last_rotated_at   = "2026-05-02"  # optional, advisory
+rotate_every_days = 90            # optional, drives doctor warnings
+required_scopes   = ["api", "read_repository"]  # optional, advisory
+```
+
+No secret value is ever written to the index. The credential store from
+ADR-005 remains the only place values live.
+
+The index is the **source of truth for ownership of metadata**. A
+per-project manifest (next section) may not invent metadata for a path
+that is not described in the global index. The reasoning: if every
+project can invent its own description and `retrieval_hint`, the
+metadata diverges, defeating the purpose of a shared namespace. New
+paths must first be described in the global index (interactively
+during `secrets bootstrap`, or by hand), and only then be referenced
+from projects.
+
+### 4. Per-project manifest (`.devboy/secrets.toml`)
+
+A project that uses `devboy-tools` declares its dependency on secrets
+in a manifest committed to the repository:
+
+```toml
+# .devboy/secrets.toml
+required = [
+    "team/gitlab/token-deploy",
+    "personal/github/pat",
+    "personal/anthropic/api-key",
+]
+
+optional = [
+    "personal/slack/notify-token",   # the notify skill works without it
+]
+
+[overrides."team/gitlab/token-deploy"]
+gate = "touchid"   # this project tightens the default gate for this secret
+```
+
+The manifest contains **only references and project-local overrides**.
+No values, no descriptions, no retrieval hints — those live in the
+global index and apply uniformly across every project that references
+the same path.
+
+Committing the manifest gives a team three things:
+
+- **Onboarding-as-data.** A new contributor runs `devboy secrets
+  bootstrap` and walks through every required secret with system
+  prompts; missing entries are filled in interactively.
+- **Visibility of cross-project reuse.** Tooling can compute "this
+  secret is referenced by N projects" by walking known manifests.
+- **A target for review.** A pull request that adds a new required
+  secret is now an explicit, reviewable change to the manifest, not a
+  hidden side effect of "code that started reading a new env var".
+
+A project may keep both `required` and `optional` empty; the manifest
+then asserts "this project does not currently depend on any managed
+secret". The validator treats an absent manifest as equivalent to an
+empty one — opt-in, no cost for projects that do not need it.
+
+### 5. Alias resolution (`@secret:<path>`)
+
+Configuration files, command lines, and HTTP request templates may
+reference a secret by its path through the alias form `@secret:<path>`.
+The resolver expands the alias on demand at the smallest possible
+scope. The resolver hands the expanded value back as
+`secrecy::SecretString` (per ADR-019); plaintext is exposed only through
+`.expose_secret()` at the call site.
+
+Four substitution points are supported:
+
+- **Config files.** A config loader that encounters `@secret:<path>`
+  in a string field resolves it through the credential chain. Example:
+
+  ```toml
+  [gitlab]
+  token = "@secret:team/gitlab/token-deploy"
+  ```
+
+  The TOML on disk holds the alias, never the value.
+
+- **External command argv.** A wrapper rewrites `@secret:<path>`
+  occurrences in argv before `exec`. Because argv is visible to other
+  processes through `ps`, the wrapper prefers passing the secret
+  through stdin or a file descriptor when the target tool supports it
+  (for example, `gh auth login --with-token`, `git credential fill`).
+  Direct argv substitution is the fallback for tools that accept
+  secrets only in argv, and is documented as such.
+
+- **HTTP through the local proxy.** The MCP proxy already mediates
+  outgoing HTTP for some flows. When it sees an outgoing
+  `Authorization: Bearer @secret:<path>` (or another whitelisted
+  header pattern), it rewrites the value to the resolved secret
+  before forwarding. The agent that constructed the request never
+  saw the value; the request as logged through transcript shows the
+  alias.
+
+- **MCP tool requests from agents.** An agent that needs a value to
+  perform a high-level operation calls a typed MCP tool such as
+  `secrets.get(path)`, subject to the soft enforcement described in
+  section 7. The preferred mode, however, is for the agent to call
+  the high-level provider tool directly (`gitlab.create_merge_request`)
+  and let `devboy-tools` resolve the credential server-side, so the
+  value never crosses the agent boundary at all.
+
+The alias prefix is `@secret:` rather than something like `${SECRET:...}`
+so that it cannot be accidentally interpreted by a shell expansion or
+by a templating engine that doesn't know about `devboy-tools`.
+
+### 6. Validation framework
+
+Each entry in the global index can declare validation. There are three
+levels, executed lazily and on demand by `devboy secrets validate`,
+`devboy doctor`, and (optionally) on `bootstrap`:
+
+- **Format validation.** A `format_regex` in the index. Cheap, runs
+  offline, catches typos and accidental `gh_xxx` vs `ghp_xxx` mixups.
+- **Liveness validation.** Provider plugins (the existing API plugins
+  under `crates/plugins/api/*`) expose a `test` method that performs
+  a known-cheap authenticated call. Liveness is opt-in per secret;
+  the validator looks up the provider from the path's second segment
+  unless an explicit `validation` block names a different one.
+- **Expiry and rotation tracking.** When the upstream API returns an
+  expiry (GitLab and GitHub PATs do, for example), liveness validation
+  records `expires_at` back into the global index. `rotate_every_days`
+  paired with `last_rotated_at` produces advisory warnings. `doctor`
+  surfaces "expires in N days" warnings under a fixed threshold
+  (default seven days).
+
+Validation never reads values from anywhere other than the credential
+store, never logs them, and never writes them to the index.
+
+### 7. Soft enforcement through manifest gating
+
+The MCP API exposes `secrets.get(path)` (and `secrets.describe`,
+`secrets.search`) for use by agents. By default, `secrets.get` resolves
+a path **only if the path is declared in the manifest of the active
+context**. A path that exists in the global keychain but is not declared
+in the active manifest yields a structured error (`E_SECRET_NOT_IN_MANIFEST`)
+rather than the secret value.
+
+This is **soft enforcement**, not isolation:
+
+- An agent that can spawn shells can still read any keychain entry by
+  invoking the OS-level CLI directly. The gate raises the visible
+  cost: a sanctioned access goes through the typed MCP API and leaves
+  a structured record; an unsanctioned access has to invoke a shell
+  and is therefore visible in the transcript.
+- A `--allow-cross-context` flag on the MCP request opts out of the
+  gate for one call, with an audit log entry. This is intended for
+  one-off operations (cross-project tooling, migrations).
+
+The benefit is that the dominant accidental-misuse pattern — an agent
+"helpfully" reaching for whichever credential happens to be in the
+keychain — fails closed and produces an error message that names the
+manifest as the place to add the dependency.
+
+## Consequences
+
+### Positive
+
+- ✅ **Onboarding becomes data, not lore.** A new contributor runs
+  `devboy secrets bootstrap`, the manifest drives an interactive walk
+  through every required secret, and the system prompts use the
+  global index's `retrieval_hint` to point at the right page.
+- ✅ **Reuse without duplication.** A personal token is provisioned
+  once and referenced from every project; rotation happens in one place.
+- ✅ **Aliases in code, not values.** `@secret:<path>` makes plaintext
+  in committed configuration a contradiction: a value next to the
+  alias means someone bypassed the resolver.
+- ✅ **Drift becomes visible.** A secret that expires, fails liveness,
+  or is missing surfaces in `doctor`; a secret that is referenced
+  with a non-conformant path fails validation at load time.
+- ✅ **Manifest review.** A change to required secrets is a change
+  to a tracked file, reviewable in a pull request.
+
+### Negative
+
+- ❌ **Two new files in the user's home directory.**
+  `~/.devboy/secrets/index.toml` (metadata) is added on top of the
+  existing `~/.devboy/config.toml`.
+- ❌ **One new file in each project that opts in.** `.devboy/secrets.toml`
+  is small but it is one more committed file.
+- ❌ **Hard path convention is a one-way migration.** Existing
+  keychain entries with names like `gitlab.token` are not valid paths
+  under the new convention. ADR-005 entries continue to be readable
+  through the legacy `CredentialStore` API, but the new manifest
+  layer ignores them; a migration step is required (tracked in the
+  implementation issue).
+- ❌ **Authoring overhead for new secrets.** A new path requires an
+  index entry before a manifest may reference it. The `bootstrap`
+  flow asks for the necessary metadata interactively, but for a
+  user accustomed to "just put a token in the keychain" this is one
+  extra step.
+
+### Risks
+
+- ⚠️ **Manifest commits leak intent.** A committed manifest reveals
+  which providers a project uses, even if no values leak. For a
+  public OSS repository this is usually intended (it's part of the
+  README); for a private repository describing a sensitive
+  integration, the project may prefer to keep the manifest in a
+  private companion repo. **Mitigation:** the manifest path is
+  configurable; teams can place it outside the main repo if needed.
+- ⚠️ **Alias-bypass via direct env-var read.** A library or tool
+  that reads `process.env.GITLAB_TOKEN` directly (without going
+  through the resolver) bypasses the alias system entirely.
+  **Mitigation:** scope of this ADR is `devboy-tools`-mediated
+  configuration; third-party tools using their own conventions are
+  out of scope. CI checks (similar to ADR-019's `secrets-discipline`
+  job) flag direct token reads inside `crates/`.
+- ⚠️ **`@secret:` aliases in unmediated config.** A user copies an
+  alias-bearing config snippet into a tool that does not understand
+  `@secret:`, and the tool sends the literal string `@secret:...` as
+  the credential. **Mitigation:** the alias prefix is documented and
+  conspicuous; the wrapper tools explicitly fail closed when
+  encountering an unresolved alias at exec time.
+- ⚠️ **Validation false negatives mask real expiry.** If a provider
+  API returns 200 even with a token that is two days from expiring,
+  liveness validation does not catch it. **Mitigation:** rotation
+  reminders driven by `last_rotated_at` and `rotate_every_days` are
+  independent of liveness and run regardless of upstream behaviour.
+
+## Alternatives Considered
+
+### Alternative 1: Per-context flat namespace
+
+**Description:** Make every secret implicitly scoped by context, so
+`gitlab/token` in `context A` and `gitlab/token` in `context B` are two
+distinct keys with two distinct values.
+
+**Why rejected:** This produces N copies of personal credentials that
+are genuinely the same value, multiplies rotation work by N, and hides
+which contexts actually share a credential. The user explicitly
+preferred a single flat namespace with the discipline of "different
+values must have different paths" enforced as a convention.
+
+### Alternative 2: Vault-style hierarchical store with policy engine
+
+**Description:** Model the namespace as a tree (like HashiCorp Vault's
+KV engine) with a per-context policy that grants or denies access to
+sub-trees.
+
+**Why rejected:** A policy engine is large surface area for a local
+CLI tool and substantially raises the floor of "what you must
+configure before you can use the system". The soft-enforcement
+mechanism in section 7 captures the most useful 10% of the policy
+behaviour (manifest-as-policy) at near-zero configuration cost. If a
+real policy engine is needed in the future, it can be introduced as a
+separate decision, ideally by delegating to an external source (see
+ADR-021).
+
+### Alternative 3: No manifest, only the global index
+
+**Description:** Drop the per-project manifest and let the index
+itself declare which secrets each project needs.
+
+**Why rejected:** The point of a per-project manifest is that it lives
+**in the project's repository**, where it can be reviewed, tested in CI
+("does this project still claim secrets it no longer uses?"), and used
+to bootstrap new contributors. A central declaration in `~/.devboy/`
+cannot fulfil any of those.
+
+### Alternative 4: Encrypted file with embedded values (sealed manifest)
+
+**Description:** Combine values and metadata into one file encrypted
+with a per-user master key (age, sops, gpg).
+
+**Why rejected:** A sealed file requires a master-key prompt on every
+invocation (or a long-running agent process holding the key in
+memory), which is exactly the ergonomic regression ADR-005 already
+considered and rejected. ADR-005's keychain-plus-env-fallback model
+remains the right place for values; this ADR layers metadata and
+discovery on top of it.
+
+### Alternative 5: Free-form path convention with linting only
+
+**Description:** Allow any non-empty string as a path; lint deviations
+from the recommended shape rather than rejecting them.
+
+**Why rejected:** The current state (free-form `<provider>.<credential>`
+keys per ADR-005) is exactly the lint-only baseline. Drift between
+projects has already happened in practice. The hard rule is the
+cheapest mechanism for preventing the namespace from re-fragmenting.
+
+## Implementation
+
+- **Issues:**
+  - [#246](https://github.com/meteora-pro/devboy-tools/issues/246) — design (this ADR + ADR-021)
+  - [#247](https://github.com/meteora-pro/devboy-tools/issues/247) — implementation, phased
+- **Code (planned):**
+  - `crates/devboy-storage/` — extend with manifest loader, global
+    index, path validator
+  - `crates/devboy-core/` — config-loader integration with
+    `@secret:` resolution
+  - `crates/devboy-executor/` — argv-substitution wrapper with
+    stdin/FD pass-through
+  - `crates/devboy-mcp/` — `secrets.*` tool surface, manifest gating,
+    `Authorization` header rewriting in `proxy.rs`
+  - `crates/devboy-cli/` — `devboy secrets {list, describe, validate,
+    bootstrap}` subcommands
+- **Migration:** legacy keychain entries from ADR-005 remain readable
+  through the existing API; a migration tool walks them, asks the
+  user for the canonical path under the new convention, and rewrites
+  the index. Tracked as a separate phase in #247.
+
+External secret sources, source routing, and per-context source
+credentials are deferred to ADR-021.
+
+## References
+
+- [ADR-005: Credential storage](./ADR-005-credential-storage.md) — where
+  values live (keychain + env fallback)
+- [ADR-019: Secrets carry SecretString end-to-end](./ADR-019-secret-string-discipline.md)
+  — how values are typed in transit through the process
+- [ADR-021: External secret sources](./ADR-021-external-secret-sources.md)
+  — pluggable backends (1Password, Vault, AWS, env-store, …) sitting
+  behind the same path namespace
+- [`secrecy` crate documentation](https://docs.rs/secrecy/)
+- [HashiCorp Vault — KV namespace concepts](https://developer.hashicorp.com/vault/docs/secrets/kv) — inspiration for path-based addressing
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-06 | Andrei Mazniak | Initial draft |

--- a/docs/architecture/adr/ADR-021-external-secret-sources.md
+++ b/docs/architecture/adr/ADR-021-external-secret-sources.md
@@ -1,0 +1,562 @@
+---
+id: ADR-021
+title: External secret sources and backend routing
+status: proposed
+date: 2026-05-06
+deciders: ["Andrei Mazniak"]
+tags: ["security", "secrets", "plugins", "storage"]
+supersedes: null
+superseded_by: null
+---
+
+# ADR-021: External secret sources and backend routing
+
+## Status
+
+**proposed**
+
+## Context
+
+[ADR-005](./ADR-005-credential-storage.md) ships a single backend layout:
+the OS keychain on the user's machine, with an environment-variable
+fallback for CI and headless hosts. [ADR-020](./ADR-020-secret-manifest-and-alias-resolution.md)
+adds a manifest, a path namespace, and an alias-resolution layer above
+the credential store, but it intentionally does not say where values
+come from beyond what ADR-005 already provided.
+
+Real-world deployments rarely live on one backend:
+
+- **Teams running HashiCorp Vault** keep credentials there for audit,
+  rotation, and per-team policy. They do not want a copy of every
+  secret in every developer's local keychain.
+- **Teams using 1Password** treat the 1Password vault as the source
+  of truth, with the CLI (`op`) and biometric session as the access
+  path. Local keychain entries become stale almost immediately.
+- **CI runners and bare-Linux containers** typically have no D-Bus,
+  no Secret Service daemon, no `op`, and sometimes not even a TTY.
+  The only shape that works is environment variables, possibly
+  loaded from a file mounted by the orchestrator (Docker secrets,
+  Kubernetes secret mounts).
+- **A single user routinely talks to several upstreams of the same
+  type.** Two Vault servers under different addresses, two 1Password
+  accounts (work and personal), two AWS profiles. Each carries its
+  own credentials and possibly its own role.
+- **The same upstream may need different credentials in different
+  contexts.** An engineer may hold `read-only` and `deploy` tokens
+  for the same Vault and want a context switch to flip which one is
+  active, without re-authenticating.
+
+ADR-020 left this surface deliberately empty. This ADR fills it.
+
+## Decision
+
+> **Decision:** The credential store is split into a thin **router**
+> and a set of **secret-source plugins**. A secret path declared
+> through the ADR-020 manifest resolves through the router to exactly
+> one source, which in turn knows how to talk to its upstream
+> (keychain, 1Password CLI, HashiCorp Vault, an env-store backend, or
+> a community-supplied subprocess plugin). The router is the only
+> code that touches the manifest; the sources are interchangeable.
+
+The decision has eight parts.
+
+### 1. The `SecretSource` trait
+
+A source is any backend able to answer questions about secrets. The
+trait is small and explicitly capability-aware:
+
+```rust
+#[async_trait]
+pub trait SecretSource: Send + Sync {
+    fn name(&self) -> &str;
+    fn capabilities(&self) -> Capabilities;     // READ | LIST | VALIDATE | WRITE | ROTATE
+
+    async fn is_available(&self) -> SourceStatus;        // Available | Locked | NotInstalled | Error
+    async fn get(&self, reference: &str) -> Result<Option<SecretString>>;
+    async fn list(&self) -> Result<Vec<RemoteRef>>;       // optional, used by discovery
+    async fn validate(&self, reference: &str) -> Result<()>;
+}
+```
+
+`reference` is a backend-specific string — for example
+`op://Personal/GitHub PAT/credential` for 1Password,
+`secret/data/team/gitlab#token` for Vault KV v2, a flat key for the
+keychain, an environment-variable name for the env-store. Sources do
+**not** know about ADR-020 paths; mapping a path to a reference is the
+router's job (section 2). This separation lets a source plugin be
+written without any awareness of the manifest layer.
+
+`capabilities()` lets the system reason about what a source can and
+cannot do. A read-only source (1Password CLI in the typical biometric
+configuration) declares `READ | LIST | VALIDATE`; an env-store
+declares `READ` only; a Vault KV v2 source with sufficient policy may
+declare `READ | LIST | VALIDATE | WRITE | ROTATE`. Operations that
+require a missing capability fail with a structured error rather than
+trying and erroring at the network boundary.
+
+### 2. Routing (`~/.devboy/secrets/sources.toml`)
+
+Routing maps an ADR-020 path to a `(source, reference)` pair. The
+configuration is global and lives at `~/.devboy/secrets/sources.toml`:
+
+```toml
+# Source definitions
+
+[[source]]
+name = "keychain"
+type = "keychain"
+
+[[source]]
+name = "1p-personal"
+type = "1password"
+account = "personal.example.1password.com"
+
+[[source]]
+name = "vault-team"
+type = "vault"
+addr   = "https://vault.example.internal/"
+mount  = "secret"
+
+[[source]]
+name = "env-store"
+type = "env-store"
+file = "/run/secrets/devboy.env"   # optional; loaded if present
+
+# Routing — prefix-based default
+
+[default]
+source = "keychain"
+
+[[route]]
+prefix = "team/"
+source = "vault-team"
+mount  = "secret/data/team"        # path → secret/data/team/<rest-of-path>
+
+[[route]]
+prefix = "personal/"
+source = "1p-personal"
+vault  = "Personal"                # path → op://Personal/<rest-of-path>
+
+# Per-secret override (rare; for one-off mappings)
+
+[secret."client-acme/jira/api-key"]
+source    = "1p-personal"
+reference = "op://Work/Acme Jira/credential"
+```
+
+The router resolves a path by:
+
+1. Looking for a `[secret."<path>"]` block — if present, the explicit
+   source and reference win.
+2. Otherwise, finding the longest matching `[[route]]` prefix.
+3. Otherwise, falling back to `[default]`.
+
+Path-to-reference mapping for prefix routes is source-specific and
+defined by the source plugin (the keychain source uses the path
+directly; the Vault source joins `mount` with the path tail; the
+1Password source produces an `op://` URL from the `vault` setting and
+the path tail).
+
+### 3. Multiple instances of the same source type
+
+Each `[[source]]` entry has a unique `name`. Two `vault` sources with
+different `addr` values are two distinct sources, addressable
+independently from routing. The `type` is what code is invoked; the
+`name` is how users and routes refer to the source. This is the
+mechanism by which a single user can talk to several upstreams of the
+same flavour without confusion.
+
+### 4. Per-context source credentials
+
+A source may itself need credentials to operate (Vault token,
+1Password account session, AWS profile). The default behaviour is
+the source's native session management — `op signin`, `vault login`,
+`aws configure sso`. ADR-005's keychain remains the place for tokens
+that the system itself manages.
+
+For users who hold several roles in the same upstream — for example,
+a `read-only` token and a `deploy` token for the same Vault — the
+**active context** of `devboy-tools` may select which credential
+profile to use. The context configuration gains a new optional block:
+
+```toml
+# in the active context
+
+[source_credentials]
+"vault-team"  = "__sources/vault-team/deploy"   # path under reserved namespace
+"1p-personal" = "biometric"                      # source-defined sentinel: "use system unlock"
+```
+
+Switching contexts therefore switches credentials at the source
+level, without re-authenticating each time. The mapping value is
+either:
+
+- A path under the reserved `__sources/` namespace (section 5), in
+  which case the router fetches it from the credential store and
+  hands it to the source's `init` step; or
+- A source-specific sentinel string (`biometric`, `default-profile`)
+  that the source plugin interprets as "use your native unlock
+  mechanism".
+
+### 5. Reserved `__sources/` namespace
+
+ADR-020 reserves the `__*` prefix as internal. This ADR uses
+`__sources/<source-name>/<profile>` for source-authentication
+credentials.
+
+```
+__sources/vault-team/deploy
+__sources/vault-team/read-only
+__sources/aws-shared/sso-session
+```
+
+These paths are valid in the credential store but are filtered out of
+`devboy secrets list` by default. They surface only with
+`devboy secrets list --internal`. The reasoning: source credentials
+are infrastructure, not business credentials, and showing them next
+to user-facing secrets clutters the discovery view.
+
+### 6. Subprocess plugin protocol
+
+Built-in sources (keychain, 1password, vault, env-store; section 8)
+implement `SecretSource` directly inside the `devboy-tools` binary.
+Community backends ship as separate executables, discovered at
+`~/.devboy/plugins/secrets/devboy-source-<name>`, communicating with
+the router over **JSON-RPC on stdio** — the same shape as MCP.
+
+The protocol surfaces the trait directly:
+
+```
+secret_source.init        →  capabilities, version
+secret_source.is_available →  status enum
+secret_source.get         →  reference → SecretString | NotFound
+secret_source.list        →  → RemoteRef[]
+secret_source.validate    →  reference → ok | invalid | unreachable
+```
+
+The router spawns the plugin lazily (first use), keeps the process
+alive for a configurable idle window (default sixty seconds), and
+restarts it transparently on crash. The plugin is run with a
+restricted environment: only variables it explicitly declares it
+needs in a manifest shipped alongside the binary
+(`devboy-source-<name>.toml`). The router never passes other secrets
+to a plugin.
+
+The protocol is part of this ADR so that built-in sources and
+external sources are interchangeable from the start. The first
+release ships only built-ins; the protocol exists so a community
+crate (AWS Secrets Manager, Bitwarden, Doppler, Infisical, …) can be
+written without forking `devboy-tools`.
+
+### 7. Caching
+
+Source latency varies by orders of magnitude. A keychain read is
+microseconds; a `vault read` is tens of milliseconds plus a TLS
+handshake; an `op read` typically takes hundreds of milliseconds and
+may prompt for biometric unlock; a misconfigured Vault behind a
+captive-portal VPN may hang for seconds. Without caching, an agent
+that resolves a dozen secrets per minute is unusable.
+
+The router caches resolved values **in-process, in memory only,
+never on disk**. The cache is keyed by ADR-020 path and holds an
+expiring `SecretString`. The default TTL is fifteen minutes; it is
+configurable per source and per secret. Cache entries are dropped
+when:
+
+- the TTL expires,
+- the user invokes `devboy secrets refresh <path>` (or `--all`),
+- a source declares an out-of-band invalidation (Vault lease
+  revocation, 1Password session timeout — surfaced through
+  `is_available()`).
+
+The cache is **never** persisted. Process exit drops every entry.
+This is the same posture as `secrecy::SecretString::zeroize_on_drop`
+extended one level up.
+
+### 8. Built-in sources
+
+The first release ships four built-in implementations of
+`SecretSource`. Together they cover the dominant deployment shapes
+without requiring any community plugin.
+
+#### `keychain`
+
+A refactor of the existing `KeychainStore` from ADR-005, wrapped in
+the `SecretSource` interface. `reference` is the path itself — the
+keychain is the only source where the ADR-020 path doubles as the
+backend reference. Capabilities: `READ | LIST | VALIDATE | WRITE`.
+Available unless the platform exposes no keychain (headless Linux
+without Secret Service); in that case `is_available()` returns
+`NotInstalled` and the router skips it.
+
+#### `1password`
+
+Backed by the `op` CLI. `reference` is an `op://` URL
+(`op://<vault>/<item>/<field>`). Capabilities: `READ | LIST |
+VALIDATE`. Write capability is omitted from the first release;
+`op item create` is mudded enough that the ADR-020 `bootstrap` flow
+opens the 1Password UI for new entries instead of writing through the
+CLI. `is_available()` checks `op whoami`; a locked session returns
+`Locked` and `doctor` shows an actionable message
+(`op signin`).
+
+#### `vault`
+
+Backed by the HashiCorp Vault HTTP API, KV v2. `reference` joins the
+mount and path (`secret/data/<path>#<field>`, where `<field>` defaults
+to `value`). Capabilities: `READ | LIST | VALIDATE | WRITE | ROTATE`,
+subject to the policy associated with the active token.
+Authentication methods are pluggable; the ADR ships token, AppRole,
+and OIDC out of the box, with the active method configured per
+source instance. `is_available()` calls `/sys/health` and a token
+lookup; an expired token returns `Locked`.
+
+#### `env-store`
+
+A first-class source for CI, containers, and bare Linux. There is no
+keychain to fall back to in those environments; treating env-vars as
+their own source makes the routing explicit and the failure modes
+clean.
+
+The env-store reads values through three mechanisms, in order:
+
+1. A **manifest-defined alias** for the secret. The ADR-020 global
+   index may declare `env_var = "GITLAB_TOKEN_DEPLOY"` for a path,
+   in which case the env-store reads that variable verbatim. This
+   exists for compatibility with existing CI conventions, where
+   variables already have well-known names that pre-date
+   `devboy-tools`.
+2. The **convention-based name** derived from the path:
+   `DEVBOY_SECRET__<flattened-path>`, with `/` rewritten to `__` and
+   `-` to `_`, uppercased.
+
+   ```
+   team/gitlab/token-deploy
+   → DEVBOY_SECRET__TEAM__GITLAB__TOKEN_DEPLOY
+   ```
+
+3. The **file loader**: at startup, if `DEVBOY_SECRETS_FILE` points
+   at an existing file, it is parsed as a `.env`-style file and its
+   contents are merged into the process environment. This is the
+   mechanism that picks up Docker secrets and Kubernetes secret
+   mounts.
+
+Capabilities: `READ` only. Validation is format-only; liveness is
+delegated to the higher-level provider check.
+
+#### CI auto-detection
+
+When the process detects that it is running in CI — environment
+variables `CI`, `GITLAB_CI`, `GITHUB_ACTIONS`, or
+`BUILDKITE` set to a truthy value — the router silently promotes
+`env-store` to the first position in the resolution chain and skips
+sources whose `is_available()` returns `NotInstalled`. This
+preserves zero-config CI behaviour while keeping local developer
+defaults unchanged.
+
+### 9. `doctor` integration
+
+`devboy doctor` gains two new sections:
+
+- **Sources** — for each configured source, its name, type,
+  availability status, last successful contact, and any actionable
+  message (`op signin`, `vault login`, `unset DEVBOY_SECRETS_FILE`,
+  …).
+- **Secrets in active context** — for each path declared in the
+  active manifest, its routed source, current status (provisioned /
+  expiring / missing / format-invalid), and (where the upstream
+  exposes it) its expiry. Optional secrets are shown in their own
+  sub-section without producing a non-zero exit.
+
+Exit code is non-zero if any required secret is missing or
+format-invalid. This makes `devboy doctor` a usable CI sanity gate
+without further wrapping.
+
+## Threat model adjustments
+
+ADR-020 stated the framework's overall threat model. This ADR moves
+two things on the spectrum:
+
+- **Improvement.** External sources typically provide audit (every
+  read is logged in 1Password and Vault), centralized rotation, and
+  per-team policy. A team that adopts an external source
+  materially raises the bar over a per-developer keychain — not
+  because `devboy-tools` is more secure, but because the upstream
+  is.
+- **New surface.** `devboy-tools` invokes `op` and `vault` (and
+  community plugins) as subprocesses. A compromised CLI on the
+  user's `PATH` can return arbitrary values, log credentials, or
+  exfiltrate the entire vault. **Mitigation:** sources are spawned
+  with explicit absolute paths resolved at install/configure time
+  and pinned in the source definition; checksums of built-in source
+  binaries are verified by `doctor`. The router never invokes
+  source CLIs through a shell — `Command::new(absolute_path)` with
+  `argv` only.
+
+Subprocess plugins inherit this surface and add another layer
+(arbitrary code in the user's plugin directory). Plugin manifests
+must be reviewed before install; `devboy secrets sources install
+<plugin>` will (in the implementation) display the plugin's declared
+permissions and require explicit confirmation.
+
+## Consequences
+
+### Positive
+
+- ✅ **Adoption path for existing teams.** Teams already on
+  1Password or Vault can route their existing tree into the
+  ADR-020 namespace without copying a single value into the local
+  keychain.
+- ✅ **CI works first-class.** The env-store is a real source, not
+  a fallback; CI behaviour is therefore predictable and
+  configurable rather than implicit.
+- ✅ **Multiple upstreams of the same type are addressable.** A user
+  with several Vault servers or several 1Password accounts can
+  configure them side by side under different `name`s.
+- ✅ **Context-aware role switching.** A context switch flips
+  which credential is presented to a source — a `read-only` token
+  in one context, a `deploy` token in another.
+- ✅ **A community plugin protocol exists from day one.** A new
+  backend is a separate binary against a documented stdio protocol;
+  it does not require forking `devboy-tools`.
+- ✅ **Cached reads keep agents responsive.** A fifteen-minute TTL
+  is invisible to interactive use and makes biometric-prompting
+  sources usable inside agentic loops.
+
+### Negative
+
+- ❌ **One more configuration file.** `~/.devboy/secrets/sources.toml`
+  joins the existing `~/.devboy/config.toml` and the ADR-020
+  `~/.devboy/secrets/index.toml`.
+- ❌ **Built-in sources couple the binary to upstream CLI versions.**
+  A breaking change in `op` or `vault` may surface as a new
+  validation failure. **Mitigation:** integration tests in CI run
+  against pinned versions of the upstream CLIs.
+- ❌ **Subprocess plugins double the install surface for users who
+  want non-built-in backends.** Discovery, signing, and update of
+  plugins is itself a problem; this ADR ships the protocol but
+  defers a managed plugin registry to a later decision.
+
+### Risks
+
+- ⚠️ **Cache outliving an upstream rotation.** A secret rotated in
+  Vault is still served from the in-process cache for up to fifteen
+  minutes. **Mitigation:** the upper bound is bounded; sources
+  expose `validate()` so a misbehaving downstream can be told to
+  flush; `secrets refresh` is one command.
+- ⚠️ **Misconfigured route silently routes to the wrong upstream.**
+  A typo in a `prefix` lands a `team/...` path in the keychain
+  instead of Vault. **Mitigation:** `devboy doctor` shows the
+  resolved source for every required path; a route that resolves
+  to the default source for a non-default prefix is flagged.
+- ⚠️ **A compromised source CLI in PATH.** Covered in the threat
+  model above; the mitigation is absolute paths plus checksums.
+- ⚠️ **Subprocess plugin lifetime leaks.** A plugin that fails to
+  exit cleanly leaves zombies. **Mitigation:** the router enforces
+  a kill timeout (default ten seconds after idle) and reports
+  zombies in `doctor`.
+
+## Alternatives Considered
+
+### Alternative 1: Single static backend, configured globally
+
+**Description:** Pick one backend per machine (keychain *or* Vault
+*or* 1Password) and configure the whole tree to live there.
+
+**Why rejected:** Real users hold mixes — a personal 1Password vault
+plus a team Vault plus a CI env-store. A single-backend model forces
+either duplication (copy team secrets into 1Password as well) or a
+manual ladder of fallbacks. The routing layer is the price of
+honest support.
+
+### Alternative 2: Use environment variables only outside the keychain
+
+**Description:** Treat external sources as a CI-only concern and
+keep the local-development story keychain-only.
+
+**Why rejected:** This is the status quo of ADR-005; teams already
+on 1Password or Vault either bypass `devboy-tools` or keep stale
+copies of credentials in two places. The point of this ADR is
+exactly to make 1Password and Vault first-class on the developer
+machine.
+
+### Alternative 3: Dynamic linking / WASM plugin model
+
+**Description:** Load source plugins as `.so` / `.dylib` files via
+`libloading`, or as WASM modules.
+
+**Why rejected:** Both options raise the floor for plugin authors
+(cross-compilation, ABI stability, sandbox escape stories) and
+deliver no advantage over a subprocess. Stdio JSON-RPC is the same
+protocol shape MCP already uses, which means existing tooling
+applies (logging, tracing, fault injection in tests).
+
+### Alternative 4: Per-source secret store with no router
+
+**Description:** Each source manages its own paths; the manifest
+declares the source per secret directly; there is no global routing
+layer.
+
+**Why rejected:** This works for two or three secrets and breaks
+once a team has a hundred. A team-wide migration from one Vault
+mount to another would touch every manifest in every project.
+Routing is exactly the indirection that lets such a migration be
+one configuration change.
+
+### Alternative 5: Always cache to disk
+
+**Description:** Persist the cache between runs, encrypted with a
+keychain-stored key.
+
+**Why rejected:** The point of an external source is that it is the
+authoritative copy. A persisted cache reintroduces stale-value
+problems — exactly what ADR-005's keychain-only model already
+exhibits in mixed environments. The fifteen-minute in-memory cache
+is a UX accelerator, not a store.
+
+## Implementation
+
+- **Issues:**
+  - [#246](https://github.com/meteora-pro/devboy-tools/issues/246) — design (ADR-020 + this ADR)
+  - [#247](https://github.com/meteora-pro/devboy-tools/issues/247) — implementation, phased
+- **Code (planned):**
+  - `crates/devboy-storage/` — `SecretSource` trait, router,
+    in-memory cache, source-credential resolution from
+    `__sources/...`
+  - `crates/plugins/secrets/keychain/` — built-in keychain source
+    (refactor of existing `KeychainStore`)
+  - `crates/plugins/secrets/1password/` — built-in 1Password CLI
+    source
+  - `crates/plugins/secrets/vault/` — built-in HashiCorp Vault
+    source
+  - `crates/plugins/secrets/env-store/` — built-in env-store source
+    with `DEVBOY_SECRETS_FILE` loader
+  - `crates/devboy-cli/` — `devboy secrets sources {list, install,
+    refresh, validate}` subcommands and `doctor` integration
+- **Subprocess protocol:** documented under
+  `docs/guide/secrets/source-plugin-protocol.md` (planned).
+- **Migration:** ADR-005 keychain remains the default for paths that
+  do not match any route; existing entries continue to be readable
+  after upgrade. ADR-020 migration tooling rewrites legacy keys to
+  the new convention; this ADR's routing then picks them up.
+
+## References
+
+- [ADR-005: Credential storage](./ADR-005-credential-storage.md) —
+  the prior single-backend layout this ADR generalises
+- [ADR-019: Secrets carry SecretString end-to-end](./ADR-019-secret-string-discipline.md)
+  — the type discipline that flows through the router unchanged
+- [ADR-020: Secret manifest, path convention, and alias resolution](./ADR-020-secret-manifest-and-alias-resolution.md)
+  — the namespace and manifest above the router
+- [HashiCorp Vault — KV v2 secret engine](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2)
+- [1Password CLI — `op` reference](https://developer.1password.com/docs/cli/)
+- [Model Context Protocol](https://modelcontextprotocol.io/) — the
+  stdio JSON-RPC shape adopted by the subprocess plugin protocol
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-06 | Andrei Mazniak | Initial draft |

--- a/docs/architecture/adr/INDEX.md
+++ b/docs/architecture/adr/INDEX.md
@@ -22,6 +22,7 @@ This directory holds Architecture Decision Records (ADRs) for `devboy-tools`. Ea
 | [018](./ADR-018-plugin-distribution.md) | Distribution as Claude Code and Codex plugins with agent-driven bootstrap | proposed | Distribution, Onboarding |
 | [019](./ADR-019-secret-string-discipline.md) | Secrets carry `SecretString` end-to-end | accepted | Security, Storage, Providers |
 | [020](./ADR-020-secret-manifest-and-alias-resolution.md) | Secret manifest, path convention, and alias resolution | proposed | Security, Secrets, Manifest, Core |
+| [021](./ADR-021-external-secret-sources.md) | External secret sources and backend routing | proposed | Security, Secrets, Plugins, Storage |
 
 **Number gaps** (006, 008, 009, 011) are intentional. Those numbers are reserved for decisions that are not in scope for this project.
 

--- a/docs/architecture/adr/INDEX.md
+++ b/docs/architecture/adr/INDEX.md
@@ -21,6 +21,7 @@ This directory holds Architecture Decision Records (ADRs) for `devboy-tools`. Ea
 | [017](./ADR-017-agent-detection-and-onboard.md) | Agent detection and `devboy onboard` command | proposed | Onboarding, Skills |
 | [018](./ADR-018-plugin-distribution.md) | Distribution as Claude Code and Codex plugins with agent-driven bootstrap | proposed | Distribution, Onboarding |
 | [019](./ADR-019-secret-string-discipline.md) | Secrets carry `SecretString` end-to-end | accepted | Security, Storage, Providers |
+| [020](./ADR-020-secret-manifest-and-alias-resolution.md) | Secret manifest, path convention, and alias resolution | proposed | Security, Secrets, Manifest, Core |
 
 **Number gaps** (006, 008, 009, 011) are intentional. Those numbers are reserved for decisions that are not in scope for this project.
 


### PR DESCRIPTION
## Summary

Two related Architecture Decision Records that design the secret management framework on top of the current ADR-005 credential store and ADR-019 SecretString discipline. Implementation is tracked separately in #247.

- **ADR-020 — Secret manifest, path convention, and alias resolution**
  Adds a global flat path namespace, a hard naming convention (3+ kebab-case segments, reserved `__*` and `_test/*`), a metadata-only global index at `~/.devboy/secrets/index.toml`, a committed per-project manifest at `.devboy/secrets.toml`, alias-based references via `@secret:<path>` (resolved in configs / argv / HTTP proxy / MCP tools), a validation framework (format + liveness + expiry), and soft enforcement of cross-context access through MCP manifest gating.

- **ADR-021 — External secret sources and backend routing**
  Splits the credential store into a router and a set of pluggable backends (`SecretSource` trait with explicit capabilities). Routing is prefix-based with per-secret overrides at `~/.devboy/secrets/sources.toml`. Multiple instances of the same source type are addressable side by side. Per-context source-credential profiles let a context flip the role used against an upstream. Subprocess plugin protocol (JSON-RPC over stdio) lets community backends ship as separate binaries. In-memory TTL cache. First-release built-ins: `keychain`, `1password`, `vault`, and a first-class `env-store` for CI / containers / bare Linux with `DEVBOY_SECRETS_FILE` loader and CI auto-detection. Doctor surfaces source availability + per-secret status.

## Threat model

Both ADRs state explicitly that the framework protects against **accidental** leakage (logs, transcripts, commits, crash dumps, shell history, `ps`, cross-context misuse). They do **not** claim isolation against a malicious agent — a shell-capable agent can always dump its own environment. ADR-021 documents one new attack surface (compromised source CLIs) and the mitigations (absolute paths, binary checksums, no shell invocation).

## Notes

- Examples in both ADRs are intentionally abstract — `team/`, `personal/`, `client-acme/`, `sandbox/`, `vault.example.internal`. No real client / team / infra references.
- Both ADRs marked `proposed`; they flip to `accepted` once implementation lands per #247.
- Implementation is phased and tracked in #247 (eleven phases, each a small reviewable PR).

## Test plan

- [x] Read ADR-020 end to end; comment on path convention, manifest schema, and threat model
- [x] Read ADR-021 end to end; comment on `SecretSource` trait, routing, subprocess protocol, and built-in source coverage
- [ ] Confirm INDEX entries are consistent (numbering, status, scope)
- [ ] Confirm no real client / team / infra references slipped through

Closes #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)