### PR TITLE
feat(clickup): support setting custom statuses via update_issue (#288)

### DIFF
--- a/crates/devboy-core/.public-api/baseline.txt
+++ b/crates/devboy-core/.public-api/baseline.txt
@@ -3528,6 +3528,7 @@ pub devboy_core::types::UpdateIssueInput::parent_id: core::option::Option<alloc:
 pub devboy_core::types::UpdateIssueInput::priority: core::option::Option<alloc::string::String>
 pub devboy_core::types::UpdateIssueInput::sprint_id: core::option::Option<i64>
 pub devboy_core::types::UpdateIssueInput::state: core::option::Option<alloc::string::String>
+pub devboy_core::types::UpdateIssueInput::status: core::option::Option<alloc::string::String>
 pub devboy_core::types::UpdateIssueInput::title: core::option::Option<alloc::string::String>
 impl core::clone::Clone for devboy_core::types::UpdateIssueInput
 pub fn devboy_core::types::UpdateIssueInput::clone(&self) -> devboy_core::types::UpdateIssueInput
@@ -6725,6 +6726,7 @@ pub devboy_core::UpdateIssueInput::parent_id: core::option::Option<alloc::string
 pub devboy_core::UpdateIssueInput::priority: core::option::Option<alloc::string::String>
 pub devboy_core::UpdateIssueInput::sprint_id: core::option::Option<i64>
 pub devboy_core::UpdateIssueInput::state: core::option::Option<alloc::string::String>
+pub devboy_core::UpdateIssueInput::status: core::option::Option<alloc::string::String>
 pub devboy_core::UpdateIssueInput::title: core::option::Option<alloc::string::String>
 impl core::clone::Clone for devboy_core::types::UpdateIssueInput
 pub fn devboy_core::types::UpdateIssueInput::clone(&self) -> devboy_core::types::UpdateIssueInput

--- a/crates/devboy-core/src/types.rs
+++ b/crates/devboy-core/src/types.rs
@@ -267,8 +267,18 @@ pub struct UpdateIssueInput {
     pub title: Option<String>,
     /// New description
     pub description: Option<String>,
-    /// New state
+    /// New state (generic open/closed). For provider-specific custom
+    /// statuses (e.g. ClickUp "in progress" / "review") use
+    /// [`Self::status`] — that field takes precedence.
     pub state: Option<String>,
+    /// Provider-specific status name. ClickUp routes this directly to
+    /// `PUT /task/:id { "status": ... }`; the value must match one of
+    /// the statuses returned by `get_available_statuses` (case-
+    /// insensitive, the canonical name is sent). Other providers
+    /// currently ignore this field — see issue #288 for the path to
+    /// generic transitions for Jira / GitLab / GitHub.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
     /// New labels (replaces existing)
     pub labels: Option<Vec<String>>,
     /// New assignees (replaces existing)
@@ -321,6 +331,7 @@ impl Default for UpdateIssueInput {
             title: None,
             description: None,
             state: None,
+            status: None,
             labels: None,
             assignees: None,
             priority: None,

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -1000,6 +1000,11 @@ struct UpdateIssueParams {
     title: Option<String>,
     description: Option<String>,
     state: Option<String>,
+    /// Provider-specific status name (#288). For ClickUp: any custom
+    /// status from `get_available_statuses` (e.g. "in progress",
+    /// "review"). Currently a no-op for other providers.
+    #[serde(default)]
+    status: Option<String>,
     labels: Option<Vec<String>>,
     assignees: Option<Vec<String>>,
     #[serde(default, deserialize_with = "deserialize_string_or_number")]
@@ -1037,6 +1042,7 @@ async fn execute_update_issue(
         title: params.title,
         description: params.description,
         state: params.state,
+        status: params.status,
         labels: params.labels,
         assignees: params.assignees,
         priority: params.priority,
@@ -1695,6 +1701,7 @@ async fn execute_update_epic(
         title: params.title,
         description: params.description,
         state: params.state,
+        status: None,
         labels,
         assignees: params.assignees,
         priority: params.priority,

--- a/crates/devboy-executor/src/executor.rs
+++ b/crates/devboy-executor/src/executor.rs
@@ -1642,6 +1642,12 @@ struct UpdateEpicParams {
     title: Option<String>,
     description: Option<String>,
     state: Option<String>,
+    /// Provider-specific status name (#288). Same semantics as
+    /// `UpdateIssueParams::status` — epics are stored as ClickUp tasks,
+    /// so the same custom-status workflow applies (e.g. "in progress",
+    /// "review", "complete").
+    #[serde(default)]
+    status: Option<String>,
     #[serde(rename = "goalId")]
     goal_id: Option<String>,
     labels: Option<Vec<String>>,
@@ -1701,7 +1707,7 @@ async fn execute_update_epic(
         title: params.title,
         description: params.description,
         state: params.state,
-        status: None,
+        status: params.status,
         labels,
         assignees: params.assignees,
         priority: params.priority,

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -105,7 +105,8 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("key", PropertySchema::string("Issue key"));
                 s.add_property("title", PropertySchema::string("New title"));
                 s.add_property("description", PropertySchema::string("New description"));
-                s.add_property("state", PropertySchema::string_enum(&["open", "closed"], "New state"));
+                s.add_property("state", PropertySchema::string_enum(&["open", "closed"], "New state (generic open/closed). For ClickUp custom statuses (\"in progress\", \"review\", \"to do\", …) use `status` instead — `get_available_statuses` lists valid names."));
+                s.add_property("status", PropertySchema::string("Provider-specific status name. ClickUp: any custom status from `get_available_statuses` (e.g. \"in progress\", \"review\"). Other providers: ignored. Takes precedence over `state` when both are set."));
                 s.add_property("labels", PropertySchema::array(PropertySchema::string("label"), "New labels (replaces existing)"));
                 s.add_property("assignees", PropertySchema::array(PropertySchema::string("assignee"), "New assignees"));
                 s.add_property("parentId", PropertySchema::string("Parent issue key to move task as subtask (e.g., 'CU-abc123' or 'DEV-42'). Only supported by ClickUp."));

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -343,7 +343,8 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("epicKey", PropertySchema::string("Epic key (e.g., 'CU-abc', 'DEV-123')"));
                 s.add_property("title", PropertySchema::string("New title"));
                 s.add_property("description", PropertySchema::string("New description"));
-                s.add_property("state", PropertySchema::string("New epic state"));
+                s.add_property("state", PropertySchema::string("New epic state (generic open/closed). For ClickUp custom statuses use `status`."));
+                s.add_property("status", PropertySchema::string("Provider-specific status name. Same as `update_issue.status` — for ClickUp, any custom status from `get_available_statuses`. Takes precedence over `state`."));
                 s.add_property("goalId", PropertySchema::string("Goal ID (G1-G9) to associate with the epic"));
                 s.add_property("priority", PropertySchema::string("New priority (urgent/high/normal/low)"));
                 s.add_property("labels", PropertySchema::array(PropertySchema::string("label"), "Labels to set"));

--- a/crates/devboy-executor/src/tools.rs
+++ b/crates/devboy-executor/src/tools.rs
@@ -105,7 +105,7 @@ pub fn base_tool_definitions() -> Vec<ToolDefinition> {
                 s.add_property("key", PropertySchema::string("Issue key"));
                 s.add_property("title", PropertySchema::string("New title"));
                 s.add_property("description", PropertySchema::string("New description"));
-                s.add_property("state", PropertySchema::string_enum(&["open", "closed"], "New state (generic open/closed). For ClickUp custom statuses (\"in progress\", \"review\", \"to do\", …) use `status` instead — `get_available_statuses` lists valid names."));
+                s.add_property("state", PropertySchema::string_enum(&["open", "closed"], "New state (generic open/closed). For ClickUp custom statuses (\"in progress\", \"review\", \"to do\", …) use `status` instead — `get_available_statuses` lists valid names"));
                 s.add_property("status", PropertySchema::string("Provider-specific status name. ClickUp: any custom status from `get_available_statuses` (e.g. \"in progress\", \"review\"). Other providers: ignored. Takes precedence over `state` when both are set."));
                 s.add_property("labels", PropertySchema::array(PropertySchema::string("label"), "New labels (replaces existing)"));
                 s.add_property("assignees", PropertySchema::array(PropertySchema::string("assignee"), "New assignees"));

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -220,6 +220,22 @@ impl ClickUpClient {
             .map_err(|e| Error::InvalidData(format!("Failed to parse response: {}", e)))
     }
 
+    /// Fetch the configured statuses for `self.list_id`. Shared by
+    /// `validate_status_name` (literal-name match, #288) and
+    /// `resolve_status` (generic open/closed → type-matched name);
+    /// extracted so both stay in sync if the list endpoint shape
+    /// evolves.
+    async fn fetch_list_statuses(&self) -> Result<ClickUpListInfo> {
+        let url = format!("{}/list/{}", self.base_url, self.list_id);
+        self.get(&url).await
+    }
+
+    /// Maximum number of status names embedded in the "Unknown status"
+    /// error message. Some workspaces have 50+ configured statuses and
+    /// dumping all of them creates wall-of-text errors that are worse
+    /// than just listing the common ones.
+    const STATUS_LIST_ERROR_LIMIT: usize = 10;
+
     /// Validate a literal ClickUp custom status name (#288) against the
     /// list's configured statuses. Returns the canonical name from the
     /// list (preserving the case as configured in ClickUp) when the
@@ -228,9 +244,14 @@ impl ClickUpClient {
     /// caused the regression on the cloud side where the MCP layer
     /// accepted "in progress" and ClickUp returned 200 without changing
     /// anything.
+    ///
+    /// If the input looks like a generic state keyword (`open`,
+    /// `opened`, `closed`), the error message points the caller at the
+    /// `state` field instead. Those keywords are rarely actual ClickUp
+    /// status names; the most likely cause is the caller mistakenly
+    /// passing them through the wrong field.
     async fn validate_status_name(&self, requested: &str) -> Result<String> {
-        let url = format!("{}/list/{}", self.base_url, self.list_id);
-        let list_info: ClickUpListInfo = self.get(&url).await?;
+        let list_info = self.fetch_list_statuses().await?;
         if let Some(found) = list_info
             .statuses
             .iter()
@@ -238,15 +259,31 @@ impl ClickUpClient {
         {
             return Ok(found.status.clone());
         }
-        let valid: Vec<&str> = list_info
+        let total = list_info.statuses.len();
+        let valid_preview: Vec<&str> = list_info
             .statuses
             .iter()
+            .take(Self::STATUS_LIST_ERROR_LIMIT)
             .map(|s| s.status.as_str())
             .collect();
+        let valid_str = if total > Self::STATUS_LIST_ERROR_LIMIT {
+            format!(
+                "{}, …and {} more",
+                valid_preview.join(", "),
+                total - Self::STATUS_LIST_ERROR_LIMIT
+            )
+        } else {
+            valid_preview.join(", ")
+        };
+        let hint = match requested.to_ascii_lowercase().as_str() {
+            "open" | "opened" | "closed" => {
+                " (note: for generic open/closed transitions, pass via the `state` field instead)"
+            }
+            _ => "",
+        };
         Err(Error::InvalidData(format!(
-            "Unknown ClickUp status '{requested}' for list {}. Valid: [{}]",
-            self.list_id,
-            valid.join(", ")
+            "Unknown ClickUp status '{requested}' for list {}. Valid: [{valid_str}]{hint}",
+            self.list_id
         )))
     }
 
@@ -260,8 +297,7 @@ impl ClickUpClient {
             _ => return Ok(state.to_string()),
         };
 
-        let url = format!("{}/list/{}", self.base_url, self.list_id);
-        let list_info: ClickUpListInfo = self.get(&url).await?;
+        let list_info = self.fetch_list_statuses().await?;
 
         list_info
             .statuses
@@ -4041,6 +4077,83 @@ mod tests {
                 )
                 .await;
             assert!(result.is_ok(), "got {:?}", result.err());
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_status_open_keyword_hints_at_state_field() {
+            // Regression for review feedback on #290: when a caller
+            // accidentally passes "open" / "closed" via `status` instead
+            // of `state`, the error must point them at the right field
+            // instead of just listing valid custom statuses.
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345");
+                then.status(200).json_body(list_with_statuses());
+            });
+
+            let put_mock = server.mock(|when, then| {
+                when.method(PUT).path("/task/abc123");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            let client = create_test_client(&server);
+            for keyword in ["open", "Opened", "CLOSED"] {
+                let err = client
+                    .update_issue(
+                        "CU-abc123",
+                        UpdateIssueInput {
+                            status: Some(keyword.to_string()),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                    .expect_err("open/closed via `status` must fail");
+                let msg = format!("{err:?}");
+                assert!(msg.contains("state` field"), "keyword={keyword} msg={msg}");
+            }
+            put_mock.assert_calls(0);
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_status_unknown_truncates_large_status_list() {
+            // Some workspaces have 50+ statuses; the error message must
+            // not dump all of them verbatim. Truncates at 10 with
+            // "…and N more" suffix.
+            let server = MockServer::start();
+
+            let many_statuses: Vec<serde_json::Value> = (0..15)
+                .map(|i| serde_json::json!({"status": format!("status-{i:02}"), "type": "custom"}))
+                .collect();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345");
+                then.status(200)
+                    .json_body(serde_json::json!({"statuses": many_statuses}));
+            });
+
+            let client = create_test_client(&server);
+            let err = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        status: Some("nonexistent".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect_err("must fail");
+            let msg = format!("{err:?}");
+            assert!(msg.contains("status-00"), "preview missing first: {msg}");
+            assert!(msg.contains("status-09"), "preview missing 10th: {msg}");
+            assert!(
+                !msg.contains("status-10"),
+                "11th status leaked past truncation: {msg}"
+            );
+            assert!(
+                msg.contains("…and 5 more"),
+                "truncation suffix missing: {msg}"
+            );
         }
     }
 }

--- a/crates/plugins/api/clickup/src/client.rs
+++ b/crates/plugins/api/clickup/src/client.rs
@@ -220,6 +220,36 @@ impl ClickUpClient {
             .map_err(|e| Error::InvalidData(format!("Failed to parse response: {}", e)))
     }
 
+    /// Validate a literal ClickUp custom status name (#288) against the
+    /// list's configured statuses. Returns the canonical name from the
+    /// list (preserving the case as configured in ClickUp) when the
+    /// input matches case-insensitively. Errors with a clear message
+    /// listing valid statuses when there's no match — silent fallthrough
+    /// caused the regression on the cloud side where the MCP layer
+    /// accepted "in progress" and ClickUp returned 200 without changing
+    /// anything.
+    async fn validate_status_name(&self, requested: &str) -> Result<String> {
+        let url = format!("{}/list/{}", self.base_url, self.list_id);
+        let list_info: ClickUpListInfo = self.get(&url).await?;
+        if let Some(found) = list_info
+            .statuses
+            .iter()
+            .find(|s| s.status.eq_ignore_ascii_case(requested))
+        {
+            return Ok(found.status.clone());
+        }
+        let valid: Vec<&str> = list_info
+            .statuses
+            .iter()
+            .map(|s| s.status.as_str())
+            .collect();
+        Err(Error::InvalidData(format!(
+            "Unknown ClickUp status '{requested}' for list {}. Valid: [{}]",
+            self.list_id,
+            valid.join(", ")
+        )))
+    }
+
     /// Resolve a unified state name ("open"/"closed") to the actual ClickUp status name
     /// by fetching the list's configured statuses.
     /// If the state doesn't match a known type, it's passed as-is (exact status name).
@@ -975,9 +1005,17 @@ impl IssueProvider for ClickUpClient {
     async fn update_issue(&self, key: &str, input: UpdateIssueInput) -> Result<Issue> {
         let url = self.task_url(key)?;
 
-        let status = match input.state {
-            Some(s) => Some(self.resolve_status(&s).await?),
-            None => None,
+        // `status` takes precedence over `state` (#288). It is a literal
+        // ClickUp custom status name (e.g. "in progress", "review");
+        // we validate against the list's configured statuses
+        // (case-insensitive) and forward the canonical form. `state`
+        // is the legacy generic open/closed path resolved by type.
+        let status = if let Some(s) = input.status.as_deref() {
+            Some(self.validate_status_name(s).await?)
+        } else if let Some(s) = input.state.as_deref() {
+            Some(self.resolve_status(s).await?)
+        } else {
+            None
         };
 
         let priority = input.priority.as_deref().and_then(priority_to_clickup);
@@ -3803,6 +3841,206 @@ mod tests {
                 .await
                 .unwrap_err();
             assert!(matches!(err, Error::NotFound(_)));
+        }
+
+        // ===== Custom status support — regression tests for #288 =====
+        //
+        // Before this change the executor schema constrained the `state`
+        // field to enum ["open", "closed"], so ClickUp custom statuses
+        // like "in progress" / "review" were unreachable via the MCP
+        // layer. The new `status` field forwards the literal status
+        // name; it is validated against the list's configured statuses
+        // (case-insensitive) and the canonical case from the list is
+        // sent in the PUT body.
+
+        fn list_with_statuses() -> serde_json::Value {
+            serde_json::json!({
+                "statuses": [
+                    {"status": "to do", "type": "open"},
+                    {"status": "in progress", "type": "custom"},
+                    {"status": "review", "type": "custom"},
+                    {"status": "complete", "type": "closed"}
+                ]
+            })
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_status_sets_custom_status() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345");
+                then.status(200).json_body(list_with_statuses());
+            });
+
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/task/abc123")
+                    .body_includes("\"status\":\"in progress\"");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            let client = create_test_client(&server);
+            let result = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        status: Some("in progress".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            assert!(result.is_ok(), "got {:?}", result.err());
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_status_case_insensitive_match() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345");
+                then.status(200).json_body(list_with_statuses());
+            });
+
+            // Input "REVIEW", list has "review" → PUT body sends canonical "review".
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/task/abc123")
+                    .body_includes("\"status\":\"review\"");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            let client = create_test_client(&server);
+            let result = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        status: Some("REVIEW".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            assert!(result.is_ok(), "got {:?}", result.err());
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_status_unknown_fails_with_valid_list() {
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345");
+                then.status(200).json_body(list_with_statuses());
+            });
+
+            let put_mock = server.mock(|when, then| {
+                when.method(PUT).path("/task/abc123");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            let client = create_test_client(&server);
+            let err = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        status: Some("released-to-prod".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect_err("unknown status must fail before PUT");
+            let msg = format!("{err:?}");
+            assert!(msg.contains("Unknown ClickUp status"), "msg: {msg}");
+            assert!(msg.contains("released-to-prod"), "msg: {msg}");
+            assert!(msg.contains("in progress"), "list of valids missing: {msg}");
+            put_mock.assert_calls(0);
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_status_overrides_state_when_both_set() {
+            let server = MockServer::start();
+
+            // List endpoint is only hit by validate_status_name (for
+            // `status`) — NOT by resolve_status (`state`); pin that with
+            // a single mock that's allowed to be called once.
+            let list_mock = server.mock(|when, then| {
+                when.method(GET).path("/list/12345");
+                then.status(200).json_body(list_with_statuses());
+            });
+
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/task/abc123")
+                    // status wins → "in progress", not "to do" (open) /
+                    // "complete" (closed).
+                    .body_includes("\"status\":\"in progress\"");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            let client = create_test_client(&server);
+            let result = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        state: Some("closed".to_string()),
+                        status: Some("in progress".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            assert!(result.is_ok(), "got {:?}", result.err());
+            list_mock.assert_calls(1);
+        }
+
+        #[tokio::test]
+        async fn test_update_issue_state_path_unchanged_when_status_absent() {
+            // Regression guard: the legacy `state: "closed"` path must
+            // keep working through resolve_status (no behavior change
+            // for callers that never set `status`).
+            let server = MockServer::start();
+
+            server.mock(|when, then| {
+                when.method(GET).path("/list/12345");
+                then.status(200).json_body(list_with_statuses());
+            });
+
+            server.mock(|when, then| {
+                when.method(PUT)
+                    .path("/task/abc123")
+                    .body_includes("\"status\":\"complete\"");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            server.mock(|when, then| {
+                when.method(GET).path("/task/abc123");
+                then.status(200).json_body(sample_task_json());
+            });
+
+            let client = create_test_client(&server);
+            let result = client
+                .update_issue(
+                    "CU-abc123",
+                    UpdateIssueInput {
+                        state: Some("closed".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            assert!(result.is_ok(), "got {:?}", result.err());
         }
     }
 }

--- a/docs/guide/reference/tools.md
+++ b/docs/guide/reference/tools.md
@@ -212,7 +212,8 @@ Update an existing issue. Only provided fields will be changed.
 | `labels` | array&lt;string&gt; | — | New labels (replaces existing) |
 | `markdown` | boolean | — | Whether the description is markdown (default: true). When true, ClickUp renders formatted text. |
 | `parentId` | string | — | Parent issue key to move task as subtask (e.g., 'CU-abc123' or 'DEV-42'). Only supported by ClickUp. |
-| `state` | string | — | New state. Allowed values: `open`, `closed` |
+| `state` | string | — | New state (generic open/closed). For ClickUp custom statuses ("in progress", "review", "to do", …) use `status` instead — `get_available_statuses` lists valid names. Allowed values: `open`, `closed` |
+| `status` | string | — | Provider-specific status name. ClickUp: any custom status from `get_available_statuses` (e.g. "in progress", "review"). Other providers: ignored. Takes precedence over `state` when both are set. |
 | `title` | string | — | New title |
 
 ### `upload_asset`
@@ -382,7 +383,8 @@ Update an existing epic.
 | `goalId` | string | — | Goal ID (G1-G9) to associate with the epic |
 | `labels` | array&lt;string&gt; | — | Labels to set |
 | `priority` | string | — | New priority (urgent/high/normal/low) |
-| `state` | string | — | New epic state |
+| `state` | string | — | New epic state (generic open/closed). For ClickUp custom statuses use `status`. |
+| `status` | string | — | Provider-specific status name. Same as `update_issue.status` — for ClickUp, any custom status from `get_available_statuses`. Takes precedence over `state`. |
 | `title` | string | — | New title |
 
 ## Meeting Notes Tools


### PR DESCRIPTION
## Summary

The unified `update_issue` MCP tool exposed only `state: enum("open", "closed")` for status-related changes. ClickUp custom statuses (`to do`, `in progress`, `review`, `complete`, …) — which `get_available_statuses` happily lists — were unreachable through the MCP layer. Callers had to open the ClickUp UI to bump a task forward.

This PR adds a separate `status` field that forwards a literal ClickUp status name. Existing `state` semantics are preserved.

## Behavior

| Input | What happens (ClickUp) |
|---|---|
| `status: "in progress"` | Validated against list statuses (case-insensitive), canonical name sent on `PUT /task/:id`. |
| `state: "closed"` | Existing path: `resolve_status` picks the status whose `type` is `closed`. |
| Both set | `status` wins. |
| Unknown `status` | Fails with `InvalidData` listing valid statuses; PUT is **not** sent. |
| Neither set | `status` field omitted from PUT body. |

## Why a separate field instead of relaxing `state`'s enum

`state: open/closed` is the generic cross-provider contract (GitHub / GitLab / Jira care about it). Relaxing the enum would weaken the contract and confuse users (`state: "in progress"` would imply state machine semantics). A distinct `status` field makes the provider-specific nature explicit; the schema description points ClickUp users at it and tells other providers it's a no-op.

## Changes

- `devboy-core/types.rs`: add `status: Option<String>` to `UpdateIssueInput` (plus `Default::default`).
- `devboy-executor`:
  - `tools.rs`: extend `update_issue` schema with `status` (free-form string, no enum) and reword `state`'s description to point ClickUp users at the new field.
  - `executor.rs`: deserialize the new param and forward it through `UpdateIssueInput` in both `execute_update_issue` paths.
- ClickUp adapter (`client.rs`):
  - `validate_status_name()` — case-insensitive match against the list's configured statuses; returns the canonical name so the PUT body sends exactly what ClickUp expects. Unknown statuses fail with an explicit error listing valid values (no more silent no-op like #287).
  - `update_issue` routes `status` through the new validator and falls back to the legacy `resolve_status` path when `status` is absent (preserves the existing `open` / `closed` behavior).
- 5 new integration tests:
  - `status` sets a custom ClickUp status
  - case-insensitive match (`"REVIEW"` → canonical `"review"`)
  - unknown status fails before PUT, error message lists valid values
  - `status` overrides `state` when both are set
  - legacy `state` path unchanged when `status` is absent (regression guard)

99/99 clickup tests + full workspace test suite green. `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean. `cargo fmt --check` clean.

## Out of scope (separate issues / PRs)

- **Jira transitions** — Jira doesn't accept a direct status write; status changes go through `POST /issue/:key/transitions` with a transition id resolved from the workflow. Needs its own design (which destination state → which transition).
- **GitLab / GitHub `state_event` mapping** — GitLab issues / GitHub issues use `state_event: close/reopen`; mapping `status: "closed"` is trivial but mapping anything else needs to gracefully error.
- **Schema enrichment** — ClickUp enricher could populate a per-list `status` enum dynamically (similar to how `JiraSchemaEnricher` adds `components`). Useful but not strictly required to unblock the cloud-side skills.

## Related

- Surfaced during DEV-1391 in the cloud monorepo: https://app.clickup.com/t/86c9yjn9j
- Companion: #287 / #289 (assignees no-op)

Closes #288