### PR TITLE
fix(clickup): wire assignees through PUT/POST /task (#287)

### DIFF
--- a/crates/plugins/api/clickup/.public-api/baseline.txt
+++ b/crates/plugins/api/clickup/.public-api/baseline.txt
@@ -126,6 +126,24 @@ impl core::marker::Unpin for devboy_clickup::metadata::ClickUpStatus
 impl core::marker::UnsafeUnpin for devboy_clickup::metadata::ClickUpStatus
 impl core::panic::unwind_safe::RefUnwindSafe for devboy_clickup::metadata::ClickUpStatus
 impl core::panic::unwind_safe::UnwindSafe for devboy_clickup::metadata::ClickUpStatus
+pub struct devboy_clickup::AssigneeDiff
+pub devboy_clickup::AssigneeDiff::add: alloc::vec::Vec<u64>
+pub devboy_clickup::AssigneeDiff::rem: alloc::vec::Vec<u64>
+impl core::clone::Clone for devboy_clickup::AssigneeDiff
+pub fn devboy_clickup::AssigneeDiff::clone(&self) -> devboy_clickup::AssigneeDiff
+impl core::default::Default for devboy_clickup::AssigneeDiff
+pub fn devboy_clickup::AssigneeDiff::default() -> devboy_clickup::AssigneeDiff
+impl core::fmt::Debug for devboy_clickup::AssigneeDiff
+pub fn devboy_clickup::AssigneeDiff::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for devboy_clickup::AssigneeDiff
+pub fn devboy_clickup::AssigneeDiff::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl core::marker::Freeze for devboy_clickup::AssigneeDiff
+impl core::marker::Send for devboy_clickup::AssigneeDiff
+impl core::marker::Sync for devboy_clickup::AssigneeDiff
+impl core::marker::Unpin for devboy_clickup::AssigneeDiff
+impl core::marker::UnsafeUnpin for devboy_clickup::AssigneeDiff
+impl core::panic::unwind_safe::RefUnwindSafe for devboy_clickup::AssigneeDiff
+impl core::panic::unwind_safe::UnwindSafe for devboy_clickup::AssigneeDiff
 pub struct devboy_clickup::ClickUpAttachment
 pub devboy_clickup::ClickUpAttachment::date: core::option::Option<alloc::string::String>
 pub devboy_clickup::ClickUpAttachment::extension: core::option::Option<alloc::string::String>
@@ -466,6 +484,52 @@ impl core::marker::Unpin for devboy_clickup::ClickUpTaskList
 impl core::marker::UnsafeUnpin for devboy_clickup::ClickUpTaskList
 impl core::panic::unwind_safe::RefUnwindSafe for devboy_clickup::ClickUpTaskList
 impl core::panic::unwind_safe::UnwindSafe for devboy_clickup::ClickUpTaskList
+pub struct devboy_clickup::ClickUpTeam
+pub devboy_clickup::ClickUpTeam::id: alloc::string::String
+pub devboy_clickup::ClickUpTeam::members: alloc::vec::Vec<devboy_clickup::ClickUpTeamMember>
+impl core::clone::Clone for devboy_clickup::ClickUpTeam
+pub fn devboy_clickup::ClickUpTeam::clone(&self) -> devboy_clickup::ClickUpTeam
+impl core::fmt::Debug for devboy_clickup::ClickUpTeam
+pub fn devboy_clickup::ClickUpTeam::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'de> serde_core::de::Deserialize<'de> for devboy_clickup::ClickUpTeam
+pub fn devboy_clickup::ClickUpTeam::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for devboy_clickup::ClickUpTeam
+impl core::marker::Send for devboy_clickup::ClickUpTeam
+impl core::marker::Sync for devboy_clickup::ClickUpTeam
+impl core::marker::Unpin for devboy_clickup::ClickUpTeam
+impl core::marker::UnsafeUnpin for devboy_clickup::ClickUpTeam
+impl core::panic::unwind_safe::RefUnwindSafe for devboy_clickup::ClickUpTeam
+impl core::panic::unwind_safe::UnwindSafe for devboy_clickup::ClickUpTeam
+pub struct devboy_clickup::ClickUpTeamMember
+pub devboy_clickup::ClickUpTeamMember::user: devboy_clickup::ClickUpUser
+impl core::clone::Clone for devboy_clickup::ClickUpTeamMember
+pub fn devboy_clickup::ClickUpTeamMember::clone(&self) -> devboy_clickup::ClickUpTeamMember
+impl core::fmt::Debug for devboy_clickup::ClickUpTeamMember
+pub fn devboy_clickup::ClickUpTeamMember::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'de> serde_core::de::Deserialize<'de> for devboy_clickup::ClickUpTeamMember
+pub fn devboy_clickup::ClickUpTeamMember::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for devboy_clickup::ClickUpTeamMember
+impl core::marker::Send for devboy_clickup::ClickUpTeamMember
+impl core::marker::Sync for devboy_clickup::ClickUpTeamMember
+impl core::marker::Unpin for devboy_clickup::ClickUpTeamMember
+impl core::marker::UnsafeUnpin for devboy_clickup::ClickUpTeamMember
+impl core::panic::unwind_safe::RefUnwindSafe for devboy_clickup::ClickUpTeamMember
+impl core::panic::unwind_safe::UnwindSafe for devboy_clickup::ClickUpTeamMember
+pub struct devboy_clickup::ClickUpTeamsResponse
+pub devboy_clickup::ClickUpTeamsResponse::teams: alloc::vec::Vec<devboy_clickup::ClickUpTeam>
+impl core::clone::Clone for devboy_clickup::ClickUpTeamsResponse
+pub fn devboy_clickup::ClickUpTeamsResponse::clone(&self) -> devboy_clickup::ClickUpTeamsResponse
+impl core::fmt::Debug for devboy_clickup::ClickUpTeamsResponse
+pub fn devboy_clickup::ClickUpTeamsResponse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'de> serde_core::de::Deserialize<'de> for devboy_clickup::ClickUpTeamsResponse
+pub fn devboy_clickup::ClickUpTeamsResponse::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for devboy_clickup::ClickUpTeamsResponse
+impl core::marker::Send for devboy_clickup::ClickUpTeamsResponse
+impl core::marker::Sync for devboy_clickup::ClickUpTeamsResponse
+impl core::marker::Unpin for devboy_clickup::ClickUpTeamsResponse
+impl core::marker::UnsafeUnpin for devboy_clickup::ClickUpTeamsResponse
+impl core::panic::unwind_safe::RefUnwindSafe for devboy_clickup::ClickUpTeamsResponse
+impl core::panic::unwind_safe::UnwindSafe for devboy_clickup::ClickUpTeamsResponse
 pub struct devboy_clickup::ClickUpUser
 pub devboy_clickup::ClickUpUser::email: core::option::Option<alloc::string::String>
 pub devboy_clickup::ClickUpUser::id: u64
@@ -540,6 +604,7 @@ impl core::marker::UnsafeUnpin for devboy_clickup::CreateTaskRequest
 impl core::panic::unwind_safe::RefUnwindSafe for devboy_clickup::CreateTaskRequest
 impl core::panic::unwind_safe::UnwindSafe for devboy_clickup::CreateTaskRequest
 pub struct devboy_clickup::UpdateTaskRequest
+pub devboy_clickup::UpdateTaskRequest::assignees: core::option::Option<devboy_clickup::AssigneeDiff>
 pub devboy_clickup::UpdateTaskRequest::description: core::option::Option<alloc::string::String>
 pub devboy_clickup::UpdateTaskRequest::markdown_content: core::option::Option<alloc::string::String>
 pub devboy_clickup::UpdateTaskRequest::name: core::option::Option<alloc::string::String>

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -12,9 +12,9 @@ use tracing::{debug, warn};
 
 use crate::DEFAULT_CLICKUP_URL;
 use crate::types::{
-    ClickUpAttachment, ClickUpComment, ClickUpCommentList, ClickUpLinkedTask, ClickUpListInfo,
-    ClickUpPriority, ClickUpTask, ClickUpTaskList, ClickUpUser, CreateCommentRequest,
-    CreateCommentResponse, CreateTaskRequest, UpdateTaskRequest,
+    AssigneeDiff, ClickUpAttachment, ClickUpComment, ClickUpCommentList, ClickUpLinkedTask,
+    ClickUpListInfo, ClickUpPriority, ClickUpTask, ClickUpTaskList, ClickUpTeamsResponse,
+    ClickUpUser, CreateCommentRequest, CreateCommentResponse, CreateTaskRequest, UpdateTaskRequest,
 };
 
 /// Maximum number of tasks per page in ClickUp API.
@@ -244,6 +244,70 @@ impl ClickUpClient {
                     status_type, self.list_id
                 ))
             })
+    }
+
+    /// Fetch the auth user's workspaces with embedded members.
+    /// If a `team_id` is configured on the client, returns only that team's
+    /// members; otherwise flattens across all teams the token has access to.
+    async fn fetch_workspace_members(&self) -> Result<Vec<ClickUpUser>> {
+        let url = format!("{}/team", self.base_url);
+        let resp: ClickUpTeamsResponse = self.get(&url).await?;
+        let target = self.team_id.as_deref();
+        let members: Vec<ClickUpUser> = resp
+            .teams
+            .into_iter()
+            .filter(|t| target.is_none_or(|id| t.id == id))
+            .flat_map(|t| t.members.into_iter().map(|m| m.user))
+            .collect();
+        Ok(members)
+    }
+
+    /// Resolve a list of assignee identifiers (numeric ClickUp user IDs,
+    /// emails, or usernames) to numeric IDs.
+    ///
+    /// Numeric strings are accepted as-is without a lookup. Non-numeric
+    /// strings trigger a single `GET /team` call to load workspace
+    /// members; matching is case-insensitive against `email` first,
+    /// then `username`. Unresolvable identifiers fail the whole call
+    /// rather than silently dropping (callers expect that what they
+    /// asked for is what gets persisted).
+    async fn resolve_assignee_ids(&self, inputs: &[String]) -> Result<Vec<u64>> {
+        let mut resolved: Vec<u64> = Vec::with_capacity(inputs.len());
+        let mut needs_lookup: Vec<&str> = Vec::new();
+        for raw in inputs {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Ok(id) = trimmed.parse::<u64>() {
+                resolved.push(id);
+            } else {
+                needs_lookup.push(trimmed);
+            }
+        }
+        if needs_lookup.is_empty() {
+            return Ok(resolved);
+        }
+        let members = self.fetch_workspace_members().await?;
+        for needle in needs_lookup {
+            let id = members
+                .iter()
+                .find(|u| {
+                    u.email
+                        .as_deref()
+                        .is_some_and(|e| e.eq_ignore_ascii_case(needle))
+                        || u.username.eq_ignore_ascii_case(needle)
+                })
+                .map(|u| u.id);
+            let id = id.ok_or_else(|| {
+                Error::InvalidData(format!(
+                    "Cannot resolve assignee '{needle}' to a ClickUp user id \
+                     (not found by email or username in any accessible workspace)"
+                ))
+            })?;
+            resolved.push(id);
+        }
+        Ok(resolved)
     }
 
     /// Resolve a task key to its raw ClickUp task ID.
@@ -931,6 +995,15 @@ impl IssueProvider for ClickUpClient {
             (input.description, None)
         };
 
+        // ClickUp POST /task accepts a flat `assignees: [u64]` array (no
+        // diff envelope, unlike PUT). Resolve email/username strings to
+        // numeric ids — see `resolve_assignee_ids` for the lookup logic.
+        let assignees = if input.assignees.is_empty() {
+            None
+        } else {
+            Some(self.resolve_assignee_ids(&input.assignees).await?)
+        };
+
         let request = CreateTaskRequest {
             name: input.title,
             description,
@@ -939,7 +1012,7 @@ impl IssueProvider for ClickUpClient {
             status: None,
             priority,
             tags,
-            assignees: None, // ClickUp expects user IDs, not usernames
+            assignees,
         };
 
         let task: ClickUpTask = self.post(&url, &request).await?;
@@ -1007,6 +1080,36 @@ impl IssueProvider for ClickUpClient {
             None => None,
         };
 
+        // Compute assignee diff (`{add, rem}`) before the PUT. ClickUp
+        // silently drops a flat `assignees: [...]` array on update — see
+        // https://clickup.com/api/clickupreference/operation/UpdateTask/.
+        // `None` (not present in the request body) leaves the field
+        // untouched; `Some(empty_diff)` means input was provided but no
+        // change is needed.
+        let assignees_diff = match input.assignees.as_deref() {
+            Some(requested) => {
+                let new_ids = self.resolve_assignee_ids(requested).await?;
+                let current_task: ClickUpTask = self.get(&url).await?;
+                let current_ids: Vec<u64> = current_task.assignees.iter().map(|u| u.id).collect();
+                let add: Vec<u64> = new_ids
+                    .iter()
+                    .copied()
+                    .filter(|id| !current_ids.contains(id))
+                    .collect();
+                let rem: Vec<u64> = current_ids
+                    .iter()
+                    .copied()
+                    .filter(|id| !new_ids.contains(id))
+                    .collect();
+                if add.is_empty() && rem.is_empty() {
+                    None
+                } else {
+                    Some(AssigneeDiff { add, rem })
+                }
+            }
+            None => None,
+        };
+
         let request = UpdateTaskRequest {
             name: input.title,
             description,
@@ -1015,6 +1118,7 @@ impl IssueProvider for ClickUpClient {
             priority,
             parent,
             tags: None, // Tags updated via separate API below
+            assignees: assignees_diff,
         };
 
         let task: ClickUpTask = self.put(&url, &request).await?;
@@ -3803,6 +3907,331 @@ mod tests {
                 .await
                 .unwrap_err();
             assert!(matches!(err, Error::NotFound(_)));
+        }
+
+        // ===== Assignees on PUT /task — regression tests for #287 =====
+        //
+        // Prior to the fix, `UpdateTaskRequest` did not include an
+        // `assignees` field at all, so any `assignees` value passed via
+        // `UpdateIssueInput` was silently dropped — ClickUp returned
+        // 200 with no actual change. The tests below pin the PUT body
+        // shape ClickUp actually expects (`{add: [u64], rem: [u64]}`)
+        // and the diff computation.
+
+        fn team_payload(members: serde_json::Value) -> serde_json::Value {
+            serde_json::json!({
+                "teams": [
+                    {
+                        "id": "9876",
+                        "members": members,
+                    }
+                ]
+            })
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_assignees_resolves_email_and_sends_diff() {
+            let server = MockServer::start();
+
+            // Workspace lookup — used to resolve `m.kitaev@meteora.pro`.
+            server.mock(|when, then| {
+                when.method(GET).path("/team");
+                then.status(200).json_body(team_payload(serde_json::json!([
+                    {"user": {"id": 94519669, "username": "m.kitaev",
+                              "email": "m.kitaev@meteora.pro"}},
+                    {"user": {"id": 11111, "username": "other",
+                              "email": "other@meteora.pro"}}
+                ])));
+            });
+
+            // Current task — bot has no assignees, will add user 94519669.
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(sample_task_no_assignees_json());
+            });
+
+            // PUT body must contain `assignees: {add: [94519669]}`.
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/task/abc123")
+                    .body_includes("\"assignees\":{\"add\":[94519669]")
+                    .body_excludes("\"rem\":");
+                then.status(200).json_body(sample_task_no_assignees_json());
+            });
+
+            let client = create_test_client_with_team(&server);
+            let result = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        assignees: Some(vec!["m.kitaev@meteora.pro".to_string()]),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            assert!(result.is_ok(), "expected ok, got {:?}", result.err());
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_assignees_accepts_numeric_id_without_lookup() {
+            let server = MockServer::start();
+
+            // No /team mock — must NOT be hit for numeric inputs.
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(sample_task_no_assignees_json());
+            });
+
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/task/abc123")
+                    .body_includes("\"assignees\":{\"add\":[42]");
+                then.status(200).json_body(sample_task_no_assignees_json());
+            });
+
+            let client = create_test_client(&server);
+            let result = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        assignees: Some(vec!["42".to_string()]),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            assert!(result.is_ok(), "expected ok, got {:?}", result.err());
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_assignees_diff_add_and_rem() {
+            let server = MockServer::start();
+
+            // Current = [1, 2]; new = [2, 3] → add=[3], rem=[1].
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "abc123", "name": "T",
+                    "status": {"status": "open", "type": "open"},
+                    "tags": [],
+                    "assignees": [
+                        {"id": 1, "username": "u1"},
+                        {"id": 2, "username": "u2"}
+                    ],
+                    "url": "https://app.clickup.com/t/abc123",
+                    "date_created": "1704067200000",
+                    "date_updated": "1704067200000"
+                }));
+            });
+
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/task/abc123")
+                    .body_includes("\"add\":[3]")
+                    .body_includes("\"rem\":[1]");
+                then.status(200).json_body(sample_task_no_assignees_json());
+            });
+
+            let client = create_test_client(&server);
+            let result = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        assignees: Some(vec!["2".to_string(), "3".to_string()]),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            assert!(result.is_ok(), "expected ok, got {:?}", result.err());
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_assignees_empty_input_clears_all() {
+            let server = MockServer::start();
+
+            // Current has [1, 2]; new = [] → add=[], rem=[1, 2].
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "abc123", "name": "T",
+                    "status": {"status": "open", "type": "open"},
+                    "tags": [],
+                    "assignees": [
+                        {"id": 1, "username": "u1"},
+                        {"id": 2, "username": "u2"}
+                    ],
+                    "url": "https://app.clickup.com/t/abc123",
+                    "date_created": "1704067200000",
+                    "date_updated": "1704067200000"
+                }));
+            });
+
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/task/abc123")
+                    .body_includes("\"rem\":[1,2]")
+                    .body_excludes("\"add\":");
+                then.status(200).json_body(sample_task_no_assignees_json());
+            });
+
+            let client = create_test_client(&server);
+            let result = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        assignees: Some(vec![]),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            assert!(result.is_ok(), "expected ok, got {:?}", result.err());
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_assignees_none_leaves_field_untouched() {
+            let server = MockServer::start();
+
+            // PUT body must NOT contain "assignees" — None means leave alone.
+            // Re-fetch GET still happens.
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/task/abc123")
+                    .body_excludes("\"assignees\"");
+                then.status(200).json_body(sample_task_no_assignees_json());
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(sample_task_no_assignees_json());
+            });
+
+            let client = create_test_client(&server);
+            let result = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        title: Some("renamed".to_string()),
+                        // assignees: None
+                        ..Default::default()
+                    },
+                )
+                .await;
+            assert!(result.is_ok(), "expected ok, got {:?}", result.err());
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_assignees_unknown_email_fails_clearly() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/team");
+                then.status(200).json_body(team_payload(serde_json::json!([
+                    {"user": {"id": 1, "username": "u1", "email": "u1@x.com"}}
+                ])));
+            });
+
+            // PUT must NOT be called — resolution should fail first.
+            let put_mock = server.mock(|when, then| {
+                when.method(PUT).path("/task/abc123");
+                then.status(200).json_body(sample_task_no_assignees_json());
+            });
+
+            let client = create_test_client(&server);
+            let err = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        assignees: Some(vec!["nobody@nowhere.com".to_string()]),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect_err("unresolvable email must fail");
+            assert!(
+                format!("{err:?}").contains("Cannot resolve assignee"),
+                "unexpected error: {err:?}"
+            );
+            put_mock.assert_calls(0);
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_assignees_no_change_omits_field() {
+            let server = MockServer::start();
+
+            // Current=[1]; new=[1] → diff empty → assignees field omitted.
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(serde_json::json!({
+                    "id": "abc123", "name": "T",
+                    "status": {"status": "open", "type": "open"},
+                    "tags": [],
+                    "assignees": [{"id": 1, "username": "u1"}],
+                    "url": "https://app.clickup.com/t/abc123",
+                    "date_created": "1704067200000",
+                    "date_updated": "1704067200000"
+                }));
+            });
+
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/task/abc123")
+                    .body_excludes("\"assignees\"");
+                then.status(200).json_body(sample_task_no_assignees_json());
+            });
+
+            let client = create_test_client(&server);
+            let result = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        assignees: Some(vec!["1".to_string()]),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            assert!(result.is_ok(), "expected ok, got {:?}", result.err());
+        }
+
+        #[tokio::test]
+        async fn test_create_issue_assignees_resolves_and_sends_flat_array() {
+            let server = MockServer::start();
+
+            // Lookup by email.
+            server.mock(|when, then| {
+                when.method(GET).path("/team");
+                then.status(200).json_body(team_payload(serde_json::json!([
+                    {"user": {"id": 555, "username": "u",
+                              "email": "u@example.com"}}
+                ])));
+            });
+
+            // POST body must contain `assignees: [555]` (flat, no diff).
+            server.mock(|when, then| {
+                when.method(POST)
+                    .path("/list/12345/task")
+                    .body_includes("\"assignees\":[555]");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            let client = create_test_client(&server);
+            let result = client
+                .create_issue(CreateIssueInput {
+                    title: "New".to_string(),
+                    assignees: vec!["u@example.com".to_string()],
+                    ..Default::default()
+                })
+                .await;
+            assert!(result.is_ok(), "expected ok, got {:?}", result.err());
+        }
+
+        fn sample_task_no_assignees_json() -> serde_json::Value {
+            serde_json::json!({
+                "id": "abc123", "name": "Test Task",
+                "status": {"status": "open", "type": "open"},
+                "tags": [], "assignees": [],
+                "url": "https://app.clickup.com/t/abc123",
+                "date_created": "1704067200000",
+                "date_updated": "1704067200000"
+            })
         }
     }
 }

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -265,12 +265,26 @@ impl ClickUpClient {
     /// Resolve a list of assignee identifiers (numeric ClickUp user IDs,
     /// emails, or usernames) to numeric IDs.
     ///
-    /// Numeric strings are accepted as-is without a lookup. Non-numeric
-    /// strings trigger a single `GET /team` call to load workspace
-    /// members; matching is case-insensitive against `email` first,
-    /// then `username`. Unresolvable identifiers fail the whole call
-    /// rather than silently dropping (callers expect that what they
-    /// asked for is what gets persisted).
+    /// Resolution order per input:
+    ///   1. A string that parses as `u64` is treated as a ClickUp user ID
+    ///      and used as-is. **No verification** that the user exists in
+    ///      the workspace — ClickUp's PUT will simply ignore unknown IDs
+    ///      (the same silent-no-op we are fixing for the flat-array
+    ///      case is, ironically, still the failure mode for unknown
+    ///      numeric IDs on PUT). If you need verification, pass an
+    ///      email or username instead. We accept the trade-off because
+    ///      it lets numeric callers skip the workspace fetch entirely.
+    ///   2. Otherwise: a single `GET /team` call loads workspace members
+    ///      and the input is matched case-insensitively against `email`
+    ///      first, then `username`. Both fields are matched
+    ///      `eq_ignore_ascii_case` (ClickUp's UI treats both as
+    ///      case-insensitive; non-ASCII emails per RFC 6531 will fall
+    ///      back to exact-case comparison via the ASCII path, which is
+    ///      acceptable as ClickUp doesn't allow non-ASCII identifiers
+    ///      in practice).
+    ///   3. Unresolvable inputs fail the **whole** call rather than
+    ///      silently dropping — callers expect that what they pass to
+    ///      `assignees` is what gets persisted.
     async fn resolve_assignee_ids(&self, inputs: &[String]) -> Result<Vec<u64>> {
         let mut resolved: Vec<u64> = Vec::with_capacity(inputs.len());
         let mut needs_lookup: Vec<&str> = Vec::new();
@@ -1086,6 +1100,14 @@ impl IssueProvider for ClickUpClient {
         // `None` (not present in the request body) leaves the field
         // untouched; `Some(empty_diff)` means input was provided but no
         // change is needed.
+        //
+        // Race window: there is an inherent gap between this GET and the
+        // PUT below — a parallel actor that mutates assignees in between
+        // will see a stale diff applied. ClickUp doesn't offer
+        // optimistic-locking on `/task/:id`, so we can't close this
+        // cleanly here; the practical impact is small (assignee changes
+        // are rare and idempotent enough that the next call usually
+        // converges).
         let assignees_diff = match input.assignees.as_deref() {
             Some(requested) => {
                 let new_ids = self.resolve_assignee_ids(requested).await?;

--- a/crates/plugins/api/clickup/src/types.rs
+++ b/crates/plugins/api/clickup/src/types.rs
@@ -157,6 +157,30 @@ pub struct ClickUpTaskList {
 }
 
 // =============================================================================
+// Team (workspace) — used to look up assignees by email/username.
+// =============================================================================
+
+/// Response from GET /api/v2/team — list workspaces the auth user is in,
+/// each with embedded members.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClickUpTeamsResponse {
+    #[serde(default)]
+    pub teams: Vec<ClickUpTeam>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClickUpTeam {
+    pub id: String,
+    #[serde(default)]
+    pub members: Vec<ClickUpTeamMember>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClickUpTeamMember {
+    pub user: ClickUpUser,
+}
+
+// =============================================================================
 // Comment
 // =============================================================================
 
@@ -251,6 +275,22 @@ pub struct UpdateTaskRequest {
     pub parent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
+    /// Assignee diff for PUT /task/:id. ClickUp does NOT accept a flat
+    /// `assignees: [...]` array on update — it silently 200's and drops
+    /// the field. The supported shape is `{ add: [u64], rem: [u64] }`.
+    /// `None` leaves assignees untouched.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignees: Option<AssigneeDiff>,
+}
+
+/// Diff envelope for PUT /task/:id `assignees` field.
+/// Both arrays are sent only when non-empty so ClickUp doesn't see noise.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct AssigneeDiff {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub add: Vec<u64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub rem: Vec<u64>,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary

`update_issue` and `create_issue` accepted an `assignees` parameter but silently dropped it when targeting the ClickUp provider — the underlying `UpdateTaskRequest` struct didn't even declare an `assignees` field, and `CreateTaskRequest` was hardcoded to `assignees: None`. ClickUp returned 200 OK with no actual change.

## ClickUp API specifics

- `PUT /task/:id` — `assignees: { add: [u64], rem: [u64] }` (diff envelope; see https://clickup.com/api/clickupreference/operation/UpdateTask/)
- `POST /task` — `assignees: [u64]` (flat array of numeric user IDs)

A flat `[email]` or `[username]` array on PUT is accepted by ClickUp's HTTP layer but silently no-ops — that was the source of the bug.

## Changes

- `types.rs` — add `AssigneeDiff` struct, add `assignees: Option<AssigneeDiff>` to `UpdateTaskRequest`, add `ClickUpTeamsResponse` / `ClickUpTeam` / `ClickUpTeamMember` for the new workspace-members lookup.
- `client.rs`:
  - `resolve_assignee_ids()` — accepts numeric IDs (no lookup), emails, and usernames. Lookups via a single `GET /team` call, matched case-insensitively against `email` first, then `username`. Unresolvable identifiers fail the whole call (callers expect what they pass to actually persist).
  - `update_issue` — GETs the current task once, computes `{add, rem}` diff, omits the field entirely when the diff is empty so unrelated edits don't touch assignees.
  - `create_issue` — resolves and sends a flat `Vec<u64>` (replacing the hardcoded `None`).
- 8 new integration tests pin the new PUT/POST body shapes:
  - email resolution + diff
  - numeric pass-through (no `/team` lookup)
  - add/rem combination (current=[1,2], new=[2,3] → add=[3], rem=[1])
  - empty input clears all
  - None leaves field untouched
  - no-op diff omits the field
  - unknown email fails before PUT
  - POST sends flat array

102/102 clickup tests green (94 existing + 8 new). `cargo clippy --all-targets --all-features -- -D warnings` clean. `cargo fmt --check` clean.

## Out of scope

- Other providers (GitLab/GitHub/Jira) are unaffected by this change — their `update_issue` implementations already wire assignees correctly.
- Email-to-ID resolution does one `GET /team` per `update_issue` call when at least one non-numeric identifier is present; in-process memoization across calls is a future optimization.

## Related

Surfaced during DEV-1391 in the cloud monorepo (https://app.clickup.com/t/86c9yjn9j) where `devboy-create-issue` / `devboy-solve-issue` skills failed to set the assignee after creating a task. Companion: #288 (provider-specific status).

Closes #287