### PR TITLE
docs(adr): rewrite ADR-020/021 + add ADR-023 secret store UX layer

### DIFF
--- a/docs/architecture/adr/ADR-020-secret-manifest-and-alias-resolution.md
+++ b/docs/architecture/adr/ADR-020-secret-manifest-and-alias-resolution.md
@@ -72,7 +72,7 @@ skill) is the subject of [ADR-023](./ADR-023-secret-store-ux-layer.md).
 ### Differences from the 2026-05-06 draft
 
 The previous draft of this ADR insisted that a secret's metadata
-(`description`, `retrieval_hint`, …) lives **only** in the global index
+(`description`, `retrieval_url`, …) lives **only** in the global index
 and that the per-project manifest carries only references and behavioural
 overrides. Design review surfaced two reasons that rule was too strict:
 
@@ -194,7 +194,7 @@ carries:
 ```toml
 [secret."team/gitlab/token-deploy"]
 description       = "Deploy token for the team GitLab; used by CI mirrors and devboy plugins"
-retrieval_hint    = "https://gitlab.example.internal/-/profile/personal_access_tokens"
+retrieval_url    = "https://gitlab.example.internal/-/profile/personal_access_tokens"
 format_regex      = "^glpat-[A-Za-z0-9_-]{20,}$"
 default_gate      = "auto"        # auto | confirm | touchid
 expires_at        = "2026-08-01"  # optional, populated by validation if upstream exposes it
@@ -208,7 +208,7 @@ pattern_id        = "gitlab-pat"  # optional, reference into devboy-secret-patte
 `pattern_id` is a new field that links the entry to a built-in pattern
 in the `devboy-secret-patterns` crate (see [ADR-023](./ADR-023-secret-store-ux-layer.md)
 section 3.6). When set, the pattern supplies sensible defaults for
-`format_regex`, `retrieval_hint`, `rotation_method`, and `default_expiry_days`
+`format_regex`, `retrieval_url`, `rotation_method`, and `default_expiry_days`
 that the entry inherits unless explicitly overridden.
 
 No secret value is ever written to the index. The credential store from
@@ -235,7 +235,7 @@ optional = [
 ]
 
 # Per-secret overrides — behavioural fields and project-local description.
-# Other metadata (retrieval_hint, format_regex, rotation_method) is read
+# Other metadata (retrieval_url, format_regex, rotation_method) is read
 # from the global index only.
 
 [overrides."team/gitlab/token-deploy"]
@@ -249,7 +249,7 @@ description       = "Used by the staging deploy pipeline; contact ops before rot
 
 [secret."sandbox/example-provider/token"]
 description    = "Token for the example-provider sandbox account used only by this repo"
-retrieval_hint = "https://example-provider.dev/account/api-tokens"
+retrieval_url = "https://example-provider.dev/account/api-tokens"
 pattern_id     = "generic-bearer"
 ```
 

--- a/docs/architecture/adr/ADR-020-secret-manifest-and-alias-resolution.md
+++ b/docs/architecture/adr/ADR-020-secret-manifest-and-alias-resolution.md
@@ -2,7 +2,7 @@
 id: ADR-020
 title: Secret manifest, path convention, and alias resolution
 status: proposed
-date: 2026-05-06
+date: 2026-05-09
 deciders: ["Andrei Mazniak"]
 tags: ["security", "secrets", "manifest", "core"]
 supersedes: null
@@ -13,7 +13,7 @@ superseded_by: null
 
 ## Status
 
-**proposed**
+**proposed** (rewrite of the 2026-05-06 draft after design review)
 
 ## Context
 
@@ -43,9 +43,9 @@ problems on the table:
   HTTP call that uses it; the failure mode is a generic 401 from a
   third-party API, not "the value you stored doesn't match the expected
   format for this provider".
-- **No expiry tracking.** Personal access tokens commonly expire after
-  90 days. Nothing in the current system warns the user before that
-  happens.
+- **No expiry tracking and no rotation cadence.** Personal access tokens
+  commonly expire after 90 days. Nothing in the current system warns the
+  user before that happens or records when the token was last rotated.
 - **No boundary between contexts.** If an agent operates in `context A`
   but asks for a credential that "logically" belongs to `context B`, the
   request succeeds silently as long as the keychain entry exists. There
@@ -63,8 +63,30 @@ defined by ADR-005 stays where it is — this ADR adds discovery,
 declaration, and resolution discipline on top of it.
 
 External secret sources (1Password CLI, HashiCorp Vault, AWS Secrets
-Manager, an env-only store for CI, etc.) are out of scope here and are
-the subject of [ADR-021](./ADR-021-external-secret-sources.md).
+Manager, an env-only store for CI, an encrypted local vault, etc.) are
+out of scope here and are the subject of [ADR-021](./ADR-021-external-secret-sources.md).
+The user-facing UX layer (encrypted local vault crypto, native UI,
+manual-assisted rotation flow, agent provisioning protocol, onboarding
+skill) is the subject of [ADR-023](./ADR-023-secret-store-ux-layer.md).
+
+### Differences from the 2026-05-06 draft
+
+The previous draft of this ADR insisted that a secret's metadata
+(`description`, `retrieval_hint`, …) lives **only** in the global index
+and that the per-project manifest carries only references and behavioural
+overrides. Design review surfaced two reasons that rule was too strict:
+
+1. Some secrets are genuinely project-local (a sandbox account's API key,
+   a one-off integration token used by exactly one repo). Forcing them
+   into the global index creates a registry of secrets that no one else
+   needs to know about.
+2. Project-specific *context* — "this token is the one our CI uses for
+   the staging deploy" — is useful next to the manifest entry, even when
+   a global description already exists.
+
+The rewrite therefore allows per-project metadata in addition to global,
+with explicit conflict-resolution rules and a `doctor` warning when the
+two diverge. See section 4 below.
 
 ### Threat model (explicit)
 
@@ -89,13 +111,14 @@ process and is out of scope.
 
 > **Decision:** A secret in `devboy-tools` has a fixed name (its **path**)
 > drawn from a single global namespace, declared in a project-level
-> **manifest** that is committed to source, with metadata kept in a global
-> **index**. Code, configuration, and command lines reference a secret by
-> its path through the alias form `@secret:<path>`; values are resolved
-> on demand through the existing credential store and never stored
-> alongside the reference.
+> **manifest** that is committed to source. Metadata may live in either
+> the **global index** or the per-project manifest, with the per-project
+> manifest taking precedence in conflicts. Code, configuration, and
+> command lines reference a secret by its path through the alias form
+> `@secret:<path>`; values are resolved on demand through the existing
+> credential store and never stored alongside the reference.
 
-The decision has six parts.
+The decision has eight parts.
 
 ### 1. A single global flat namespace
 
@@ -177,20 +200,20 @@ default_gate      = "auto"        # auto | confirm | touchid
 expires_at        = "2026-08-01"  # optional, populated by validation if upstream exposes it
 last_rotated_at   = "2026-05-02"  # optional, advisory
 rotate_every_days = 90            # optional, drives doctor warnings
+rotation_method   = "manual"      # manual | provider-ui | provider-api (reserved for future)
 required_scopes   = ["api", "read_repository"]  # optional, advisory
+pattern_id        = "gitlab-pat"  # optional, reference into devboy-secret-patterns
 ```
 
-No secret value is ever written to the index. The credential store from
-ADR-005 remains the only place values live.
+`pattern_id` is a new field that links the entry to a built-in pattern
+in the `devboy-secret-patterns` crate (see [ADR-023](./ADR-023-secret-store-ux-layer.md)
+section 3.6). When set, the pattern supplies sensible defaults for
+`format_regex`, `retrieval_hint`, `rotation_method`, and `default_expiry_days`
+that the entry inherits unless explicitly overridden.
 
-The index is the **source of truth for ownership of metadata**. A
-per-project manifest (next section) may not invent metadata for a path
-that is not described in the global index. The reasoning: if every
-project can invent its own description and `retrieval_hint`, the
-metadata diverges, defeating the purpose of a shared namespace. New
-paths must first be described in the global index (interactively
-during `secrets bootstrap`, or by hand), and only then be referenced
-from projects.
+No secret value is ever written to the index. The credential store from
+ADR-005 (and the source router from ADR-021) remains the only place
+values live.
 
 ### 4. Per-project manifest (`.devboy/secrets.toml`)
 
@@ -199,30 +222,81 @@ in a manifest committed to the repository:
 
 ```toml
 # .devboy/secrets.toml
+
 required = [
     "team/gitlab/token-deploy",
     "personal/github/pat",
     "personal/anthropic/api-key",
+    "sandbox/example-provider/token",
 ]
 
 optional = [
     "personal/slack/notify-token",   # the notify skill works without it
 ]
 
+# Per-secret overrides — behavioural fields and project-local description.
+# Other metadata (retrieval_hint, format_regex, rotation_method) is read
+# from the global index only.
+
 [overrides."team/gitlab/token-deploy"]
-gate = "touchid"   # this project tightens the default gate for this secret
+gate              = "touchid"   # this project tightens the default gate
+rotate_every_days = 30          # this project requires more frequent rotation
+description       = "Used by the staging deploy pipeline; contact ops before rotating"
+
+# A path may be declared project-local — its metadata lives in this manifest
+# and is not registered in the global index. This is intended for genuinely
+# single-project secrets (sandbox accounts, one-off integration tokens).
+
+[secret."sandbox/example-provider/token"]
+description    = "Token for the example-provider sandbox account used only by this repo"
+retrieval_hint = "https://example-provider.dev/account/api-tokens"
+pattern_id     = "generic-bearer"
 ```
 
-The manifest contains **only references and project-local overrides**.
-No values, no descriptions, no retrieval hints — those live in the
-global index and apply uniformly across every project that references
-the same path.
+The manifest carries three things:
+
+- A list of **required** and **optional** paths. `doctor` fails the
+  exit code on a missing required path; missing optional paths surface
+  as informational.
+- Behavioural **overrides** — `gate`, `rotate_every_days`, and a
+  project-local `description` — for paths whose canonical metadata
+  lives in the global index. Overrides for any other field are
+  rejected by the loader.
+- **Project-local metadata** for paths declared as project-owned (the
+  `[secret."..."]` block). The loader treats such a path as if its
+  global-index entry were absent: the manifest is the source of truth.
+
+#### Conflict resolution rules
+
+The loader merges metadata for each required/optional path according to
+the following precedence:
+
+1. If the path appears as `[secret."<path>"]` in the manifest, its
+   metadata is read from the manifest only. The path is project-local.
+2. Otherwise, metadata is read from the global index. If the manifest
+   has an `[overrides."<path>"]` block, the listed behavioural fields
+   override the index values.
+3. If a path appears in `required` / `optional` and exists in **neither**
+   the global index nor as `[secret."..."]`, the loader fails with
+   `E_SECRET_UNKNOWN_PATH` and points at `devboy secrets bootstrap` or
+   `devboy secrets describe <path>` to register it.
+
+If `[overrides."<path>"]` mentions a field that is not one of the allowed
+behavioural fields (for example, attempts to override `format_regex`),
+the loader fails with `E_OVERRIDE_FIELD_NOT_ALLOWED`. This is enforced as
+a hard error rather than a warning so that drift between the index and
+the manifest cannot grow silently.
+
+`devboy doctor` additionally surfaces a **warning** (not an error) when
+an `[overrides]` value is the same as the corresponding global value —
+the override is a no-op and should be removed.
 
 Committing the manifest gives a team three things:
 
 - **Onboarding-as-data.** A new contributor runs `devboy secrets
-  bootstrap` and walks through every required secret with system
-  prompts; missing entries are filled in interactively.
+  bootstrap` (or invokes the `setup-secrets` skill — see ADR-023) and
+  walks through every required secret with system prompts; missing
+  entries are filled in interactively.
 - **Visibility of cross-project reuse.** Tooling can compute "this
   secret is referenced by N projects" by walking known manifests.
 - **A target for review.** A pull request that adds a new required
@@ -272,48 +346,61 @@ Four substitution points are supported:
   alias.
 
 - **MCP tool requests from agents.** An agent that needs a value to
-  perform a high-level operation calls a typed MCP tool such as
-  `secrets.get(path)`, subject to the soft enforcement described in
-  section 7. The preferred mode, however, is for the agent to call
-  the high-level provider tool directly (`gitlab.create_merge_request`)
-  and let `devboy-tools` resolve the credential server-side, so the
-  value never crosses the agent boundary at all.
+  perform a high-level operation calls a typed MCP tool. Per
+  [ADR-023](./ADR-023-secret-store-ux-layer.md) section 3.7, agents
+  do **not** have a `secrets.get` tool; the only legitimate path for
+  a value to be used is through a high-level provider tool
+  (`gitlab.create_merge_request`) where `devboy-tools` resolves the
+  credential server-side and the value never crosses the agent
+  boundary.
 
 The alias prefix is `@secret:` rather than something like `${SECRET:...}`
 so that it cannot be accidentally interpreted by a shell expansion or
 by a templating engine that doesn't know about `devboy-tools`.
 
+A pre-commit hook (`devboy hooks install --secret-alias-lint`) is
+provided as a defensive measure: if an unresolved `@secret:<path>` ends
+up committed in a file that is **not** known to be alias-aware (for
+example, an arbitrary `.env` file that is not loaded through the
+`devboy-tools` config loader), the hook fails the commit and prints
+the offending file and line.
+
 ### 6. Validation framework
 
-Each entry in the global index can declare validation. There are three
-levels, executed lazily and on demand by `devboy secrets validate`,
-`devboy doctor`, and (optionally) on `bootstrap`:
+Each entry in the global index — or the equivalent project-local entry
+— can declare validation. There are three levels, executed lazily and
+on demand by `devboy secrets validate`, `devboy doctor`, and (optionally)
+on `bootstrap`:
 
-- **Format validation.** A `format_regex` in the index. Cheap, runs
-  offline, catches typos and accidental `gh_xxx` vs `ghp_xxx` mixups.
+- **Format validation.** A `format_regex` in the index, or one inherited
+  from a `pattern_id`. Cheap, runs offline, catches typos and
+  accidental `gh_xxx` vs `ghp_xxx` mixups.
 - **Liveness validation.** Provider plugins (the existing API plugins
   under `crates/plugins/api/*`) expose a `test` method that performs
   a known-cheap authenticated call. Liveness is opt-in per secret;
   the validator looks up the provider from the path's second segment
-  unless an explicit `validation` block names a different one.
+  unless an explicit `validation` block names a different one. The
+  `devboy-secret-patterns` crate (ADR-023) supplies a default liveness
+  recipe per pattern (e.g., `GET /user` for GitHub).
 - **Expiry and rotation tracking.** When the upstream API returns an
   expiry (GitLab and GitHub PATs do, for example), liveness validation
   records `expires_at` back into the global index. `rotate_every_days`
   paired with `last_rotated_at` produces advisory warnings. `doctor`
   surfaces "expires in N days" warnings under a fixed threshold
-  (default seven days).
+  (default seven days) and may invoke the `notify` skill if the user
+  has wired it up.
 
 Validation never reads values from anywhere other than the credential
 store, never logs them, and never writes them to the index.
 
 ### 7. Soft enforcement through manifest gating
 
-The MCP API exposes `secrets.get(path)` (and `secrets.describe`,
-`secrets.search`) for use by agents. By default, `secrets.get` resolves
-a path **only if the path is declared in the manifest of the active
-context**. A path that exists in the global keychain but is not declared
-in the active manifest yields a structured error (`E_SECRET_NOT_IN_MANIFEST`)
-rather than the secret value.
+The MCP API exposes only **non-value** secret tools to agents — see
+[ADR-023](./ADR-023-secret-store-ux-layer.md) section 3.7 for the full
+list. The router-side resolver, used by high-level provider tools, also
+enforces a manifest gate: a path that exists in the global keychain but
+is not declared in the active context's manifest yields a structured
+error (`E_SECRET_NOT_IN_MANIFEST`) rather than the secret value.
 
 This is **soft enforcement**, not isolation:
 
@@ -331,22 +418,57 @@ The benefit is that the dominant accidental-misuse pattern — an agent
 keychain — fails closed and produces an error message that names the
 manifest as the place to add the dependency.
 
+### 8. Migration from ADR-005 keychain entries
+
+Existing keychain entries written under the legacy
+`<provider>.<credential>` shape (per ADR-005) are not valid paths
+under section 2. Migration is a two-step process:
+
+1. **`devboy doctor` reports nonconformant entries** as a new check
+   `secrets-path-convention`. Each row names the legacy key, the
+   suggested canonical path, and the `devboy secrets migrate <legacy>`
+   one-liner.
+2. **`devboy secrets migrate`** is a CLI subcommand that walks an
+   interactive flow per entry: confirm or edit the suggested path,
+   choose `scope` (`team` / `personal` / `client-...` / `sandbox`),
+   write the new keychain entry through the source router, register
+   the path in the global index, and optionally delete the legacy
+   entry. The original entry is left alone unless the user explicitly
+   asks for cleanup.
+
+Until the migration is complete, both shapes coexist:
+
+- The legacy `CredentialStore::get` API continues to read legacy keys
+  for code that has not yet been moved over to alias resolution.
+- The new manifest layer ignores legacy keys; references through
+  `@secret:<path>` use only the new namespace.
+
+A flag in `~/.devboy/config.toml`
+(`[secrets] migration_complete = true`) marks the keychain as fully
+migrated and disables the legacy reader, so a stale legacy entry cannot
+be silently picked up after migration.
+
 ## Consequences
 
 ### Positive
 
 - ✅ **Onboarding becomes data, not lore.** A new contributor runs
-  `devboy secrets bootstrap`, the manifest drives an interactive walk
+  `setup-secrets` (the skill from ADR-023, which delegates to
+  `devboy secrets bootstrap`), the manifest drives an interactive walk
   through every required secret, and the system prompts use the
-  global index's `retrieval_hint` to point at the right page.
+  retrieval hint to point at the right page.
 - ✅ **Reuse without duplication.** A personal token is provisioned
   once and referenced from every project; rotation happens in one place.
+- ✅ **Project-local secrets are first-class.** A genuine one-off
+  token does not pollute the shared global index.
 - ✅ **Aliases in code, not values.** `@secret:<path>` makes plaintext
   in committed configuration a contradiction: a value next to the
-  alias means someone bypassed the resolver.
+  alias means someone bypassed the resolver. The pre-commit hook
+  catches the obvious miss-pastes.
 - ✅ **Drift becomes visible.** A secret that expires, fails liveness,
   or is missing surfaces in `doctor`; a secret that is referenced
-  with a non-conformant path fails validation at load time.
+  with a non-conformant path fails validation at load time; an
+  override that no longer differs from the global value warns.
 - ✅ **Manifest review.** A change to required secrets is a change
   to a tracked file, reviewable in a pull request.
 
@@ -354,20 +476,19 @@ manifest as the place to add the dependency.
 
 - ❌ **Two new files in the user's home directory.**
   `~/.devboy/secrets/index.toml` (metadata) is added on top of the
-  existing `~/.devboy/config.toml`.
+  existing `~/.devboy/config.toml`. ADR-021 adds a third
+  (`sources.toml`); ADR-023 adds a fourth (`local-vault.dvb`).
 - ❌ **One new file in each project that opts in.** `.devboy/secrets.toml`
   is small but it is one more committed file.
 - ❌ **Hard path convention is a one-way migration.** Existing
   keychain entries with names like `gitlab.token` are not valid paths
-  under the new convention. ADR-005 entries continue to be readable
-  through the legacy `CredentialStore` API, but the new manifest
-  layer ignores them; a migration step is required (tracked in the
-  implementation issue).
-- ❌ **Authoring overhead for new secrets.** A new path requires an
-  index entry before a manifest may reference it. The `bootstrap`
-  flow asks for the necessary metadata interactively, but for a
-  user accustomed to "just put a token in the keychain" this is one
-  extra step.
+  under the new convention; the migration tool covers the mechanics
+  but the user has to walk through it once per machine.
+- ❌ **Two valid sources of metadata.** Per-project and global both
+  carry metadata, and the precedence rules have to be learned. The
+  loader's hard error on disallowed override fields and `doctor`'s
+  no-op-override warning keep the surprise small, but it is more to
+  document than a single source.
 
 ### Risks
 
@@ -377,25 +498,33 @@ manifest as the place to add the dependency.
   README); for a private repository describing a sensitive
   integration, the project may prefer to keep the manifest in a
   private companion repo. **Mitigation:** the manifest path is
-  configurable; teams can place it outside the main repo if needed.
+  configurable through `~/.devboy/config.toml`; teams can place it
+  outside the main repo if needed.
 - ⚠️ **Alias-bypass via direct env-var read.** A library or tool
   that reads `process.env.GITLAB_TOKEN` directly (without going
   through the resolver) bypasses the alias system entirely.
   **Mitigation:** scope of this ADR is `devboy-tools`-mediated
   configuration; third-party tools using their own conventions are
-  out of scope. CI checks (similar to ADR-019's `secrets-discipline`
-  job) flag direct token reads inside `crates/`.
+  out of scope. The CI grep gate from ADR-019
+  (`secrets-discipline`) flags direct token reads inside `crates/`.
 - ⚠️ **`@secret:` aliases in unmediated config.** A user copies an
   alias-bearing config snippet into a tool that does not understand
   `@secret:`, and the tool sends the literal string `@secret:...` as
   the credential. **Mitigation:** the alias prefix is documented and
   conspicuous; the wrapper tools explicitly fail closed when
-  encountering an unresolved alias at exec time.
+  encountering an unresolved alias at exec time; the pre-commit hook
+  flags unresolved aliases in committed files.
 - ⚠️ **Validation false negatives mask real expiry.** If a provider
   API returns 200 even with a token that is two days from expiring,
   liveness validation does not catch it. **Mitigation:** rotation
   reminders driven by `last_rotated_at` and `rotate_every_days` are
   independent of liveness and run regardless of upstream behaviour.
+- ⚠️ **Per-project metadata divergence.** A project-local
+  `description` for a globally-known path can drift from the global
+  one over time. **Mitigation:** the manifest's `[overrides]` block
+  is the only place to add a project-local description for a global
+  path; the loader's no-op-override warning is the existing
+  cleanup signal.
 
 ## Alternatives Considered
 
@@ -426,16 +555,19 @@ real policy engine is needed in the future, it can be introduced as a
 separate decision, ideally by delegating to an external source (see
 ADR-021).
 
-### Alternative 3: No manifest, only the global index
+### Alternative 3: Global index is the only source of metadata (the prior draft)
 
-**Description:** Drop the per-project manifest and let the index
-itself declare which secrets each project needs.
+**Description:** Do not allow per-project metadata. Any secret
+referenced from a manifest must first be described in the global
+index. The manifest carries only references and behavioural overrides.
 
-**Why rejected:** The point of a per-project manifest is that it lives
-**in the project's repository**, where it can be reviewed, tested in CI
-("does this project still claim secrets it no longer uses?"), and used
-to bootstrap new contributors. A central declaration in `~/.devboy/`
-cannot fulfil any of those.
+**Why rejected:** Genuinely project-local secrets (sandbox accounts,
+one-off integration tokens) are forced into a registry that no other
+project needs. Project-specific *context* — "in this repo this token
+is the staging deploy one" — has nowhere to live except as duplication
+in code comments. The current decision keeps the global index as the
+canonical source for shared metadata, but allows per-project
+description and project-local entries for the long tail.
 
 ### Alternative 4: Encrypted file with embedded values (sealed manifest)
 
@@ -444,10 +576,12 @@ with a per-user master key (age, sops, gpg).
 
 **Why rejected:** A sealed file requires a master-key prompt on every
 invocation (or a long-running agent process holding the key in
-memory), which is exactly the ergonomic regression ADR-005 already
-considered and rejected. ADR-005's keychain-plus-env-fallback model
-remains the right place for values; this ADR layers metadata and
-discovery on top of it.
+memory). [ADR-023](./ADR-023-secret-store-ux-layer.md) introduces
+exactly such an agent-and-vault pair as a *fallback* source for
+environments without a keychain — but that is one source among several
+managed by the router (ADR-021), not the single transport for all
+metadata. Forcing every metadata read through a vault-unlock prompt
+would be the regression ADR-005 already considered and rejected.
 
 ### Alternative 5: Free-form path convention with linting only
 
@@ -462,26 +596,32 @@ cheapest mechanism for preventing the namespace from re-fragmenting.
 ## Implementation
 
 - **Issues:**
-  - [#246](https://github.com/meteora-pro/devboy-tools/issues/246) — design (this ADR + ADR-021)
+  - [#246](https://github.com/meteora-pro/devboy-tools/issues/246) — original design (this ADR + ADR-021)
   - [#247](https://github.com/meteora-pro/devboy-tools/issues/247) — implementation, phased
+  - To be filed — design refresh covering the rewritten ADR-020/021 and the new ADR-023
 - **Code (planned):**
   - `crates/devboy-storage/` — extend with manifest loader, global
-    index, path validator
+    index, path validator, override merge logic
   - `crates/devboy-core/` — config-loader integration with
     `@secret:` resolution
   - `crates/devboy-executor/` — argv-substitution wrapper with
     stdin/FD pass-through
-  - `crates/devboy-mcp/` — `secrets.*` tool surface, manifest gating,
-    `Authorization` header rewriting in `proxy.rs`
+  - `crates/devboy-mcp/` — manifest gating, `Authorization` header
+    rewriting in `proxy.rs`
   - `crates/devboy-cli/` — `devboy secrets {list, describe, validate,
-    bootstrap}` subcommands
+    bootstrap, migrate}` subcommands; `devboy hooks install
+    --secret-alias-lint`
 - **Migration:** legacy keychain entries from ADR-005 remain readable
-  through the existing API; a migration tool walks them, asks the
-  user for the canonical path under the new convention, and rewrites
-  the index. Tracked as a separate phase in #247.
+  through the existing API until `[secrets] migration_complete = true`
+  is set in `~/.devboy/config.toml`. The migration tool walks them,
+  asks the user for the canonical path under the new convention, and
+  rewrites the index. Tracked as a separate phase in #247.
 
 External secret sources, source routing, and per-context source
-credentials are deferred to ADR-021.
+credentials are deferred to ADR-021. The encrypted local vault, the
+native UI, the manual-assisted rotation flow, the pattern catalogue,
+the agent provisioning protocol, and the `setup-secrets` skill are
+deferred to ADR-023.
 
 ## References
 
@@ -490,8 +630,10 @@ credentials are deferred to ADR-021.
 - [ADR-019: Secrets carry SecretString end-to-end](./ADR-019-secret-string-discipline.md)
   — how values are typed in transit through the process
 - [ADR-021: External secret sources](./ADR-021-external-secret-sources.md)
-  — pluggable backends (1Password, Vault, AWS, env-store, …) sitting
-  behind the same path namespace
+  — pluggable backends sitting behind the same path namespace
+- [ADR-023: Secret store UX layer](./ADR-023-secret-store-ux-layer.md)
+  — encrypted local vault, native UI, agent provisioning protocol,
+  pattern catalogue, manual-assisted rotation, `setup-secrets` skill
 - [`secrecy` crate documentation](https://docs.rs/secrecy/)
 - [HashiCorp Vault — KV namespace concepts](https://developer.hashicorp.com/vault/docs/secrets/kv) — inspiration for path-based addressing
 
@@ -502,3 +644,4 @@ credentials are deferred to ADR-021.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-06 | Andrei Mazniak | Initial draft |
+| 2026-05-09 | Andrei Mazniak | Rewrite after design review: per-project metadata is allowed alongside global; conflict-resolution rules added; migration tooling section made explicit; references to ADR-023 (UX layer) added |

--- a/docs/architecture/adr/ADR-021-external-secret-sources.md
+++ b/docs/architecture/adr/ADR-021-external-secret-sources.md
@@ -148,12 +148,18 @@ two new flags are descriptive — they let `doctor` and the agent
 provisioning surface (see [ADR-023](./ADR-023-secret-store-ux-layer.md)
 section 3.7) reason about UX trade-offs:
 
-- `BIOMETRIC_PROMPT` — the source prompts for biometric or PIN
-  unlock on every read in its default configuration. The router
-  surfaces this as a `cost` hint to agents so that an agent loop
+- `BIOMETRIC_PROMPT` — the source **may** require user-presence
+  confirmation (biometric unlock or a PIN/passphrase prompt) on at
+  least one of its operations in its default configuration. The
+  flag is a single bit on the source as a whole — it does not
+  encode "prompts only on writes" or "prompts only on reads", and
+  the router does not infer per-operation cost from it. Sources
+  whose reads are usually cached but whose writes always prompt
+  (e.g. the local-vault, see §8) still set the flag. The router
+  surfaces it as a `cost` hint to agents so that an agent loop
   doing twelve reads per minute does not blindly trigger twelve
-  TouchID prompts; the agent should batch through a high-level
-  provider tool instead.
+  prompts; the agent should batch through a high-level provider
+  tool instead.
 - `AUDIT_LOGGED` — every read is durably logged on the upstream
   (Vault audit log, 1Password account activity). `doctor` shows
   this in the source-status section so the user knows their
@@ -443,10 +449,13 @@ or a BIP39 recovery phrase. Crypto, daemon protocol, and UI flows are
 the subject of [ADR-023](./ADR-023-secret-store-ux-layer.md).
 
 `reference` is the ADR-020 path itself. Capabilities:
-`READ | LIST | VALIDATE | WRITE | ROTATE | BIOMETRIC_PROMPT` (the
-biometric flag is set when the unlock method is the Touch-ID
-envelope; with a passphrase envelope only, the flag is absent on
-read but set on write/rotate where the passphrase is required again).
+`READ | LIST | VALIDATE | WRITE | ROTATE | BIOMETRIC_PROMPT`. The
+`BIOMETRIC_PROMPT` flag is always set because at least one operation
+of the source can prompt for user presence — write/rotate always
+require a fresh passphrase or biometric confirmation regardless of
+the daemon's unlocked state, and reads can prompt when the unlocked
+session has expired. Per the §1.1 contract, the bit reflects the
+source as a whole and does not vary by operation.
 
 The `local-vault` source is intended primarily for two scenarios:
 headless Linux machines without a Secret Service daemon (where it is

--- a/docs/architecture/adr/ADR-021-external-secret-sources.md
+++ b/docs/architecture/adr/ADR-021-external-secret-sources.md
@@ -2,7 +2,7 @@
 id: ADR-021
 title: External secret sources and backend routing
 status: proposed
-date: 2026-05-06
+date: 2026-05-09
 deciders: ["Andrei Mazniak"]
 tags: ["security", "secrets", "plugins", "storage"]
 supersedes: null
@@ -13,7 +13,7 @@ superseded_by: null
 
 ## Status
 
-**proposed**
+**proposed** (rewrite of the 2026-05-06 draft after design review)
 
 ## Context
 
@@ -37,6 +37,11 @@ Real-world deployments rarely live on one backend:
   The only shape that works is environment variables, possibly
   loaded from a file mounted by the orchestrator (Docker secrets,
   Kubernetes secret mounts).
+- **Headless Linux machines without a Secret Service daemon** still
+  need somewhere to store credentials at rest. Environment variables
+  alone are not always acceptable (containers that shell out to
+  child processes, dotfile managers that replicate `~`). An
+  encrypted file backed by a passphrase is the natural fallback.
 - **A single user routinely talks to several upstreams of the same
   type.** Two Vault servers under different addresses, two 1Password
   accounts (work and personal), two AWS profiles. Each carries its
@@ -48,17 +53,46 @@ Real-world deployments rarely live on one backend:
 
 ADR-020 left this surface deliberately empty. This ADR fills it.
 
+### Differences from the 2026-05-06 draft
+
+The previous draft of this ADR shipped four built-ins (`keychain`,
+`1password`, `vault`, `env-store`) and a single in-memory cache TTL.
+Design review surfaced four issues:
+
+1. There was no fallback for headless machines without a keychain
+   *and* without a configured external source. Falling all the way
+   through to env-only was acceptable for CI but not for local
+   off-network development.
+2. The `Capabilities` enum did not distinguish backends that prompt
+   for biometrics on every read (1Password CLI in the typical
+   configuration) from backends that don't. The router could not
+   warn the user when an agent loop would trigger N TouchID prompts.
+3. The cache TTL was a flat default. Backends that return short
+   leases (Vault dynamic secrets) became stale-by-design when the
+   default outlived the lease.
+4. CI behaviour was inferred from environment variables, not
+   selected. A developer running a CI script locally, or a CI
+   runner that did not set the expected variables, both got
+   surprising routing.
+
+The rewrite adds a fifth built-in (`local-vault`, with crypto and UX
+detailed in [ADR-023](./ADR-023-secret-store-ux-layer.md)),
+extends `Capabilities`, makes the cache TTL adaptive against upstream
+lease duration, and turns CI mode into an explicit setting rather
+than a heuristic.
+
 ## Decision
 
 > **Decision:** The credential store is split into a thin **router**
 > and a set of **secret-source plugins**. A secret path declared
 > through the ADR-020 manifest resolves through the router to exactly
 > one source, which in turn knows how to talk to its upstream
-> (keychain, 1Password CLI, HashiCorp Vault, an env-store backend, or
-> a community-supplied subprocess plugin). The router is the only
-> code that touches the manifest; the sources are interchangeable.
+> (keychain, 1Password CLI, HashiCorp Vault, an env-store backend,
+> the encrypted local vault from ADR-023, or a community-supplied
+> subprocess plugin). The router is the only code that touches the
+> manifest; the sources are interchangeable.
 
-The decision has eight parts.
+The decision has nine parts.
 
 ### 1. The `SecretSource` trait
 
@@ -69,30 +103,70 @@ trait is small and explicitly capability-aware:
 #[async_trait]
 pub trait SecretSource: Send + Sync {
     fn name(&self) -> &str;
-    fn capabilities(&self) -> Capabilities;     // READ | LIST | VALIDATE | WRITE | ROTATE
+    fn capabilities(&self) -> Capabilities;     // see section 1.1
+    fn requires_credential(&self) -> Option<CredentialRef>;  // see section 4
 
     async fn is_available(&self) -> SourceStatus;        // Available | Locked | NotInstalled | Error
-    async fn get(&self, reference: &str) -> Result<Option<SecretString>>;
+    async fn get(&self, reference: &str) -> Result<Option<GetOutcome>>;
     async fn list(&self) -> Result<Vec<RemoteRef>>;       // optional, used by discovery
     async fn validate(&self, reference: &str) -> Result<()>;
+}
+
+pub struct GetOutcome {
+    pub value: SecretString,
+    pub lease_duration: Option<Duration>,  // see section 7
 }
 ```
 
 `reference` is a backend-specific string — for example
 `op://Personal/GitHub PAT/credential` for 1Password,
 `secret/data/team/gitlab#token` for Vault KV v2, a flat key for the
-keychain, an environment-variable name for the env-store. Sources do
-**not** know about ADR-020 paths; mapping a path to a reference is the
-router's job (section 2). This separation lets a source plugin be
+keychain, an environment-variable name for the env-store, an ADR-020
+path itself for the local-vault. Sources do **not** know about ADR-020
+paths beyond using them as references; mapping a path to a reference is
+the router's job (section 2). This separation lets a source plugin be
 written without any awareness of the manifest layer.
 
-`capabilities()` lets the system reason about what a source can and
-cannot do. A read-only source (1Password CLI in the typical biometric
-configuration) declares `READ | LIST | VALIDATE`; an env-store
-declares `READ` only; a Vault KV v2 source with sufficient policy may
-declare `READ | LIST | VALIDATE | WRITE | ROTATE`. Operations that
-require a missing capability fail with a structured error rather than
-trying and erroring at the network boundary.
+#### 1.1 Capabilities
+
+```rust
+bitflags! {
+    pub struct Capabilities: u32 {
+        const READ              = 0b0000_0001;
+        const LIST              = 0b0000_0010;
+        const VALIDATE          = 0b0000_0100;
+        const WRITE             = 0b0000_1000;
+        const ROTATE            = 0b0001_0000;
+        const BIOMETRIC_PROMPT  = 0b0010_0000;
+        const AUDIT_LOGGED      = 0b0100_0000;
+    }
+}
+```
+
+`READ`, `LIST`, `VALIDATE`, `WRITE`, `ROTATE` are operational. The
+two new flags are descriptive — they let `doctor` and the agent
+provisioning surface (see [ADR-023](./ADR-023-secret-store-ux-layer.md)
+section 3.7) reason about UX trade-offs:
+
+- `BIOMETRIC_PROMPT` — the source prompts for biometric or PIN
+  unlock on every read in its default configuration. The router
+  surfaces this as a `cost` hint to agents so that an agent loop
+  doing twelve reads per minute does not blindly trigger twelve
+  TouchID prompts; the agent should batch through a high-level
+  provider tool instead.
+- `AUDIT_LOGGED` — every read is durably logged on the upstream
+  (Vault audit log, 1Password account activity). `doctor` shows
+  this in the source-status section so the user knows their
+  reads are observable.
+
+A read-only source declares `READ | LIST | VALIDATE`; the 1Password
+CLI in the typical biometric configuration declares
+`READ | LIST | VALIDATE | BIOMETRIC_PROMPT | AUDIT_LOGGED`; an
+env-store declares `READ` only; a Vault KV v2 source with sufficient
+policy may declare `READ | LIST | VALIDATE | WRITE | ROTATE | AUDIT_LOGGED`.
+Operations that require a missing operational capability fail with a
+structured error rather than trying and erroring at the network
+boundary.
 
 ### 2. Routing (`~/.devboy/secrets/sources.toml`)
 
@@ -105,6 +179,10 @@ configuration is global and lives at `~/.devboy/secrets/sources.toml`:
 [[source]]
 name = "keychain"
 type = "keychain"
+
+[[source]]
+name = "local-vault"
+type = "local-vault"      # see ADR-023 for crypto and UX
 
 [[source]]
 name = "1p-personal"
@@ -126,6 +204,7 @@ file = "/run/secrets/devboy.env"   # optional; loaded if present
 
 [default]
 source = "keychain"
+fallback = "local-vault"           # see section 8
 
 [[route]]
 prefix = "team/"
@@ -149,13 +228,17 @@ The router resolves a path by:
 1. Looking for a `[secret."<path>"]` block — if present, the explicit
    source and reference win.
 2. Otherwise, finding the longest matching `[[route]]` prefix.
-3. Otherwise, falling back to `[default]`.
+3. Otherwise, falling back to `[default].source`. If that source
+   reports `is_available() == NotInstalled` and `[default].fallback`
+   is set, the router retries against the fallback (typically the
+   local-vault on a headless machine without keychain).
 
 Path-to-reference mapping for prefix routes is source-specific and
 defined by the source plugin (the keychain source uses the path
 directly; the Vault source joins `mount` with the path tail; the
 1Password source produces an `op://` URL from the `vault` setting and
-the path tail).
+the path tail; the local-vault source uses the path itself as the
+reference).
 
 ### 3. Multiple instances of the same source type
 
@@ -166,13 +249,14 @@ independently from routing. The `type` is what code is invoked; the
 mechanism by which a single user can talk to several upstreams of the
 same flavour without confusion.
 
-### 4. Per-context source credentials
+### 4. Per-context source credentials and the recursion invariant
 
 A source may itself need credentials to operate (Vault token,
-1Password account session, AWS profile). The default behaviour is
-the source's native session management — `op signin`, `vault login`,
-`aws configure sso`. ADR-005's keychain remains the place for tokens
-that the system itself manages.
+1Password account session, AWS profile). A source declares this in
+the `requires_credential()` method on the trait. The default behaviour
+is the source's native session management — `op signin`,
+`vault login`, `aws configure sso`. ADR-005's keychain remains the
+place for tokens that the system itself manages.
 
 For users who hold several roles in the same upstream — for example,
 a `read-only` token and a `deploy` token for the same Vault — the
@@ -198,6 +282,26 @@ either:
   that the source plugin interprets as "use your native unlock
   mechanism".
 
+#### Recursion invariant
+
+A source `A` that declares `requires_credential() = Some(...)` must
+have its credential resolved through a source `B` whose
+`requires_credential()` is `None`. The router enforces this at
+configuration load: it walks the source-credentials graph, fails
+with `E_SOURCE_CREDENTIAL_CYCLE` on any cycle, and fails with
+`E_SOURCE_CREDENTIAL_DEEP` if the chain is longer than one hop.
+
+The reasoning is simple: a Vault token cannot itself be stored in
+Vault, because reading it would require Vault to already be
+unlockable. The keychain (and the local-vault from ADR-023, once
+unlocked) are the only sources that may hold source-credentials,
+because they have no `requires_credential()` of their own.
+
+In practice this means `__sources/<source-name>/<profile>` paths
+**always** resolve to the keychain or the local-vault, regardless of
+how the rest of the routing table is configured. The router enforces
+this independently of the user-supplied `[[route]]` rules.
+
 ### 5. Reserved `__sources/` namespace
 
 ADR-020 reserves the `__*` prefix as internal. This ADR uses
@@ -218,29 +322,50 @@ to user-facing secrets clutters the discovery view.
 
 ### 6. Subprocess plugin protocol
 
-Built-in sources (keychain, 1password, vault, env-store; section 8)
-implement `SecretSource` directly inside the `devboy-tools` binary.
-Community backends ship as separate executables, discovered at
+Built-in sources (keychain, local-vault, 1password, vault, env-store;
+section 8) implement `SecretSource` directly inside the `devboy-tools`
+binary. Community backends ship as separate executables, discovered at
 `~/.devboy/plugins/secrets/devboy-source-<name>`, communicating with
 the router over **JSON-RPC on stdio** — the same shape as MCP.
 
 The protocol surfaces the trait directly:
 
 ```
-secret_source.init        →  capabilities, version
+secret_source.init        →  capabilities, version, requires_credential
 secret_source.is_available →  status enum
-secret_source.get         →  reference → SecretString | NotFound
+secret_source.get         →  reference → { value, lease_duration? } | NotFound
 secret_source.list        →  → RemoteRef[]
 secret_source.validate    →  reference → ok | invalid | unreachable
 ```
 
-The router spawns the plugin lazily (first use), keeps the process
-alive for a configurable idle window (default sixty seconds), and
-restarts it transparently on crash. The plugin is run with a
-restricted environment: only variables it explicitly declares it
-needs in a manifest shipped alongside the binary
-(`devboy-source-<name>.toml`). The router never passes other secrets
-to a plugin.
+#### Lifetime contract
+
+The router enforces a strict lifecycle for plugin processes:
+
+- **Spawn:** lazy, on first use. The router invokes the plugin with
+  `Command::new(absolute_path)` and a restricted environment; only
+  variables the plugin declared in its sidecar manifest
+  (`devboy-source-<name>.toml`) are passed through.
+- **Idle timeout:** the plugin is kept alive across calls for an
+  idle window of **60 seconds** by default (configurable per
+  source). After the window, the router sends `SIGTERM` and gives
+  the plugin **10 seconds** to drain in-flight requests and exit
+  cleanly.
+- **Force kill:** if the plugin has not exited within the 10-second
+  grace window, the router sends `SIGKILL`. Zombies are reported
+  through `doctor` in the source-status section.
+- **Crash recovery:** if the plugin exits with a non-zero status code
+  while in use, the router restarts it transparently up to **three
+  times within 60 seconds**. Beyond that, the source is marked
+  `Error` and the router stops invoking it; a message in `doctor`
+  tells the user to run `devboy secrets sources reset <name>` once
+  the underlying issue is fixed.
+
+The router never invokes source CLIs through a shell. Built-in sources
+that wrap an external CLI (`op`, `vault`) follow the same rule:
+absolute paths resolved at install/configure time, no shell-meta in
+arguments. The plugin manifest may declare a checksum that `doctor`
+verifies on each invocation; mismatch is a hard error.
 
 The protocol is part of this ADR so that built-in sources and
 external sources are interchangeable from the start. The first
@@ -259,23 +384,43 @@ that resolves a dozen secrets per minute is unusable.
 
 The router caches resolved values **in-process, in memory only,
 never on disk**. The cache is keyed by ADR-020 path and holds an
-expiring `SecretString`. The default TTL is fifteen minutes; it is
-configurable per source and per secret. Cache entries are dropped
-when:
+expiring `SecretString`.
 
-- the TTL expires,
+The TTL is **adaptive**:
+
+- The **base TTL** is configurable per source (`cache_ttl_seconds`
+  in the source definition) and defaults to **900 seconds**
+  (15 minutes).
+- If `get()` returns a `lease_duration`, the effective TTL is
+  `min(base_ttl, lease_duration)`. This keeps the cache from
+  outliving a Vault dynamic-secret lease. A `lease_duration` of
+  `Some(0)` disables caching entirely for that read.
+- A per-secret override may lower the TTL further through the
+  global index (`cache_ttl_seconds_max` in the secret entry) but
+  may not raise it above the source default.
+
+Cache entries are dropped when:
+
+- the effective TTL expires,
 - the user invokes `devboy secrets refresh <path>` (or `--all`),
 - a source declares an out-of-band invalidation (Vault lease
   revocation, 1Password session timeout — surfaced through
-  `is_available()`).
+  `is_available()`),
+- the process exits.
 
 The cache is **never** persisted. Process exit drops every entry.
 This is the same posture as `secrecy::SecretString::zeroize_on_drop`
 extended one level up.
 
+The local-vault daemon from ADR-023 holds its own cache of the
+unlocked vault key, separate from this router cache. The router
+sees a normal `get()` that returns a `SecretString` in microseconds;
+the daemon's lifecycle (idle re-lock, PIN re-prompt for write
+operations) is internal to the local-vault source.
+
 ### 8. Built-in sources
 
-The first release ships four built-in implementations of
+The first release ships five built-in implementations of
 `SecretSource`. Together they cover the dominant deployment shapes
 without requiring any community plugin.
 
@@ -287,29 +432,55 @@ keychain is the only source where the ADR-020 path doubles as the
 backend reference. Capabilities: `READ | LIST | VALIDATE | WRITE`.
 Available unless the platform exposes no keychain (headless Linux
 without Secret Service); in that case `is_available()` returns
-`NotInstalled` and the router skips it.
+`NotInstalled` and the router falls back to `local-vault` if it is
+configured as `[default].fallback`.
+
+#### `local-vault`
+
+An encrypted file at `~/.devboy/secrets/local-vault.dvb` unlocked
+through a passphrase, a Touch-ID-wrapped key in the system keychain,
+or a BIP39 recovery phrase. Crypto, daemon protocol, and UI flows are
+the subject of [ADR-023](./ADR-023-secret-store-ux-layer.md).
+
+`reference` is the ADR-020 path itself. Capabilities:
+`READ | LIST | VALIDATE | WRITE | ROTATE | BIOMETRIC_PROMPT` (the
+biometric flag is set when the unlock method is the Touch-ID
+envelope; with a passphrase envelope only, the flag is absent on
+read but set on write/rotate where the passphrase is required again).
+
+The `local-vault` source is intended primarily for two scenarios:
+headless Linux machines without a Secret Service daemon (where it is
+the routed default), and any user who explicitly wants to keep some
+paths out of the OS keychain. It is **not** intended as a third
+parallel store next to keychain and external sources for routine use
+— the router treats it as one option among many, and the routing
+configuration is what determines when it is consulted.
 
 #### `1password`
 
 Backed by the `op` CLI. `reference` is an `op://` URL
 (`op://<vault>/<item>/<field>`). Capabilities: `READ | LIST |
-VALIDATE`. Write capability is omitted from the first release;
-`op item create` is mudded enough that the ADR-020 `bootstrap` flow
-opens the 1Password UI for new entries instead of writing through the
-CLI. `is_available()` checks `op whoami`; a locked session returns
-`Locked` and `doctor` shows an actionable message
-(`op signin`).
+VALIDATE | BIOMETRIC_PROMPT | AUDIT_LOGGED`. Write capability is
+omitted from the first release; `op item create` is muddled enough
+that the ADR-020 `bootstrap` flow opens the 1Password UI for new
+entries instead of writing through the CLI. `is_available()` checks
+`op whoami`; a locked session returns `Locked` and `doctor` shows an
+actionable message (`op signin`).
 
 #### `vault`
 
 Backed by the HashiCorp Vault HTTP API, KV v2. `reference` joins the
 mount and path (`secret/data/<path>#<field>`, where `<field>` defaults
-to `value`). Capabilities: `READ | LIST | VALIDATE | WRITE | ROTATE`,
-subject to the policy associated with the active token.
+to `value`). Capabilities: `READ | LIST | VALIDATE | WRITE | ROTATE |
+AUDIT_LOGGED`, subject to the policy associated with the active token.
 Authentication methods are pluggable; the ADR ships token, AppRole,
 and OIDC out of the box, with the active method configured per
 source instance. `is_available()` calls `/sys/health` and a token
 lookup; an expired token returns `Locked`.
+
+The `vault` source's `get()` implementation populates
+`lease_duration` from the upstream response; section 7's adaptive
+TTL keeps the router cache honest against dynamic secrets.
 
 #### `env-store`
 
@@ -344,29 +515,55 @@ The env-store reads values through three mechanisms, in order:
 Capabilities: `READ` only. Validation is format-only; liveness is
 delegated to the higher-level provider check.
 
-#### CI auto-detection
+#### CI mode (explicit, not heuristic)
 
-When the process detects that it is running in CI — environment
-variables `CI`, `GITLAB_CI`, `GITHUB_ACTIONS`, or
-`BUILDKITE` set to a truthy value — the router silently promotes
-`env-store` to the first position in the resolution chain and skips
-sources whose `is_available()` returns `NotInstalled`. This
-preserves zero-config CI behaviour while keeping local developer
-defaults unchanged.
+CI behaviour is selected, not inferred. The router runs in **CI mode**
+when **any** of the following holds:
+
+- `DEVBOY_CI=1` (or `=true`) is set in the environment;
+- the active context declares `[runtime] ci = true` in
+  `~/.devboy/contexts/<name>.toml`;
+- the CLI was invoked with `--ci`.
+
+The router still **detects** CI heuristically (presence of `CI`,
+`GITLAB_CI`, `GITHUB_ACTIONS`, `BUILDKITE`) and shows a `doctor`
+notice "CI signals detected — but `DEVBOY_CI` is not set; routing
+falls back to interactive defaults". This avoids two confusing
+failure modes from the previous draft:
+
+- A developer running a CI script locally with `CI=1` exported
+  silently switching to env-store routing.
+- A CI runner that does not set the expected variables silently
+  staying on interactive routing and failing on the first
+  keychain-unlock prompt.
+
+In CI mode the router:
+
+- promotes the `env-store` source to the front of the resolution
+  chain regardless of the routing table;
+- silently skips sources whose `is_available()` returns
+  `NotInstalled`;
+- refuses to invoke the local-vault unlock UI (no PIN prompt in CI);
+- refuses to invoke biometric unlock (`BIOMETRIC_PROMPT` capability
+  causes the source to be skipped);
+- emits all decisions as structured logs at `info` level so a CI
+  pipeline can grep for routing surprises.
 
 ### 9. `doctor` integration
 
 `devboy doctor` gains two new sections:
 
 - **Sources** — for each configured source, its name, type,
-  availability status, last successful contact, and any actionable
-  message (`op signin`, `vault login`, `unset DEVBOY_SECRETS_FILE`,
-  …).
+  availability status, capabilities (with `BIOMETRIC_PROMPT` /
+  `AUDIT_LOGGED` flagged so the user knows the cost of each read),
+  last successful contact, and any actionable message (`op signin`,
+  `vault login`, `unset DEVBOY_SECRETS_FILE`, …).
 - **Secrets in active context** — for each path declared in the
   active manifest, its routed source, current status (provisioned /
   expiring / missing / format-invalid), and (where the upstream
   exposes it) its expiry. Optional secrets are shown in their own
-  sub-section without producing a non-zero exit.
+  sub-section without producing a non-zero exit. The CI-mode
+  notice from section 8 surfaces here too.
 
 Exit code is non-zero if any required secret is missing or
 format-invalid. This makes `devboy doctor` a usable CI sanity gate
@@ -378,11 +575,11 @@ ADR-020 stated the framework's overall threat model. This ADR moves
 two things on the spectrum:
 
 - **Improvement.** External sources typically provide audit (every
-  read is logged in 1Password and Vault), centralized rotation, and
-  per-team policy. A team that adopts an external source
-  materially raises the bar over a per-developer keychain — not
-  because `devboy-tools` is more secure, but because the upstream
-  is.
+  read is logged in 1Password and Vault — surfaced in
+  `Capabilities` as `AUDIT_LOGGED`), centralized rotation, and
+  per-team policy. A team that adopts an external source materially
+  raises the bar over a per-developer keychain — not because
+  `devboy-tools` is more secure, but because the upstream is.
 - **New surface.** `devboy-tools` invokes `op` and `vault` (and
   community plugins) as subprocesses. A compromised CLI on the
   user's `PATH` can return arbitrary values, log credentials, or
@@ -407,9 +604,12 @@ permissions and require explicit confirmation.
   1Password or Vault can route their existing tree into the
   ADR-020 namespace without copying a single value into the local
   keychain.
-- ✅ **CI works first-class.** The env-store is a real source, not
-  a fallback; CI behaviour is therefore predictable and
-  configurable rather than implicit.
+- ✅ **CI works first-class.** The env-store is a real source, and
+  CI mode is selected explicitly; routing is therefore predictable
+  rather than implicit.
+- ✅ **Headless Linux works without external infrastructure.** The
+  local-vault fallback (ADR-023) makes "no keychain, no Vault, no
+  1Password" a supported configuration rather than a workaround.
 - ✅ **Multiple upstreams of the same type are addressable.** A user
   with several Vault servers or several 1Password accounts can
   configure them side by side under different `name`s.
@@ -419,15 +619,20 @@ permissions and require explicit confirmation.
 - ✅ **A community plugin protocol exists from day one.** A new
   backend is a separate binary against a documented stdio protocol;
   it does not require forking `devboy-tools`.
-- ✅ **Cached reads keep agents responsive.** A fifteen-minute TTL
-  is invisible to interactive use and makes biometric-prompting
+- ✅ **Cached reads keep agents responsive.** The adaptive TTL
+  honours upstream lease duration so dynamic-secret backends do
+  not become stale-by-design, while still keeping biometric-prompt
   sources usable inside agentic loops.
+- ✅ **Capability-aware UX.** `BIOMETRIC_PROMPT` and `AUDIT_LOGGED`
+  let `doctor` and the agent surface (ADR-023 section 3.7)
+  communicate the real cost and observability of each read.
 
 ### Negative
 
-- ❌ **One more configuration file.** `~/.devboy/secrets/sources.toml`
-  joins the existing `~/.devboy/config.toml` and the ADR-020
-  `~/.devboy/secrets/index.toml`.
+- ❌ **Two new configuration files.**
+  `~/.devboy/secrets/sources.toml` and the local-vault file from
+  ADR-023 join the ADR-020 `~/.devboy/secrets/index.toml` and the
+  pre-existing `~/.devboy/config.toml`.
 - ❌ **Built-in sources couple the binary to upstream CLI versions.**
   A breaking change in `op` or `vault` may surface as a new
   validation failure. **Mitigation:** integration tests in CI run
@@ -436,14 +641,21 @@ permissions and require explicit confirmation.
   want non-built-in backends.** Discovery, signing, and update of
   plugins is itself a problem; this ADR ships the protocol but
   defers a managed plugin registry to a later decision.
+- ❌ **Source-credential recursion is one rule the user has to
+  internalise.** "Vault tokens cannot live in Vault" is obvious in
+  retrospect but is one more concept on the onboarding path.
+  **Mitigation:** the router enforces it; a confused configuration
+  fails at load with `E_SOURCE_CREDENTIAL_CYCLE` and a pointer to
+  the keychain or local-vault.
 
 ### Risks
 
 - ⚠️ **Cache outliving an upstream rotation.** A secret rotated in
-  Vault is still served from the in-process cache for up to fifteen
-  minutes. **Mitigation:** the upper bound is bounded; sources
-  expose `validate()` so a misbehaving downstream can be told to
-  flush; `secrets refresh` is one command.
+  Vault is still served from the in-process cache for up to the
+  effective TTL (now bounded by `lease_duration`). **Mitigation:**
+  the upper bound is bounded; sources expose `validate()` so a
+  misbehaving downstream can be told to flush; `secrets refresh`
+  is one command.
 - ⚠️ **Misconfigured route silently routes to the wrong upstream.**
   A typo in a `prefix` lands a `team/...` path in the keychain
   instead of Vault. **Mitigation:** `devboy doctor` shows the
@@ -452,9 +664,15 @@ permissions and require explicit confirmation.
 - ⚠️ **A compromised source CLI in PATH.** Covered in the threat
   model above; the mitigation is absolute paths plus checksums.
 - ⚠️ **Subprocess plugin lifetime leaks.** A plugin that fails to
-  exit cleanly leaves zombies. **Mitigation:** the router enforces
-  a kill timeout (default ten seconds after idle) and reports
-  zombies in `doctor`.
+  exit cleanly leaves zombies. **Mitigation:** the lifetime
+  contract in section 6 (60s idle, 10s grace, force kill, restart
+  cap of 3 in 60s) is testable; acceptance tests in #247 Phase 5
+  exercise crash recovery and zombie reporting.
+- ⚠️ **CI heuristic divergence.** A user expecting CI mode because
+  `CI=1` is set but not setting `DEVBOY_CI` may be surprised by
+  interactive routing. **Mitigation:** `doctor` actively warns
+  when CI signals are present without an explicit
+  `DEVBOY_CI`/`--ci`.
 
 ## Alternatives Considered
 
@@ -464,10 +682,10 @@ permissions and require explicit confirmation.
 *or* 1Password) and configure the whole tree to live there.
 
 **Why rejected:** Real users hold mixes — a personal 1Password vault
-plus a team Vault plus a CI env-store. A single-backend model forces
-either duplication (copy team secrets into 1Password as well) or a
-manual ladder of fallbacks. The routing layer is the price of
-honest support.
+plus a team Vault plus a CI env-store plus a headless box that runs
+neither. A single-backend model forces either duplication (copy team
+secrets into 1Password as well) or a manual ladder of fallbacks. The
+routing layer is the price of honest support.
 
 ### Alternative 2: Use environment variables only outside the keychain
 
@@ -511,20 +729,47 @@ keychain-stored key.
 **Why rejected:** The point of an external source is that it is the
 authoritative copy. A persisted cache reintroduces stale-value
 problems — exactly what ADR-005's keychain-only model already
-exhibits in mixed environments. The fifteen-minute in-memory cache
-is a UX accelerator, not a store.
+exhibits in mixed environments. The adaptive in-memory cache is a
+UX accelerator, not a store. The local-vault from ADR-023 is the
+right answer for "I want a persistent encrypted store" — it is
+exposed as a source, not a cache.
+
+### Alternative 6: Heuristic CI mode (the prior draft)
+
+**Description:** Auto-detect CI from `CI` / `GITLAB_CI` /
+`GITHUB_ACTIONS` and silently switch routing.
+
+**Why rejected:** Both directions of the heuristic surprise the
+user — a developer with `CI=1` set locally falls into env-store
+routing, and a CI runner that does not set the expected variables
+falls out of it. CI mode is now an explicit setting; the heuristic
+becomes a `doctor` notice.
+
+### Alternative 7: Flat 15-minute cache TTL (the prior draft)
+
+**Description:** A single default TTL for all sources, configurable
+per source but flat per get().
+
+**Why rejected:** Vault dynamic secrets routinely have leases
+shorter than 15 minutes; the flat default served stale values until
+the user manually refreshed. The adaptive TTL
+(`min(default, lease_duration)`) costs almost nothing to implement
+and removes a whole class of confusing bugs.
 
 ## Implementation
 
 - **Issues:**
-  - [#246](https://github.com/meteora-pro/devboy-tools/issues/246) — design (ADR-020 + this ADR)
+  - [#246](https://github.com/meteora-pro/devboy-tools/issues/246) — original design (ADR-020 + this ADR)
   - [#247](https://github.com/meteora-pro/devboy-tools/issues/247) — implementation, phased
+  - To be filed — design refresh covering the rewritten ADR-020/021 and the new ADR-023
 - **Code (planned):**
   - `crates/devboy-storage/` — `SecretSource` trait, router,
-    in-memory cache, source-credential resolution from
-    `__sources/...`
+    in-memory cache (with adaptive TTL), source-credential
+    resolution from `__sources/...`, recursion check
   - `crates/plugins/secrets/keychain/` — built-in keychain source
     (refactor of existing `KeychainStore`)
+  - `crates/plugins/secrets/local-vault/` — built-in encrypted
+    vault source (crypto and daemon detailed in ADR-023)
   - `crates/plugins/secrets/1password/` — built-in 1Password CLI
     source
   - `crates/plugins/secrets/vault/` — built-in HashiCorp Vault
@@ -532,7 +777,7 @@ is a UX accelerator, not a store.
   - `crates/plugins/secrets/env-store/` — built-in env-store source
     with `DEVBOY_SECRETS_FILE` loader
   - `crates/devboy-cli/` — `devboy secrets sources {list, install,
-    refresh, validate}` subcommands and `doctor` integration
+    refresh, validate, reset}` subcommands and `doctor` integration
 - **Subprocess protocol:** documented under
   `docs/guide/secrets/source-plugin-protocol.md` (planned).
 - **Migration:** ADR-005 keychain remains the default for paths that
@@ -548,6 +793,10 @@ is a UX accelerator, not a store.
   — the type discipline that flows through the router unchanged
 - [ADR-020: Secret manifest, path convention, and alias resolution](./ADR-020-secret-manifest-and-alias-resolution.md)
   — the namespace and manifest above the router
+- [ADR-023: Secret store UX layer](./ADR-023-secret-store-ux-layer.md)
+  — encrypted local vault crypto, daemon protocol, native UI,
+  manual-assisted rotation, pattern catalogue, agent provisioning
+  protocol, `setup-secrets` skill
 - [HashiCorp Vault — KV v2 secret engine](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2)
 - [1Password CLI — `op` reference](https://developer.1password.com/docs/cli/)
 - [Model Context Protocol](https://modelcontextprotocol.io/) — the
@@ -560,3 +809,4 @@ is a UX accelerator, not a store.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-06 | Andrei Mazniak | Initial draft |
+| 2026-05-09 | Andrei Mazniak | Rewrite after design review: 5th built-in `local-vault` (UX in ADR-023); `BIOMETRIC_PROMPT` / `AUDIT_LOGGED` capabilities; adaptive cache TTL bounded by upstream `lease_duration`; explicit source-credential recursion invariant; CI mode as an explicit setting (no longer a heuristic); subprocess plugin lifetime contract spelled out (60s idle / 10s grace / restart cap) |

--- a/docs/architecture/adr/ADR-023-secret-store-ux-layer.md
+++ b/docs/architecture/adr/ADR-023-secret-store-ux-layer.md
@@ -1,0 +1,884 @@
+---
+id: ADR-023
+title: Secret store UX layer — local vault, daemon, native UI, agent protocol, rotation, pattern catalogue, onboarding skill
+status: proposed
+date: 2026-05-09
+deciders: ["Andrei Mazniak"]
+tags: ["security", "secrets", "ui", "agent", "rotation", "patterns", "skills"]
+supersedes: null
+superseded_by: null
+---
+
+# ADR-023: Secret store UX layer
+
+## Status
+
+**proposed**
+
+This ADR is intentionally an **umbrella**. The conventions in
+[`INDEX.md`](./INDEX.md) prefer one decision per ADR, and the eight
+sub-decisions here could be split into eight separate files. They are
+not, because they describe a **single coherent layer** sitting above
+[ADR-021](./ADR-021-external-secret-sources.md): the components are
+designed against each other (the daemon serves the UI, the UI is what
+the agent triggers when it cannot get a value, the rotation flow uses
+both, the pattern catalogue feeds all of them, the onboarding skill
+walks a user through the whole stack at once). Splitting them would
+multiply cross-references without adding clarity. If review surfaces
+that a sub-decision should evolve independently — for example, the
+pattern catalogue grows beyond the secret store and is used by other
+subsystems — that section is a candidate for promotion to its own ADR.
+
+## Context
+
+[ADR-019](./ADR-019-secret-string-discipline.md), [ADR-020](./ADR-020-secret-manifest-and-alias-resolution.md),
+and [ADR-021](./ADR-021-external-secret-sources.md) together form the
+**transport layer** of the secret framework: how secrets are typed in
+memory, how they are named and discovered, and where their values live.
+None of those layers say what the user **sees**, what the **agent** is
+allowed to do, how a token gets **rotated** in practice, or how a new
+contributor **gets set up** for the first time.
+
+In practice this leaves four concrete gaps that the transport layer
+cannot close on its own:
+
+1. **No fallback for fully offline / no-keychain machines.** ADR-021
+   ships an env-store, but env-store is a CI shape, not a developer
+   shape. A developer working off-network on a Linux box without
+   Secret Service has nowhere to put a passphrase-protected store.
+2. **No way for the user to enter a value without the agent seeing
+   it.** The agent that is helping the user set up the project is
+   the same channel through which the user would type a secret. A
+   second, agent-bypassing UI is required.
+3. **No rotation flow.** The transport layer can detect "this token
+   expires in three days" but cannot guide the user through the
+   rotation: open the right URL, accept the new value, validate, and
+   record the rotation. Without a flow, rotation reminders become
+   notification fatigue.
+4. **No agent-mediated provisioning.** When the agent finds that a
+   project needs a credential that is not yet provisioned, it can
+   neither read existing values (by design) nor accept new ones
+   (it is the leak surface). It needs a typed protocol for asking
+   the user to provision a path through the UI.
+
+This ADR introduces the **UX layer**: an encrypted local vault for
+the offline-fallback case, a daemon to manage its unlocked state, a
+native UI (TUI + GUI) that the user interacts with directly, a
+manual-assisted rotation flow built on top, a pattern catalogue
+shared with the OTLP sanitizer (#240/#242), an MCP protocol for
+agent-mediated provisioning, and an onboarding skill that walks a
+user through the stack on first run.
+
+### Threat model alignment
+
+This ADR inherits the threat model of [ADR-020](./ADR-020-secret-manifest-and-alias-resolution.md):
+the framework protects against accidental leakage by humans, by
+agents acting in good faith, and by routine tooling. It does not
+claim isolation against a malicious agent that can spawn shells.
+The local vault and the daemon raise the bar (encrypted at rest,
+zeroized in memory, segmented unlock), but they do not change the
+boundary — a process running as the user can still read the
+keychain and `/proc/self/environ`. The UX layer's stronger claim
+is operational, not cryptographic: the user types secrets into a
+UI that the agent does not mediate, the agent never receives
+values, and rotation happens on a cadence rather than on demand.
+
+## Decision
+
+> **Decision:** A user-facing UX layer sits above the router from
+> [ADR-021](./ADR-021-external-secret-sources.md), built around an
+> encrypted local vault, a single-purpose daemon, a native TUI/GUI,
+> an agent provisioning protocol over MCP, a manual-assisted
+> rotation flow, a shared pattern catalogue, and an onboarding skill.
+> The agent never sees secret values; the user never types secrets
+> through the agent.
+
+The decision has eight parts.
+
+### 3.1 Encrypted local vault
+
+The local vault is one of the built-in sources from
+[ADR-021](./ADR-021-external-secret-sources.md) section 8. It is the
+fallback for environments without an OS keychain and for users who
+explicitly want a portion of their namespace stored locally,
+encrypted, behind a passphrase.
+
+#### File layout
+
+The vault lives at `~/.devboy/secrets/local-vault.dvb`. Its layout is
+plaintext-header plus per-entry AEAD ciphertexts:
+
+```
+HEADER (plaintext, fixed-width fields):
+  MAGIC          [4]   = b"DVB1"
+  VERSION        [1]   = 0x01
+  KDF_PARAMS     [16]  = Argon2id (m_cost, t_cost, p_cost, salt-len)
+  SALT           [32]  = random per-vault, used by passphrase envelope
+
+UNLOCK_ENVELOPES (TOML-serialised, each is an AEAD-wrap of the vault-key):
+  [[envelope]]
+  kind = "passphrase"
+  argon2_salt    = "<32B base64>"
+  argon2_params  = { m = 65536, t = 3, p = 1 }
+  wrapped_key    = "<AEAD(vault_key, key=Argon2id(passphrase, salt))>"
+
+  [[envelope]]
+  kind = "keychain"           # macOS-only; optional
+  keychain_account = "dev.devboy.secrets.vault.macos-touchid"
+  wrapped_key      = "<AEAD(vault_key, key=Keychain-protected key)>"
+
+  [[envelope]]
+  kind = "recovery"
+  bip39_salt    = "<32B base64>"
+  wrapped_key   = "<AEAD(vault_key, key=HKDF(bip39_seed))>"
+
+ENTRIES_INDEX (plaintext TOML, metadata only):
+  [[entry]]
+  path           = "team/gitlab/token-deploy"
+  nonce          = "<24B base64>"
+  ct_offset      = 0
+  ct_length      = 312
+  description    = "..."
+  retrieval_url  = "..."
+  expires_at     = "2026-08-01"
+  last_rotated_at = "2026-05-02"
+  pattern_id     = "gitlab-pat"
+
+  [[entry]]
+  ...
+
+AEAD_BLOBS:
+  contiguous concatenation of per-entry ciphertexts; each entry is
+    ChaCha20-Poly1305(
+      plaintext     = value (utf-8 bytes),
+      key           = vault_key,
+      nonce         = entry.nonce,
+      associated_data = entry.path utf-8 bytes
+    )
+```
+
+Critical invariants:
+
+- **Envelope encryption.** A single random `vault_key` (32 bytes)
+  encrypts every entry. The header carries one or more *envelopes*,
+  each of which independently wraps `vault_key` under a different
+  unlock method. Adding a new unlock path (Touch ID, recovery
+  phrase) is a write to the header only and never touches the
+  per-entry ciphertexts.
+- **AAD includes path.** Per-entry AEAD uses the path as
+  associated data. A tampering attempt that swaps the ciphertext
+  blob from `team/gitlab/...` under the index entry for
+  `personal/github/...` fails decryption. This closes a class of
+  swap attacks that pure encryption-without-AAD does not.
+- **Plaintext metadata is intentional.** `description`,
+  `retrieval_url`, `expires_at` are all readable without an unlock
+  step. The discovery and rotation-reminder flows need this; the
+  threat model already grants any local process read access to
+  metadata, and encrypting it would gate every `secrets list` on a
+  PIN prompt for no real benefit.
+- **No file-level integrity over the whole vault.** Each entry is
+  independently authenticated; there is no Merkle tree or
+  whole-file MAC. A truncation attack on the entry table is
+  detected at parse time (TOML parse error or entry-count
+  mismatch), not cryptographically. This is acceptable because the
+  vault file is single-writer (the daemon, see section 3.3) and
+  protected by filesystem permissions.
+
+#### Algorithms
+
+- **AEAD:** ChaCha20-Poly1305 (RFC 8439). Picked over AES-GCM
+  because it does not require AES-NI and runs constant-time on all
+  targets (including ARM Linux); RustCrypto provides a vetted
+  pure-Rust implementation (`chacha20poly1305`).
+- **KDF:** Argon2id with `m_cost = 65536` (64 MiB), `t_cost = 3`,
+  `p_cost = 1` for the passphrase envelope. Tuned to ≈250 ms on a
+  2024-class laptop; tuneable per-vault if a host is too slow.
+  The recovery envelope uses HKDF over the BIP39 seed (no
+  brute-force resistance needed; the seed has 256 bits of entropy
+  by construction).
+- **CSPRNG:** the `getrandom` crate, the same source used by the
+  rest of the workspace.
+
+#### Crate
+
+A new workspace member, `crates/devboy-vault-crypto/`, exposes the
+algorithms behind a small API:
+
+```rust
+pub struct Vault { /* unlocked state */ }
+impl Vault {
+    pub fn open(path: &Path, unlock: UnlockMethod) -> Result<Self>;
+    pub fn create(path: &Path, methods: &[InitialUnlock]) -> Result<Self>;
+    pub fn add_envelope(&mut self, kind: EnvelopeKind, secret: SecretString) -> Result<()>;
+    pub fn get(&self, path: &str) -> Result<Option<SecretString>>;
+    pub fn put(&mut self, path: &str, value: SecretString, meta: EntryMetadata) -> Result<()>;
+    pub fn rotate(&mut self, path: &str, new: SecretString) -> Result<()>;
+    pub fn delete(&mut self, path: &str) -> Result<()>;
+    pub fn list(&self) -> impl Iterator<Item = &EntryMetadata>;
+}
+```
+
+The vault unlocked state holds `vault_key` in a `secrecy::SecretBox<[u8; 32]>`
+that zeroizes on drop (per ADR-019). The `Vault` instance is owned by
+the daemon (section 3.3); CLI commands and the UI talk to the daemon,
+not to this crate directly.
+
+### 3.2 Authentication and recovery
+
+The vault accepts three independent unlock methods:
+
+- **Passphrase** — minimum 12 characters. Required at vault
+  creation; cannot be removed.
+- **Keychain (Touch ID)** — macOS only. The user runs
+  `devboy secrets vault add-keychain-unlock`, the CLI generates a
+  random 32-byte key, stores it in the macOS keychain under
+  `kSecAttrAccessControlBiometryAny | kSecAttrAccessControlUserPresence`
+  (Touch ID required, fallback to user password), and adds a
+  `keychain` envelope. Future unlocks via Touch ID don't require
+  the passphrase.
+- **Recovery (BIP39)** — generated at vault creation. The CLI
+  derives a recovery key from a 24-word BIP39 phrase, wraps
+  `vault_key` under it, and shows the phrase **once** with explicit
+  acknowledgement (`Type 'I have written it down' to continue`).
+  The phrase is never stored.
+
+A user who loses both the passphrase and the keychain unlock can
+recover with `devboy secrets vault recover`, which prompts for the
+24-word phrase, decrypts `vault_key`, prompts for a new passphrase,
+and rewrites the passphrase envelope. A user who loses the
+passphrase, the keychain unlock, **and** the recovery phrase has no
+recovery path; the documentation says so explicitly.
+
+#### Why not just keychain?
+
+On macOS the keychain alone is sufficient. The reason the local
+vault exists at all is for the cases that the keychain does not
+cover (headless Linux, containers without `loginctl`, a user who
+explicitly wants some paths off-keychain). The keychain-as-unlock
+path is an ergonomic add-on for macOS users who want both stores
+under a single biometric flow.
+
+### 3.3 Daemon: `devboy-secrets-agent`
+
+The daemon owns the unlocked `Vault` instance. It speaks JSON-RPC
+2.0 over a UNIX domain socket at `~/.devboy/secrets/agent.sock`,
+mode `0600`, owned by the running user. Windows is out of scope for
+the first release; on Windows the local-vault source falls back to
+a per-call unlock until a named-pipe transport ships.
+
+#### Lifecycle
+
+The daemon supports two startup modes:
+
+- **On-demand (default).** The CLI checks for a live socket; if
+  none is found, it spawns the daemon as a detached child and
+  hands the user the unlock UI before issuing the first
+  `secret.get`. After **15 minutes** of idle time, the daemon
+  zeroizes `vault_key` and exits. This mode requires no install
+  step; the only configuration is the vault file itself.
+- **Persistent (opt-in).** `devboy secrets agent install` writes a
+  launchd `LaunchAgent` plist on macOS or a `systemd --user`
+  service on Linux. The daemon starts on user login and stays
+  running, but the *unlocked state* still expires on idle and on
+  SIGTERM. The user trades a process always running for not
+  having to re-enter the unlock method between CLI sessions.
+
+The lifecycle code is identical in both modes; only the supervision
+differs. In both modes the daemon enforces:
+
+- **Idle timeout:** the unlocked vault key is zeroized 15 minutes
+  after the last successful `secret.get` or `metadata.update`.
+  Configurable per user in `~/.devboy/config.toml`.
+- **Eager re-lock:** `vault.lock` zeroizes immediately. Used by
+  the UI's "lock now" button and by the rotation flow after a
+  successful rotation.
+- **SIGTERM zeroization:** the daemon traps SIGTERM, zeroizes,
+  flushes pending writes, and exits within 10 seconds.
+- **Authenticated operations.** `secret.put`, `secret.rotate`, and
+  `vault.add-envelope` always require a fresh PIN/passphrase
+  prompt independent of the daemon's current unlocked state. This
+  is the "hybrid" model from design review: reads benefit from
+  daemon caching, writes do not.
+
+#### Wire protocol
+
+JSON-RPC 2.0, the same shape as MCP. Methods:
+
+```
+vault.unlock(method)      params: { kind: "passphrase" | "keychain" | "recovery", secret: string }
+                          result: { unlocked_at: timestamp, expires_at: timestamp }
+
+vault.lock                params: {}
+                          result: { locked: true }
+
+vault.status              params: {}
+                          result: { state: "locked" | "unlocked",
+                                    unlocked_at?: timestamp,
+                                    expires_at?: timestamp,
+                                    available_methods: [...] }
+
+secret.get(path)          params: { path: string }
+                          result: { value: string }      // SecretString on the wire
+                                | { error: "Locked" | "NotFound" }
+
+secret.list(filter?)      params: { filter?: { scope?, provider?, status? } }
+                          result: { entries: [{ path, status, expires_at?, ... }] }
+                          // Never returns values.
+
+secret.put(path,          params: { path, value, meta, fresh_unlock: { kind, secret } }
+           value, meta)   result: { ok: true } | { error: "BadUnlock" }
+
+secret.rotate(path, new)  params: { path, new_value, fresh_unlock: { ... } }
+                          result: { ok: true, last_rotated_at }
+
+metadata.update(path,     params: { path, fields }
+                fields)   result: { ok: true, applied_fields: [...] }
+                          // Does not require unlock; metadata is plaintext.
+```
+
+#### Security boundary
+
+The socket file is created with `umask 077` and verified at connect
+time: the daemon checks the connecting peer's UID through
+`SO_PEERCRED` (Linux) or `LOCAL_PEERCRED` (macOS). A connection
+from a different UID is rejected. This is defence in depth on top
+of the filesystem permissions; it costs nothing and catches a
+subset of misconfigurations.
+
+The daemon **does not** hand out `vault_key`. Every read goes
+through `secret.get(path)` which returns one decrypted value at a
+time. A compromised socket-listener that intercepts the wire
+between the CLI and the daemon learns the secrets that the
+listener was specifically targeting, not the entire vault.
+
+### 3.4 Native UI
+
+The UI is a `devboy secrets ui` subcommand of the main `devboy`
+binary. There is one binary; no separate `.app` bundle for the
+first release.
+
+The subcommand has two backends:
+
+- **TUI** — `ratatui`, runs in any terminal. Used by default in
+  contexts where a full GUI is impractical (SSH sessions,
+  containers, headless screens).
+- **GUI** — `egui`, runs in a native window. Used by default
+  when `$DISPLAY` / `$WAYLAND_DISPLAY` is set on Linux or when
+  running on macOS / Windows. `egui` was picked over `iced`
+  because its immediate-mode API matches the `ratatui` mental
+  model (one render function per frame), making the two backends
+  share the same view code.
+
+Backend selection: `--tui` / `--gui` flags, falling through to
+`devboy secrets ui` which auto-detects.
+
+#### MVP views
+
+Four views ship in the first release:
+
+- **Inventory** — a sortable, filterable table of every secret
+  the active context can see. Columns: path, status
+  (`provisioned` / `expiring` / `missing` / `format-invalid`),
+  routed source, `expires_at`, provider, scope. Filters by scope,
+  provider, status. **No values are ever shown.**
+- **Provision / rotation dialog** — opened by an agent
+  request_provision call (section 3.7) or by `devboy secrets
+  provision <path>` directly. Shows the path's metadata, a
+  `[Open retrieval URL]` button that opens the user's browser at
+  `retrieval_url`, a hidden input for the new value, and a
+  `[Validate & save]` button that runs the format check, runs the
+  liveness check, writes through the daemon (with a fresh PIN
+  prompt for the local-vault), and updates `last_rotated_at`. The
+  same dialog handles initial provision and rotation; a `mode`
+  parameter changes the title and the destructive-confirm
+  behaviour.
+- **Edit metadata** — editable fields: `description`,
+  `retrieval_url`, `rotate_every_days`, `expires_at`, `pattern_id`.
+  Dirty fields are highlighted; `[Save]` writes through the
+  daemon's `metadata.update`. A subview `[Apply agent suggestion]`
+  shows the diff from a `secrets.propose_metadata` call (section
+  3.7) and lets the user accept all / reject all / accept per
+  field.
+- **Discovery import** — connects to a configured 1Password vault
+  or HashiCorp Vault mount, lists item titles (no values) through
+  the source's `list()` method, suggests `<scope>/<provider>/<purpose>`
+  paths via the algorithm in section 3.6, and asks the user to
+  confirm or edit each mapping. **Values are never copied out
+  of the upstream**; the import only registers paths in the
+  global index with `source` and `reference` set so future reads
+  resolve through the source.
+
+The UI talks to the daemon, never to the keychain or the local
+vault directly. This keeps the security boundary uniform: the
+daemon is the only process that holds `vault_key`.
+
+### 3.5 Manual-assisted rotation
+
+Rotation is **assisted**, not automatic. The decision to call
+provider rotate-APIs is deferred to a future ADR; this release
+covers the case where the user changes a token in the upstream UI
+and `devboy-tools` records the change.
+
+#### Flow
+
+`devboy secrets rotate <path>` (or the agent's
+`secrets.request_rotation(path)` call):
+
+1. The CLI / MCP server calls `secrets.describe(path)` to load
+   metadata. If `retrieval_url` is set, the CLI opens it in the
+   user's default browser.
+2. The UI's provision/rotation dialog opens in `mode = "rotation"`
+   with the existing path metadata.
+3. The user pastes the new value into the hidden input.
+4. The UI runs format validation against `format_regex` (or the
+   pattern's regex if `pattern_id` is set). On format failure the
+   dialog shows the mismatch and does not save.
+5. The UI runs liveness validation through the provider plugin.
+   On liveness failure the dialog asks for confirmation
+   ("upstream rejected this token; save anyway?") with a default
+   of *no*. If the user confirms anyway, the rotation proceeds
+   but a warning is recorded.
+6. The UI writes the new value through the daemon's
+   `secret.rotate` (which requires a fresh PIN if the route
+   targets the local-vault) and updates `last_rotated_at` in the
+   index.
+7. On success, the agent (if it was the caller) receives
+   `{ ok: true, last_rotated_at }`. The agent never sees the
+   value.
+
+#### Rotation cadence and reminders
+
+`devboy doctor` warns at `< 7` days before `expires_at` (default,
+configurable). If the `notify` skill is wired up, the warning is
+also delivered there. Rotation is otherwise a quiet background
+fact; the system does not page the user.
+
+#### What this ADR does **not** ship
+
+Provider-driven rotation (calling `gitlab.users.create_personal_access_token`,
+`aws iam create-access-key`, etc.) is deferred. The reasoning:
+provider rotation APIs are heterogeneous (some require existing
+credentials, some require browser interaction, some don't exist),
+and the assisted flow above covers 100% of providers. A future ADR
+("ADR-2N: Provider-driven secret rotation") will add per-provider
+rotators behind the same `secrets.request_rotation` MCP call,
+falling through to manual rotation when the provider has no
+auto-rotate path.
+
+### 3.6 Pattern catalogue (`devboy-secret-patterns`)
+
+A new workspace crate, `crates/devboy-secret-patterns/`, holds the
+canonical descriptions of secret types: GitHub PATs, GitLab tokens,
+AWS access keys, OpenAI API keys, JWTs, Slack tokens, Vault tokens,
+and so on. The crate is shared with the OTLP sanitizer (#240) and
+the `otel scan` auditor (#242) so all three subsystems see the
+same regex and severity, but the patterns are written from the
+secret-store side first.
+
+#### Layered trait
+
+```rust
+pub trait SecretPattern: Send + Sync {
+    fn id(&self) -> &str;
+    fn display_name(&self) -> &str;
+    fn format_regex(&self) -> &Regex;
+    fn severity(&self) -> Severity;
+
+    // Optional layers — present if the pattern supplies them
+    fn metadata(&self) -> Option<&PatternMetadata>;
+    fn rotation(&self) -> Option<&RotationSpec>;
+    fn liveness(&self) -> Option<&LivenessSpec>;
+}
+
+pub struct PatternMetadata {
+    pub provider_id: &'static str,
+    pub retrieval_url_template: &'static str,
+    pub default_expiry_days: Option<u32>,
+    pub scopes_hint: Vec<&'static str>,
+}
+
+pub struct RotationSpec {
+    pub method: RotationMethod,            // Manual | ProviderUi { url } | ProviderApi { reserved }
+}
+
+pub struct LivenessSpec {
+    pub kind: LivenessKind,                // Http { url, method, auth, expect_status }
+}
+```
+
+The OTLP sanitizer and `otel scan` consume only `format_regex` +
+`severity`. The secret store consumes everything available; missing
+optional fields are user-fillable in the UI's edit-metadata view.
+
+#### Built-in catalogue + user extension
+
+The crate ships a catalogue of ~30 well-known patterns hard-coded
+behind `SecretPattern` impls. Users may extend the catalogue by
+dropping TOML files into `~/.devboy/secrets/patterns.d/`. Each TOML
+file declares one or more patterns:
+
+```toml
+[[pattern]]
+id              = "internal-mfa-token"
+display_name    = "Internal MFA Service Token"
+format_regex    = "^mfa_[A-Z0-9]{40}$"
+severity        = "high"
+provider_id     = "internal"
+retrieval_url_template = "https://mfa.example.internal/tokens"
+default_expiry_days = 180
+```
+
+User-supplied patterns are loaded at process start and merged with
+the built-in catalogue. A user-supplied pattern with the same `id`
+as a built-in shadows the built-in (with a `doctor` warning so the
+user knows shadowing happened).
+
+#### Why a new crate
+
+The catalogue is small but central, and three consumers want to
+import it. Putting it in `devboy-storage` would force the OTLP
+sanitizer to depend on the storage layer just to read regexes;
+putting it in `devboy-otel-sanitizer` would force the storage layer
+to depend on OTLP. A small dedicated crate is the cleanest split.
+
+### 3.7 MCP agent provisioning protocol
+
+The MCP server (from [ADR-021](./ADR-021-external-secret-sources.md)
+section 6 / [ADR-005](./ADR-005-credential-storage.md)) exposes the
+following typed tools to the agent. **There is no `secrets.get`
+tool exposed to the agent surface.** The only legitimate path for
+a value to reach the agent is through a high-level provider tool
+(e.g. `gitlab.create_merge_request`) where the resolution happens
+server-side and the agent receives only the operation's outcome.
+
+```
+secrets.list(filter?)
+  → [ { path, status, expires_at?, source_name, capabilities_hint? } ]
+  Reads the active context's manifest. Never returns values.
+
+secrets.describe(path)
+  → { path, metadata: PatternMetadata?, status, expires_at?, last_rotated_at? }
+  Reads the global index + per-project overrides. Never returns the value.
+
+secrets.request_provision(path)
+  → { request_id, status: "pending" }
+  Opens the provision dialog (section 3.4) on the user's UI.
+  The agent polls poll_status to track the result.
+
+secrets.request_rotation(path)
+  → { request_id, status: "pending" }
+  Same flow with mode=rotation.
+
+secrets.poll_status(request_id)
+  → { status: "pending" | "ok" | "cancelled" | "expired",
+      expires_at?, last_rotated_at? }
+  Default timeout for a pending request is 5 minutes; after
+  that the request_id resolves to "expired".
+
+secrets.propose_metadata(path, fields)
+  → { request_id, status: "pending" }
+  Opens the edit-metadata view with a diff of fields to apply.
+  The user accepts/rejects per field; the agent receives the
+  applied subset through poll_status.
+
+secrets.propose_new_path(suggested_path, metadata)
+  → { request_id, status: "pending" }
+  Opens a registration dialog. The user can accept the suggested
+  path, edit it, or reject. Used by the agent when it detects a
+  project consuming a token that has no manifest entry.
+```
+
+#### "Agent never sees value" as an enforced invariant
+
+The MCP server's tool-registration code asserts at startup that no
+registered tool returns a `SecretString` directly to the agent.
+This is enforced by:
+
+- A trait bound on the tool result type: tools may return
+  `serde_json::Value` plus a typed wrapper, but the wrapper does
+  not implement `Serialize` if it contains a `SecretString`
+  (per ADR-019).
+- A pre-commit grep gate in `crates/devboy-mcp/` that flags any
+  use of `.expose_secret()` outside of the high-level provider
+  tools' internal HTTP-call construction.
+- A negative test in `crates/devboy-mcp/tests/` that constructs
+  every registered tool, drives it with mock inputs, and asserts
+  no tool's result serialises any `SecretString`-derived value.
+
+These checks are aspirational hard guarantees: a contributor who
+adds a tool that *would* return a value receives a compile error
+or a CI failure, not a code review comment they might miss.
+
+### 3.8 Onboarding skill `setup-secrets`
+
+A new skill at `skills/setup-secrets/skill.md` walks the user
+through the framework on first run. The existing `setup` skill
+gains a `secrets bootstrap` step that delegates to `setup-secrets`
+when a project has a `.devboy/secrets.toml` manifest with at least
+one required path; otherwise the step is a no-op so projects that
+don't use secrets pay no cost.
+
+#### Flow
+
+The skill is **idempotent**: a re-run resumes from the first
+incomplete step. State is recorded in
+`~/.devboy/secrets/setup-state.toml`.
+
+1. **Vault state.** Check `local-vault.dvb`. If absent and the
+   keychain is available, skip to step 4 (the user does not need
+   a local vault). If absent and the keychain is not available,
+   proceed to step 2.
+2. **Create vault.** Prompt for a passphrase (min 12 chars,
+   confirmed twice). Generate a 24-word recovery phrase, display
+   it once with explicit acknowledgement, do not store it. Write
+   `local-vault.dvb` with passphrase + recovery envelopes.
+3. **Optional Touch ID.** On macOS, ask the user whether to add
+   a Touch-ID unlock. If yes, add a keychain envelope.
+4. **Configure routing.** Walk through the candidate sources.
+   For each available source, register it in `sources.toml`;
+   for each unavailable source (e.g. `op` not installed),
+   record a skipped status with a one-line "install with `brew
+   install 1password-cli`" hint. The keychain (or local-vault)
+   is configured as `[default]` automatically.
+5. **Walk required secrets.** For each path in
+   `.devboy/secrets.toml`'s `required` list:
+   - Run `secrets.describe(path)` to fetch metadata.
+   - If already provisioned and not expiring, skip.
+   - Otherwise, open the provision dialog (section 3.4) and
+     record the outcome.
+6. **Walk optional secrets.** Same flow with informational
+   skipping of missing values.
+7. **Run validation.** Format + liveness for every required
+   path. Failures are surfaced inline; the user can re-enter or
+   skip.
+8. **Run `doctor`.** Expected to pass. If `doctor` fails, the
+   skill loops back to the failing step with the specific path
+   and reason.
+
+Each step emits one structured message to the agent
+(`{step, status, summary, next_options}`), and the agent presents
+the user with explicit `next` / `skip` / `abort` choices. The
+skill does **not** continue to the next step on its own; it
+always waits for the user.
+
+#### Documentation
+
+`docs/guide/secrets/onboarding.md` (planned) describes the same
+flow for users running `devboy secrets bootstrap` manually without
+the agent. The skill and the manual flow share state through
+`setup-state.toml`; mixing them is supported.
+
+## Consequences
+
+### Positive
+
+- ✅ **Headless Linux works without external infrastructure.**
+  The local vault is a real, encrypted store; "no keychain, no
+  Vault, no 1Password" is now a supported configuration.
+- ✅ **The agent never sees secret values.** The MCP surface is
+  designed around request/poll, the local-vault never hands out
+  `vault_key`, and the high-level provider tools resolve
+  credentials server-side. The `secrets.get` tool simply does
+  not exist on the agent surface.
+- ✅ **Rotation is a guided action, not a notification.** The
+  rotation dialog opens the right URL, validates the new value,
+  and records the rotation in one flow — the user does not have
+  to remember to update `last_rotated_at`.
+- ✅ **Pattern catalogue is shared infrastructure.** The same
+  regex and severity drive secret-store validation, OTLP
+  sanitization (#240), and OTEL artifact scanning (#242). One
+  source of truth, three consumers.
+- ✅ **Onboarding is data, not lore (continued from ADR-020).**
+  The `setup-secrets` skill walks every required path through a
+  consistent UI, with idempotent resume on interruption.
+- ✅ **One binary, two UIs.** TUI on `ratatui` and GUI on `egui`
+  share view code; the user gets the right interface for their
+  context without an extra install step.
+
+### Negative
+
+- ❌ **One more long-running process.** The on-demand daemon is
+  the smallest version of this; the persistent install adds a
+  launchd / systemd service to manage. Both are testable but the
+  surface is larger than "stateless CLI".
+- ❌ **An umbrella ADR.** Eight sub-decisions in one file
+  trades enforceability of the "single decision per ADR" rule
+  for cohesion. Future evolution may need to split sections out
+  (the pattern catalogue is the most likely candidate).
+- ❌ **GUI dependencies in the main binary.** `egui` and the
+  `winit` stack add ~3 MB to the release binary. Users who only
+  use the TUI pay this cost. Mitigation: feature-gate the GUI
+  behind `default-features = ["gui"]` in `devboy-cli`'s
+  `Cargo.toml`; CI binaries can opt out.
+- ❌ **Two unlock paths means two places for unlock bugs to
+  hide.** A failure in either the passphrase or the keychain
+  envelope must surface clearly; the daemon's `vault.unlock`
+  result enumerates the failure cause.
+
+### Risks
+
+- ⚠️ **Lost recovery phrase = lost vault.** The user who loses
+  passphrase + keychain unlock + recovery phrase has no recourse.
+  **Mitigation:** the bootstrap flow shows the recovery phrase
+  with explicit acknowledgement; the documentation calls this
+  out; users on teams with external sources should route the
+  primary tree through the external source and use the local
+  vault only for paths they can afford to recreate.
+- ⚠️ **Daemon survives a session it shouldn't.** A user logs
+  out without the daemon receiving SIGTERM (a hard kill of the
+  parent shell, for example) and the unlocked key persists in
+  RAM until the OS reclaims the page. **Mitigation:** the
+  Argon2id KDF cost makes brute force on the wrapped key
+  expensive even after RAM acquisition; the idle timeout
+  (15 min default) bounds the window; `vault.lock` is exposed
+  for explicit re-lock.
+- ⚠️ **A compromised egui dependency could log keystrokes.**
+  GUI input goes through `winit` and `egui`'s text-edit widget.
+  **Mitigation:** the dependency is pinned to a vetted
+  version, audited at release; the TUI fallback is available
+  for users who prefer to limit the GUI surface.
+- ⚠️ **Pattern catalogue becomes a maintenance burden.** New
+  providers, new token formats, new rotation patterns
+  accumulate. **Mitigation:** the user-extension mechanism
+  (`patterns.d/`) lets new patterns ship out-of-band; the core
+  catalogue ships ~30 patterns covering the long-tail of
+  GitHub / GitLab / AWS / GCP / OpenAI / Anthropic / Slack /
+  Stripe / Vault / common JWT shapes.
+- ⚠️ **Agent abuses `request_provision` for prompt injection.**
+  A malicious prompt could ask the agent to call
+  `request_provision` for a path that opens a dialog asking the
+  user to enter another credential under a misleading
+  `description`. **Mitigation:** the dialog renders metadata
+  from the global index, **not** strings supplied by the agent;
+  `propose_metadata` shows the proposed change as a diff, not
+  as an applied state.
+
+## Alternatives Considered
+
+### Alternative 1: No local vault — keychain or external sources only
+
+**Description:** Drop section 3.1 / 3.2 / 3.3 entirely; users on
+headless machines without a keychain must use an env-store or set
+up an external source.
+
+**Why rejected:** The "I want to work off-network on a Linux box
+without provisioning Vault" case is real for short-lived
+projects, demos, and contractor laptops. Forcing those users to
+either set up a full Vault or paste tokens into env vars is
+exactly the friction this ADR is designed to remove. The local
+vault is also useful as a deliberate choice for users who want
+some paths off-keychain — the routing layer makes that a per-path
+decision.
+
+### Alternative 2: Keychain-only with no daemon
+
+**Description:** Skip the daemon entirely; rely on the OS
+keychain's own session management.
+
+**Why rejected:** The keychain is one source among five
+(ADR-021); the local-vault still needs to manage unlocked state,
+and that state is the daemon. The same daemon serves the
+biometric-prompt batching argument (an agent loop should not
+trigger N keychain unlocks for N reads).
+
+### Alternative 3: Sealed file with sops/age and no daemon
+
+**Description:** Use sops or age over a TOML file and unlock
+on each read.
+
+**Why rejected:** Sops pulls in a backend (age, GPG, KMS) and
+turns the unlock step into a per-read prompt. The daemon's
+single unlock per session is the ergonomic difference; without
+it the local vault is unusable for any flow that touches more
+than one secret.
+
+### Alternative 4: Web UI on localhost
+
+**Description:** Replace the `egui` GUI with a localhost-bound
+HTTP server and a browser frontend.
+
+**Why rejected:** Browser frontends pull in CORS, certificate,
+and clipboard concerns that a native widget set does not have.
+The TUI fallback covers the "I am SSH'd into a server and want
+to provision a secret" case; the browser would not help there.
+A future companion web UI for team admin views is not ruled out
+but is out of scope here.
+
+### Alternative 5: Provider-driven auto-rotation in v1
+
+**Description:** Ship per-provider rotators alongside the manual
+flow.
+
+**Why rejected:** Provider rotation APIs are heterogeneous and
+each one is a separate research project (which credential rotates
+which, what scopes are needed for the rotate call itself, what
+happens to in-flight tokens during rotation). Manual-assisted
+rotation covers 100% of providers today; provider-driven
+rotation is best handled per-provider once we have rotation
+telemetry from the manual flow.
+
+### Alternative 6: Eight separate ADRs
+
+**Description:** Split this ADR into ADR-023 through ADR-029
+along the eight section boundaries.
+
+**Why rejected:** The components are designed against each
+other; review would have to thread through all eight to see
+the whole. The "single decision per ADR" convention is a
+default; this ADR is an explicit exception, marked as such in
+the Status section, with the candidate-for-promotion path
+named.
+
+## Implementation
+
+- **Issues:**
+  - [#247](https://github.com/meteora-pro/devboy-tools/issues/247) — implementation, phased; the Phase 6 cluster splits along this ADR's section boundaries
+  - [#240](https://github.com/meteora-pro/devboy-tools/issues/240) — OTLP sanitizer; consumes `devboy-secret-patterns`
+  - [#242](https://github.com/meteora-pro/devboy-tools/issues/242) — OTEL scan; also consumes `devboy-secret-patterns`
+  - To be filed — design refresh covering rewritten ADR-020/021 and this new ADR-023
+- **Code (planned):**
+  - `crates/devboy-vault-crypto/` — file format + AEAD + KDF
+  - `crates/devboy-secrets-agent/` — daemon, JSON-RPC server,
+    socket handling
+  - `crates/plugins/secrets/local-vault/` — `SecretSource`
+    implementation talking to the daemon
+  - `crates/devboy-secret-patterns/` — pattern catalogue
+  - `crates/devboy-secrets-ui/` — `ratatui` + `egui` UIs (one
+    crate, two backends behind `cfg`)
+  - `crates/devboy-cli/` — `devboy secrets {ui, vault, agent,
+    rotate, provision, bootstrap, recover, migrate}` subcommands
+  - `crates/devboy-mcp/` — `secrets.*` MCP tool surface, the
+    "agent never sees value" enforcement, the manifest-gated
+    resolver in provider tools
+  - `skills/setup-secrets/` — onboarding skill
+- **Documentation (planned):**
+  - `docs/guide/secrets/onboarding.md` — manual bootstrap flow
+  - `docs/guide/secrets/local-vault.md` — file format, recovery,
+    backup recommendations
+  - `docs/guide/secrets/agent-protocol.md` — the MCP surface,
+    aimed at agent authors
+  - `docs/guide/secrets/source-plugin-protocol.md` — from
+    ADR-021 section 6, cross-referenced
+
+## References
+
+- [ADR-005: Credential storage](./ADR-005-credential-storage.md)
+- [ADR-019: Secrets carry SecretString end-to-end](./ADR-019-secret-string-discipline.md)
+- [ADR-020: Secret manifest, path convention, and alias resolution](./ADR-020-secret-manifest-and-alias-resolution.md)
+- [ADR-021: External secret sources and backend routing](./ADR-021-external-secret-sources.md)
+- [`secrecy` crate documentation](https://docs.rs/secrecy/)
+- [`chacha20poly1305` crate (RustCrypto)](https://docs.rs/chacha20poly1305/)
+- [`argon2` crate (RustCrypto)](https://docs.rs/argon2/)
+- [BIP-39: Mnemonic code for generating deterministic keys](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
+- [`ratatui` book](https://ratatui.rs/)
+- [`egui` documentation](https://docs.rs/egui/)
+- [Model Context Protocol](https://modelcontextprotocol.io/) — wire-format reference for the daemon and agent protocols
+- [RFC 8439: ChaCha20 and Poly1305 for IETF Protocols](https://datatracker.ietf.org/doc/html/rfc8439)
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-09 | Andrei Mazniak | Initial draft as the umbrella UX layer above ADR-021 routing — local vault crypto, daemon, native UI, manual-assisted rotation, pattern catalogue, agent provisioning protocol, `setup-secrets` skill |

--- a/docs/architecture/adr/ADR-023-secret-store-ux-layer.md
+++ b/docs/architecture/adr/ADR-023-secret-store-ux-layer.md
@@ -90,8 +90,10 @@ values, and rotation happens on a cadence rather than on demand.
 > encrypted local vault, a single-purpose daemon, a native TUI/GUI,
 > an agent provisioning protocol over MCP, a manual-assisted
 > rotation flow, a shared pattern catalogue, and an onboarding skill.
-> The agent never sees secret values; the user never types secrets
-> through the agent.
+> The agent never sees secret values through the MCP surface; the user
+> never types secrets through the agent. (See §3.7 for the precise
+> scope of this property — it is an enforced invariant on the agent
+> tool surface, not a claim about a sandboxed agent.)
 
 The decision has eight parts.
 
@@ -149,7 +151,7 @@ ENTRIES_INDEX (plaintext TOML, metadata only):
 
 AEAD_BLOBS:
   contiguous concatenation of per-entry ciphertexts; each entry is
-    ChaCha20-Poly1305(
+    XChaCha20-Poly1305(
       plaintext     = value (utf-8 bytes),
       key           = vault_key,
       nonce         = entry.nonce,
@@ -186,10 +188,16 @@ Critical invariants:
 
 #### Algorithms
 
-- **AEAD:** ChaCha20-Poly1305 (RFC 8439). Picked over AES-GCM
-  because it does not require AES-NI and runs constant-time on all
-  targets (including ARM Linux); RustCrypto provides a vetted
-  pure-Rust implementation (`chacha20poly1305`).
+- **AEAD:** XChaCha20-Poly1305 (192-bit nonce; ChaCha20 from RFC
+  8439 extended with the XSalsa20-style HChaCha20 nonce derivation).
+  Picked over AES-GCM because it does not require AES-NI and runs
+  constant-time on all targets (including ARM Linux). Picked over
+  the IETF 12-byte-nonce ChaCha20-Poly1305 variant because each
+  per-entry nonce is generated randomly: a 12-byte random nonce has
+  birthday-collision risk after ~2³² writes per key, while the
+  24-byte random nonce makes collisions cryptographically negligible.
+  RustCrypto provides a vetted pure-Rust implementation
+  (`chacha20poly1305::XChaCha20Poly1305`).
 - **KDF:** Argon2id with `m_cost = 65536` (64 MiB), `t_cost = 3`,
   `p_cost = 1` for the passphrase envelope. Tuned to ≈250 ms on a
   2024-class laptop; tuneable per-vault if a host is too slow.
@@ -231,8 +239,9 @@ The vault accepts three independent unlock methods:
   creation; cannot be removed.
 - **Keychain (Touch ID)** — macOS only. The user runs
   `devboy secrets vault add-keychain-unlock`, the CLI generates a
-  random 32-byte key, stores it in the macOS keychain under
-  `kSecAttrAccessControlBiometryAny | kSecAttrAccessControlUserPresence`
+  random 32-byte key and stores it in the macOS keychain with a
+  `SecAccessControl` object created via `SecAccessControlCreateWithFlags`
+  using flags `kSecAccessControlBiometryAny | kSecAccessControlUserPresence`
   (Touch ID required, fallback to user password), and adds a
   `keychain` envelope. Future unlocks via Touch ID don't require
   the passphrase.
@@ -675,11 +684,13 @@ the agent. The skill and the manual flow share state through
 - ✅ **Headless Linux works without external infrastructure.**
   The local vault is a real, encrypted store; "no keychain, no
   Vault, no 1Password" is now a supported configuration.
-- ✅ **The agent never sees secret values.** The MCP surface is
-  designed around request/poll, the local-vault never hands out
-  `vault_key`, and the high-level provider tools resolve
-  credentials server-side. The `secrets.get` tool simply does
-  not exist on the agent surface.
+- ✅ **The agent never sees secret values through the MCP surface.**
+  The agent tool surface is designed around request/poll, the
+  local-vault never hands out `vault_key`, and the high-level
+  provider tools resolve credentials server-side. The `secrets.get`
+  tool simply does not exist on the agent surface. This is a
+  property of the surface, not isolation against a shell-capable
+  agent (see §3.7 and the threat-model alignment above).
 - ✅ **Rotation is a guided action, not a notification.** The
   rotation dialog opens the right URL, validates the new value,
   and records the rotation in one flow — the user does not have

--- a/docs/architecture/adr/INDEX.md
+++ b/docs/architecture/adr/INDEX.md
@@ -21,9 +21,10 @@ This directory holds Architecture Decision Records (ADRs) for `devboy-tools`. Ea
 | [017](./ADR-017-agent-detection-and-onboard.md) | Agent detection and `devboy onboard` command | proposed | Onboarding, Skills |
 | [018](./ADR-018-plugin-distribution.md) | Distribution as Claude Code and Codex plugins with agent-driven bootstrap | proposed | Distribution, Onboarding |
 | [019](./ADR-019-secret-string-discipline.md) | Secrets carry `SecretString` end-to-end | accepted | Security, Storage, Providers |
-| [020](./ADR-020-secret-manifest-and-alias-resolution.md) | Secret manifest, path convention, and alias resolution | proposed | Security, Secrets, Manifest, Core |
-| [021](./ADR-021-external-secret-sources.md) | External secret sources and backend routing | proposed | Security, Secrets, Plugins, Storage |
+| [020](./ADR-020-secret-manifest-and-alias-resolution.md) | Secret manifest, path convention, and alias resolution | proposed (rewrite 2026-05-09) | Security, Secrets, Manifest, Core |
+| [021](./ADR-021-external-secret-sources.md) | External secret sources and backend routing | proposed (rewrite 2026-05-09) | Security, Secrets, Plugins, Storage |
 | [022](./ADR-022-crates-io-publishing.md) | Publish workspace library crates on crates.io alongside the npm CLI binary | proposed | Distribution, Rust |
+| [023](./ADR-023-secret-store-ux-layer.md) | Secret store UX layer — local vault, daemon, native UI, agent protocol, rotation, pattern catalogue, onboarding skill | proposed | Security, Secrets, UI, Agent, Rotation, Patterns, Skills |
 
 **Number gaps** (006, 008, 009, 011) are intentional. Those numbers are reserved for decisions that are not in scope for this project.
 


### PR DESCRIPTION
## Summary

Design refresh of the secret-management framework after review of the 2026-05-06 draft. Closes #252; refines #246; informs #247 phase plan.

- **ADR-020 v2** — manifest + alias resolution; per-project metadata alongside global with conflict-resolution rules; rotation metadata fields; migration tooling explicit.
- **ADR-021 v2** — source router; 5th built-in `local-vault`; `BIOMETRIC_PROMPT` / `AUDIT_LOGGED` capabilities; adaptive cache TTL; recursion invariant; CI mode explicit; subprocess plugin lifetime contract.
- **ADR-023 (new umbrella)** — encrypted local vault (ChaCha20-Poly1305 + Argon2id, envelope encryption, AAD = path); daemon over UNIX-socket JSON-RPC; native TUI + GUI; manual-assisted rotation; `devboy-secret-patterns` crate; MCP agent provisioning protocol with "agent never sees value" invariant; `setup-secrets` skill.

ADR-022 stays as the crates.io publishing decision (from #250); the UX-layer ADR took the next free number, 023.

## Why

See #252 for the full list of gaps in the 2026-05-06 draft that this PR addresses (per-project metadata, headless fallback, biometric-cost UX, cache-vs-lease, explicit CI mode, missing user-facing UX layer).

## Test plan

- [ ] Read ADR-020 v2 — verify per-project override rules and migration section make sense
- [ ] Read ADR-021 v2 — verify capability semantics, recursion invariant, CI-mode contract
- [ ] Read ADR-023 — vault crypto, daemon protocol, agent surface, rotation flow, skill flow
- [ ] Confirm INDEX has ADR-022 (crates.io) AND ADR-023 (UX layer) both listed
- [ ] No real client / team / infrastructure references anywhere in the three files
- [ ] No values or value-adjacent strings in any code sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)