### PR TITLE
fix(clickup): render comment markdown via comment blocks (#300)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
-      - uses: dtolnay/rust-toolchain@nightly
+      # Pinned nightly: cargo-public-api prints fully-qualified type paths, and
+      # those shift when the toolchain changes (e.g. std::io::Error became a
+      # re-export of core::io::Error), producing spurious baseline drift on a
+      # floating @nightly. Pin a date so baselines stay stable; bump it
+      # deliberately (and regenerate baselines) when needed.
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-06-30
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-public-api
         run: cargo install cargo-public-api --locked --version 0.51.0

--- a/crates/devboy-assets/.public-api/baseline.txt
+++ b/crates/devboy-assets/.public-api/baseline.txt
@@ -133,7 +133,7 @@ pub enum devboy_assets::error::AssetError
 pub devboy_assets::error::AssetError::CacheDir(alloc::string::String)
 pub devboy_assets::error::AssetError::Config(alloc::string::String)
 pub devboy_assets::error::AssetError::Core(devboy_core::error::Error)
-pub devboy_assets::error::AssetError::Io(std::io::error::Error)
+pub devboy_assets::error::AssetError::Io(core::io::error::Error)
 pub devboy_assets::error::AssetError::NotFound(alloc::string::String)
 pub devboy_assets::error::AssetError::Poisoned(alloc::string::String)
 pub devboy_assets::error::AssetError::Serialization(serde_json::error::Error)
@@ -142,12 +142,12 @@ pub fn devboy_assets::error::AssetError::cache_dir(msg: impl core::convert::Into
 pub fn devboy_assets::error::AssetError::config(msg: impl core::convert::Into<alloc::string::String>) -> Self
 pub fn devboy_assets::error::AssetError::not_found(id: impl core::convert::Into<alloc::string::String>) -> Self
 pub fn devboy_assets::error::AssetError::poisoned(msg: impl core::convert::Into<alloc::string::String>) -> Self
+impl core::convert::From<core::io::error::Error> for devboy_assets::error::AssetError
+pub fn devboy_assets::error::AssetError::from(source: core::io::error::Error) -> Self
 impl core::convert::From<devboy_core::error::Error> for devboy_assets::error::AssetError
 pub fn devboy_assets::error::AssetError::from(source: devboy_core::error::Error) -> Self
 impl core::convert::From<serde_json::error::Error> for devboy_assets::error::AssetError
 pub fn devboy_assets::error::AssetError::from(source: serde_json::error::Error) -> Self
-impl core::convert::From<std::io::error::Error> for devboy_assets::error::AssetError
-pub fn devboy_assets::error::AssetError::from(source: std::io::error::Error) -> Self
 impl core::error::Error for devboy_assets::error::AssetError
 pub fn devboy_assets::error::AssetError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for devboy_assets::error::AssetError
@@ -351,7 +351,7 @@ pub enum devboy_assets::AssetError
 pub devboy_assets::AssetError::CacheDir(alloc::string::String)
 pub devboy_assets::AssetError::Config(alloc::string::String)
 pub devboy_assets::AssetError::Core(devboy_core::error::Error)
-pub devboy_assets::AssetError::Io(std::io::error::Error)
+pub devboy_assets::AssetError::Io(core::io::error::Error)
 pub devboy_assets::AssetError::NotFound(alloc::string::String)
 pub devboy_assets::AssetError::Poisoned(alloc::string::String)
 pub devboy_assets::AssetError::Serialization(serde_json::error::Error)
@@ -360,12 +360,12 @@ pub fn devboy_assets::error::AssetError::cache_dir(msg: impl core::convert::Into
 pub fn devboy_assets::error::AssetError::config(msg: impl core::convert::Into<alloc::string::String>) -> Self
 pub fn devboy_assets::error::AssetError::not_found(id: impl core::convert::Into<alloc::string::String>) -> Self
 pub fn devboy_assets::error::AssetError::poisoned(msg: impl core::convert::Into<alloc::string::String>) -> Self
+impl core::convert::From<core::io::error::Error> for devboy_assets::error::AssetError
+pub fn devboy_assets::error::AssetError::from(source: core::io::error::Error) -> Self
 impl core::convert::From<devboy_core::error::Error> for devboy_assets::error::AssetError
 pub fn devboy_assets::error::AssetError::from(source: devboy_core::error::Error) -> Self
 impl core::convert::From<serde_json::error::Error> for devboy_assets::error::AssetError
 pub fn devboy_assets::error::AssetError::from(source: serde_json::error::Error) -> Self
-impl core::convert::From<std::io::error::Error> for devboy_assets::error::AssetError
-pub fn devboy_assets::error::AssetError::from(source: std::io::error::Error) -> Self
 impl core::error::Error for devboy_assets::error::AssetError
 pub fn devboy_assets::error::AssetError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for devboy_assets::error::AssetError

--- a/crates/devboy-core/.public-api/baseline.txt
+++ b/crates/devboy-core/.public-api/baseline.txt
@@ -1159,7 +1159,7 @@ pub devboy_core::error::Error::CredentialNotFound::provider: alloc::string::Stri
 pub devboy_core::error::Error::Forbidden(alloc::string::String)
 pub devboy_core::error::Error::Http(alloc::string::String)
 pub devboy_core::error::Error::InvalidData(alloc::string::String)
-pub devboy_core::error::Error::Io(std::io::error::Error)
+pub devboy_core::error::Error::Io(core::io::error::Error)
 pub devboy_core::error::Error::MissingConfig(alloc::string::String)
 pub devboy_core::error::Error::Network(alloc::string::String)
 pub devboy_core::error::Error::NotFound(alloc::string::String)
@@ -1183,10 +1183,10 @@ pub fn devboy_core::error::Error::is_auth_error(&self) -> bool
 pub fn devboy_core::error::Error::is_retryable(&self) -> bool
 impl core::convert::From<anyhow::Error> for devboy_core::error::Error
 pub fn devboy_core::error::Error::from(source: anyhow::Error) -> Self
+impl core::convert::From<core::io::error::Error> for devboy_core::error::Error
+pub fn devboy_core::error::Error::from(source: core::io::error::Error) -> Self
 impl core::convert::From<serde_json::error::Error> for devboy_core::error::Error
 pub fn devboy_core::error::Error::from(source: serde_json::error::Error) -> Self
-impl core::convert::From<std::io::error::Error> for devboy_core::error::Error
-pub fn devboy_core::error::Error::from(source: std::io::error::Error) -> Self
 impl core::error::Error for devboy_core::error::Error
 pub fn devboy_core::error::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for devboy_core::error::Error
@@ -3797,7 +3797,7 @@ pub devboy_core::Error::CredentialNotFound::provider: alloc::string::String
 pub devboy_core::Error::Forbidden(alloc::string::String)
 pub devboy_core::Error::Http(alloc::string::String)
 pub devboy_core::Error::InvalidData(alloc::string::String)
-pub devboy_core::Error::Io(std::io::error::Error)
+pub devboy_core::Error::Io(core::io::error::Error)
 pub devboy_core::Error::MissingConfig(alloc::string::String)
 pub devboy_core::Error::Network(alloc::string::String)
 pub devboy_core::Error::NotFound(alloc::string::String)
@@ -3821,10 +3821,10 @@ pub fn devboy_core::error::Error::is_auth_error(&self) -> bool
 pub fn devboy_core::error::Error::is_retryable(&self) -> bool
 impl core::convert::From<anyhow::Error> for devboy_core::error::Error
 pub fn devboy_core::error::Error::from(source: anyhow::Error) -> Self
+impl core::convert::From<core::io::error::Error> for devboy_core::error::Error
+pub fn devboy_core::error::Error::from(source: core::io::error::Error) -> Self
 impl core::convert::From<serde_json::error::Error> for devboy_core::error::Error
 pub fn devboy_core::error::Error::from(source: serde_json::error::Error) -> Self
-impl core::convert::From<std::io::error::Error> for devboy_core::error::Error
-pub fn devboy_core::error::Error::from(source: std::io::error::Error) -> Self
 impl core::error::Error for devboy_core::error::Error
 pub fn devboy_core::error::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for devboy_core::error::Error

--- a/crates/devboy-mcp/.public-api/baseline.txt
+++ b/crates/devboy-mcp/.public-api/baseline.txt
@@ -1506,10 +1506,10 @@ impl core::panic::unwind_safe::RefUnwindSafe for devboy_mcp::transport::Incoming
 impl core::panic::unwind_safe::UnwindSafe for devboy_mcp::transport::IncomingMessage
 pub struct devboy_mcp::transport::StdioTransport
 impl devboy_mcp::transport::StdioTransport
-pub fn devboy_mcp::transport::StdioTransport::read_message(&mut self) -> std::io::error::Result<core::option::Option<devboy_mcp::transport::IncomingMessage>>
+pub fn devboy_mcp::transport::StdioTransport::read_message(&mut self) -> core::io::error::Result<core::option::Option<devboy_mcp::transport::IncomingMessage>>
 pub fn devboy_mcp::transport::StdioTransport::stdio() -> Self
-pub fn devboy_mcp::transport::StdioTransport::write_notification(&mut self, notification: &devboy_mcp::protocol::JsonRpcNotification) -> std::io::error::Result<()>
-pub fn devboy_mcp::transport::StdioTransport::write_response(&mut self, response: &devboy_mcp::protocol::JsonRpcResponse) -> std::io::error::Result<()>
+pub fn devboy_mcp::transport::StdioTransport::write_notification(&mut self, notification: &devboy_mcp::protocol::JsonRpcNotification) -> core::io::error::Result<()>
+pub fn devboy_mcp::transport::StdioTransport::write_response(&mut self, response: &devboy_mcp::protocol::JsonRpcResponse) -> core::io::error::Result<()>
 impl core::marker::Freeze for devboy_mcp::transport::StdioTransport
 impl core::marker::Send for devboy_mcp::transport::StdioTransport
 impl !core::marker::Sync for devboy_mcp::transport::StdioTransport

--- a/crates/devboy-skills/.public-api/baseline.txt
+++ b/crates/devboy-skills/.public-api/baseline.txt
@@ -57,7 +57,7 @@ pub devboy_skills::error::SkillError::InvalidYaml::skill: alloc::string::String
 pub devboy_skills::error::SkillError::InvalidYaml::source: serde_yaml::error::Error
 pub devboy_skills::error::SkillError::Io
 pub devboy_skills::error::SkillError::Io::path: std::path::PathBuf
-pub devboy_skills::error::SkillError::Io::source: std::io::error::Error
+pub devboy_skills::error::SkillError::Io::source: core::io::error::Error
 pub devboy_skills::error::SkillError::MissingFrontmatter
 pub devboy_skills::error::SkillError::MissingFrontmatter::skill: alloc::string::String
 pub devboy_skills::error::SkillError::MissingRequiredField
@@ -827,7 +827,7 @@ pub devboy_skills::SkillError::InvalidYaml::skill: alloc::string::String
 pub devboy_skills::SkillError::InvalidYaml::source: serde_yaml::error::Error
 pub devboy_skills::SkillError::Io
 pub devboy_skills::SkillError::Io::path: std::path::PathBuf
-pub devboy_skills::SkillError::Io::source: std::io::error::Error
+pub devboy_skills::SkillError::Io::source: core::io::error::Error
 pub devboy_skills::SkillError::MissingFrontmatter
 pub devboy_skills::SkillError::MissingFrontmatter::skill: alloc::string::String
 pub devboy_skills::SkillError::MissingRequiredField

--- a/crates/devboy-storage/.public-api/baseline.txt
+++ b/crates/devboy-storage/.public-api/baseline.txt
@@ -211,7 +211,7 @@ pub devboy_storage::index::IndexError::Path
 pub devboy_storage::index::IndexError::Path::source: devboy_storage::secret_path::PathError
 pub devboy_storage::index::IndexError::Read
 pub devboy_storage::index::IndexError::Read::path: std::path::PathBuf
-pub devboy_storage::index::IndexError::Read::source: std::io::error::Error
+pub devboy_storage::index::IndexError::Read::source: core::io::error::Error
 pub devboy_storage::index::IndexError::Serialize
 pub devboy_storage::index::IndexError::Serialize::path: std::path::PathBuf
 pub devboy_storage::index::IndexError::Serialize::source: toml::ser::Error
@@ -334,7 +334,7 @@ pub devboy_storage::manifest::ManifestError::Path::role: devboy_storage::manifes
 pub devboy_storage::manifest::ManifestError::Path::source: devboy_storage::secret_path::PathError
 pub devboy_storage::manifest::ManifestError::Read
 pub devboy_storage::manifest::ManifestError::Read::path: std::path::PathBuf
-pub devboy_storage::manifest::ManifestError::Read::source: std::io::error::Error
+pub devboy_storage::manifest::ManifestError::Read::source: core::io::error::Error
 impl core::error::Error for devboy_storage::manifest::ManifestError
 pub fn devboy_storage::manifest::ManifestError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for devboy_storage::manifest::ManifestError
@@ -629,7 +629,7 @@ pub devboy_storage::plugin_client::PluginClientError::InitFailed::detail: alloc:
 pub devboy_storage::plugin_client::PluginClientError::InitFailed::plugin: alloc::string::String
 pub devboy_storage::plugin_client::PluginClientError::Io
 pub devboy_storage::plugin_client::PluginClientError::Io::plugin: alloc::string::String
-pub devboy_storage::plugin_client::PluginClientError::Io::source: std::io::error::Error
+pub devboy_storage::plugin_client::PluginClientError::Io::source: core::io::error::Error
 pub devboy_storage::plugin_client::PluginClientError::MalformedResponse
 pub devboy_storage::plugin_client::PluginClientError::MalformedResponse::plugin: alloc::string::String
 pub devboy_storage::plugin_client::PluginClientError::MalformedResponse::source: serde_json::error::Error
@@ -643,7 +643,7 @@ pub devboy_storage::plugin_client::PluginClientError::RestartCapExceeded::window
 pub devboy_storage::plugin_client::PluginClientError::Spawn
 pub devboy_storage::plugin_client::PluginClientError::Spawn::path: std::path::PathBuf
 pub devboy_storage::plugin_client::PluginClientError::Spawn::plugin: alloc::string::String
-pub devboy_storage::plugin_client::PluginClientError::Spawn::source: std::io::error::Error
+pub devboy_storage::plugin_client::PluginClientError::Spawn::source: core::io::error::Error
 pub devboy_storage::plugin_client::PluginClientError::UnexpectedPayload
 pub devboy_storage::plugin_client::PluginClientError::UnexpectedPayload::method: alloc::string::String
 pub devboy_storage::plugin_client::PluginClientError::UnexpectedPayload::plugin: alloc::string::String
@@ -765,7 +765,7 @@ pub devboy_storage::plugin_manifest::ManifestError::BadFilename
 pub devboy_storage::plugin_manifest::ManifestError::BadFilename::filename: alloc::string::String
 pub devboy_storage::plugin_manifest::ManifestError::ChecksumIo
 pub devboy_storage::plugin_manifest::ManifestError::ChecksumIo::path: std::path::PathBuf
-pub devboy_storage::plugin_manifest::ManifestError::ChecksumIo::source: std::io::error::Error
+pub devboy_storage::plugin_manifest::ManifestError::ChecksumIo::source: core::io::error::Error
 pub devboy_storage::plugin_manifest::ManifestError::ChecksumMismatch
 pub devboy_storage::plugin_manifest::ManifestError::ChecksumMismatch::actual: alloc::string::String
 pub devboy_storage::plugin_manifest::ManifestError::ChecksumMismatch::declared: alloc::string::String
@@ -781,7 +781,7 @@ pub devboy_storage::plugin_manifest::ManifestError::Parse::path: std::path::Path
 pub devboy_storage::plugin_manifest::ManifestError::Parse::source: toml::de::Error
 pub devboy_storage::plugin_manifest::ManifestError::Read
 pub devboy_storage::plugin_manifest::ManifestError::Read::path: std::path::PathBuf
-pub devboy_storage::plugin_manifest::ManifestError::Read::source: std::io::error::Error
+pub devboy_storage::plugin_manifest::ManifestError::Read::source: core::io::error::Error
 impl core::error::Error for devboy_storage::plugin_manifest::ManifestError
 pub fn devboy_storage::plugin_manifest::ManifestError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for devboy_storage::plugin_manifest::ManifestError
@@ -1333,7 +1333,7 @@ pub devboy_storage::router_config::RouterConfigError::Parse::path: std::path::Pa
 pub devboy_storage::router_config::RouterConfigError::Parse::source: toml::de::Error
 pub devboy_storage::router_config::RouterConfigError::Read
 pub devboy_storage::router_config::RouterConfigError::Read::path: std::path::PathBuf
-pub devboy_storage::router_config::RouterConfigError::Read::source: std::io::error::Error
+pub devboy_storage::router_config::RouterConfigError::Read::source: core::io::error::Error
 pub devboy_storage::router_config::RouterConfigError::UndefinedDefaultSource
 pub devboy_storage::router_config::RouterConfigError::UndefinedDefaultSource::name: alloc::string::String
 pub devboy_storage::router_config::RouterConfigError::UndefinedFallbackSource
@@ -1683,7 +1683,7 @@ pub devboy_storage::source::SourceError::BadReference::reason: alloc::string::St
 pub devboy_storage::source::SourceError::BadReference::reference: alloc::string::String
 pub devboy_storage::source::SourceError::Io
 pub devboy_storage::source::SourceError::Io::name: alloc::string::String
-pub devboy_storage::source::SourceError::Io::source: std::io::error::Error
+pub devboy_storage::source::SourceError::Io::source: core::io::error::Error
 pub devboy_storage::source::SourceError::Locked
 pub devboy_storage::source::SourceError::Locked::name: alloc::string::String
 pub devboy_storage::source::SourceError::Unavailable
@@ -2117,7 +2117,7 @@ pub devboy_storage::IndexError::Path
 pub devboy_storage::IndexError::Path::source: devboy_storage::secret_path::PathError
 pub devboy_storage::IndexError::Read
 pub devboy_storage::IndexError::Read::path: std::path::PathBuf
-pub devboy_storage::IndexError::Read::source: std::io::error::Error
+pub devboy_storage::IndexError::Read::source: core::io::error::Error
 pub devboy_storage::IndexError::Serialize
 pub devboy_storage::IndexError::Serialize::path: std::path::PathBuf
 pub devboy_storage::IndexError::Serialize::source: toml::ser::Error
@@ -2162,7 +2162,7 @@ pub devboy_storage::ManifestError::Path::role: devboy_storage::manifest::PathRol
 pub devboy_storage::ManifestError::Path::source: devboy_storage::secret_path::PathError
 pub devboy_storage::ManifestError::Read
 pub devboy_storage::ManifestError::Read::path: std::path::PathBuf
-pub devboy_storage::ManifestError::Read::source: std::io::error::Error
+pub devboy_storage::ManifestError::Read::source: core::io::error::Error
 impl core::error::Error for devboy_storage::manifest::ManifestError
 pub fn devboy_storage::manifest::ManifestError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for devboy_storage::manifest::ManifestError
@@ -2391,7 +2391,7 @@ pub devboy_storage::RouterConfigError::Parse::path: std::path::PathBuf
 pub devboy_storage::RouterConfigError::Parse::source: toml::de::Error
 pub devboy_storage::RouterConfigError::Read
 pub devboy_storage::RouterConfigError::Read::path: std::path::PathBuf
-pub devboy_storage::RouterConfigError::Read::source: std::io::error::Error
+pub devboy_storage::RouterConfigError::Read::source: core::io::error::Error
 pub devboy_storage::RouterConfigError::UndefinedDefaultSource
 pub devboy_storage::RouterConfigError::UndefinedDefaultSource::name: alloc::string::String
 pub devboy_storage::RouterConfigError::UndefinedFallbackSource
@@ -2468,7 +2468,7 @@ pub devboy_storage::SourceError::BadReference::reason: alloc::string::String
 pub devboy_storage::SourceError::BadReference::reference: alloc::string::String
 pub devboy_storage::SourceError::Io
 pub devboy_storage::SourceError::Io::name: alloc::string::String
-pub devboy_storage::SourceError::Io::source: std::io::error::Error
+pub devboy_storage::SourceError::Io::source: core::io::error::Error
 pub devboy_storage::SourceError::Locked
 pub devboy_storage::SourceError::Locked::name: alloc::string::String
 pub devboy_storage::SourceError::Unavailable

--- a/crates/plugins/api/clickup/.public-api/baseline.txt
+++ b/crates/plugins/api/clickup/.public-api/baseline.txt
@@ -22,6 +22,8 @@ pub struct devboy_clickup::comment_format::CommentAttributes
 pub devboy_clickup::comment_format::CommentAttributes::bold: bool
 pub devboy_clickup::comment_format::CommentAttributes::code: bool
 pub devboy_clickup::comment_format::CommentAttributes::code_block: core::option::Option<devboy_clickup::comment_format::CodeBlockAttr>
+pub devboy_clickup::comment_format::CommentAttributes::italic: bool
+pub devboy_clickup::comment_format::CommentAttributes::link: core::option::Option<alloc::string::String>
 pub devboy_clickup::comment_format::CommentAttributes::list: core::option::Option<devboy_clickup::comment_format::ListAttr>
 impl core::clone::Clone for devboy_clickup::comment_format::CommentAttributes
 pub fn devboy_clickup::comment_format::CommentAttributes::clone(&self) -> devboy_clickup::comment_format::CommentAttributes

--- a/crates/plugins/api/clickup/src/comment_format.rs
+++ b/crates/plugins/api/clickup/src/comment_format.rs
@@ -12,9 +12,11 @@
 //! block marks (`code-block`, `list`) attach to the trailing `"\n"` separator
 //! that closes the line. See <https://developer.clickup.com/docs/comment-formatting>.
 //!
-//! This module converts the small markdown subset our comments use — inline
-//! code, bold, fenced code blocks, bullet/ordered lists, ATX headings, and
-//! plain paragraphs — into that array. Anything it doesn't recognise is
+//! This module converts the markdown subset our comments use — inline code,
+//! bold, italic, links, fenced code blocks, bullet/ordered/task lists, ATX
+//! headings, blockquotes, horizontal rules, GFM tables, and plain paragraphs —
+//! into that array. ClickUp comments have no table block, so GFM tables render
+//! as an aligned monospace `code-block`. Anything it doesn't recognise is
 //! emitted as plain text, so output is never worse than the old behaviour.
 
 use serde::Serialize;
@@ -37,11 +39,17 @@ pub struct CommentAttributes {
     #[serde(skip_serializing_if = "is_false")]
     pub bold: bool,
     #[serde(skip_serializing_if = "is_false")]
+    pub italic: bool,
+    #[serde(skip_serializing_if = "is_false")]
     pub code: bool,
+    /// Hyperlink target URL for this run's text (inline `[text](url)`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link: Option<String>,
     /// Block-level code fence. ClickUp's shape is `{"code-block": "plain"}`.
     #[serde(rename = "code-block", skip_serializing_if = "Option::is_none")]
     pub code_block: Option<CodeBlockAttr>,
-    /// List membership. ClickUp's shape is `{"list": "bullet" | "ordered"}`.
+    /// List membership. ClickUp's shape is
+    /// `{"list": "bullet" | "ordered" | "checked" | "unchecked"}`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub list: Option<ListAttr>,
 }
@@ -59,7 +67,12 @@ pub struct ListAttr {
 
 impl CommentAttributes {
     fn is_empty(&self) -> bool {
-        !self.bold && !self.code && self.code_block.is_none() && self.list.is_none()
+        !self.bold
+            && !self.italic
+            && !self.code
+            && self.link.is_none()
+            && self.code_block.is_none()
+            && self.list.is_none()
     }
 }
 
@@ -81,9 +94,12 @@ fn newline(attributes: CommentAttributes) -> CommentBlock {
 /// The supported subset:
 /// - fenced code blocks (```` ``` ````) → each line + a `code-block` newline;
 /// - `- ` / `* ` / `+ ` bullets → content + a `bullet` list newline;
+/// - `- [ ]` / `- [x]` task items → content + an `unchecked`/`checked` newline;
 /// - `1. ` ordered items → content + an `ordered` list newline;
-/// - ATX headings (`#`..`######`) → bold content (comments have no heading mark);
-/// - inline `` `code` `` and `**bold**` within any non-code line;
+/// - ATX headings (`#`..`######`) → bold content + a leading glyph (no heading mark);
+/// - GFM tables → an aligned monospace `code-block` (comments have no table mark);
+/// - `> ` blockquotes and `---` horizontal rules;
+/// - inline `` `code` ``, `**bold**`, `*italic*`, and `[text](url)` links;
 /// - everything else → plain text.
 pub fn markdown_to_comment_blocks(body: &str) -> Vec<CommentBlock> {
     // An empty body has no structure to express; returning no blocks lets the
@@ -96,11 +112,18 @@ pub fn markdown_to_comment_blocks(body: &str) -> Vec<CommentBlock> {
     let mut blocks: Vec<CommentBlock> = Vec::new();
     let mut in_code_fence = false;
 
-    for line in body.split('\n') {
+    // Indexed walk (not a plain `for`) so table detection can look ahead at the
+    // separator row and consume the contiguous table block.
+    let lines: Vec<&str> = body.split('\n').collect();
+    let mut idx = 0;
+    while idx < lines.len() {
+        let line = lines[idx];
+
         // Fence toggles. A line whose trimmed start is ``` opens or closes a
         // fenced block; the fence line itself (and its info string) is dropped.
         if line.trim_start().starts_with("```") {
             in_code_fence = !in_code_fence;
+            idx += 1;
             continue;
         }
 
@@ -118,6 +141,48 @@ pub fn markdown_to_comment_blocks(body: &str) -> Vec<CommentBlock> {
                 }),
                 ..Default::default()
             }));
+            idx += 1;
+            continue;
+        }
+
+        // GFM table: a `|...|` row immediately followed by a separator row.
+        // Rendered as an aligned monospace code-block (no table mark exists).
+        if is_table_row(line)
+            && idx + 1 < lines.len()
+            && is_separator_row(&split_table_row(lines[idx + 1]))
+        {
+            let mut rows = vec![line.to_string()];
+            let mut j = idx + 1;
+            while j < lines.len() && is_table_row(lines[j]) {
+                rows.push(lines[j].to_string());
+                j += 1;
+            }
+            for rendered in render_table(&rows) {
+                blocks.push(CommentBlock {
+                    text: rendered,
+                    attributes: CommentAttributes::default(),
+                });
+                blocks.push(newline(CommentAttributes {
+                    code_block: Some(CodeBlockAttr {
+                        code_block: "plain".to_string(),
+                    }),
+                    ..Default::default()
+                }));
+            }
+            idx = j;
+            continue;
+        }
+
+        // Task list item: `- [ ]` / `- [x]` (checked/unchecked list).
+        if let Some((checked, rest)) = strip_task_item(line) {
+            push_inline_runs(&mut blocks, rest);
+            blocks.push(newline(CommentAttributes {
+                list: Some(ListAttr {
+                    list: if checked { "checked" } else { "unchecked" }.to_string(),
+                }),
+                ..Default::default()
+            }));
+            idx += 1;
             continue;
         }
 
@@ -130,6 +195,7 @@ pub fn markdown_to_comment_blocks(body: &str) -> Vec<CommentBlock> {
                 }),
                 ..Default::default()
             }));
+            idx += 1;
             continue;
         }
 
@@ -142,20 +208,61 @@ pub fn markdown_to_comment_blocks(body: &str) -> Vec<CommentBlock> {
                 }),
                 ..Default::default()
             }));
+            idx += 1;
             continue;
         }
 
         // ATX heading: 1–6 leading `#` then a space. Comments have no heading
-        // attribute, so render the text bold to preserve emphasis.
-        if let Some(rest) = strip_heading(line) {
+        // attribute, so render the text bold with a leading glyph (◆ for h1,
+        // ▸ for h2) to preserve section structure.
+        if let Some((level, rest)) = strip_heading(line) {
+            let prefix = heading_prefix(level);
+            if !prefix.is_empty() {
+                blocks.push(CommentBlock {
+                    text: prefix.to_string(),
+                    attributes: CommentAttributes {
+                        bold: true,
+                        ..Default::default()
+                    },
+                });
+            }
             push_bold_run(&mut blocks, rest);
             blocks.push(newline(CommentAttributes::default()));
+            idx += 1;
             continue;
         }
 
-        // Plain paragraph line (may contain inline code / bold).
+        // Horizontal rule: `---`, `***`, or `___` on its own line.
+        if matches!(line.trim(), "---" | "***" | "___") {
+            blocks.push(CommentBlock {
+                text: "\u{2500}".repeat(10),
+                attributes: CommentAttributes::default(),
+            });
+            blocks.push(newline(CommentAttributes::default()));
+            idx += 1;
+            continue;
+        }
+
+        // Blockquote: `> ...` rendered as an italic line with a `| ` gutter
+        // (comments have no quote mark).
+        if let Some(rest) = strip_blockquote(line) {
+            blocks.push(CommentBlock {
+                text: "| ".to_string(),
+                attributes: CommentAttributes::default(),
+            });
+            for mut run in parse_inline(rest) {
+                run.attributes.italic = true;
+                blocks.push(run);
+            }
+            blocks.push(newline(CommentAttributes::default()));
+            idx += 1;
+            continue;
+        }
+
+        // Plain paragraph line (may contain inline code / bold / italic / link).
         push_inline_runs(&mut blocks, line);
         blocks.push(newline(CommentAttributes::default()));
+        idx += 1;
     }
 
     // `split('\n')` yields a trailing empty segment for every trailing newline
@@ -207,16 +314,48 @@ fn strip_ordered(line: &str) -> Option<&str> {
     None
 }
 
-/// Strip 1–6 leading `#` followed by a space, returning the heading text.
-fn strip_heading(line: &str) -> Option<&str> {
+/// Strip 1–6 leading `#` followed by a space, returning `(level, heading text)`.
+fn strip_heading(line: &str) -> Option<(usize, &str)> {
     let hashes = line.chars().take_while(|&c| c == '#').count();
     if (1..=6).contains(&hashes) {
         let rest = &line[hashes..];
         if let Some(rest) = rest.strip_prefix(' ') {
-            return Some(rest);
+            return Some((hashes, rest));
         }
     }
     None
+}
+
+/// Leading glyph for a heading level (comments have no heading mark). Neutral
+/// geometric glyphs keep it locale-neutral; deeper levels get plain bold.
+fn heading_prefix(level: usize) -> &'static str {
+    match level {
+        1 => "\u{25C6} ", // ◆
+        2 => "\u{25B8} ", // ▸
+        _ => "",
+    }
+}
+
+/// Strip a `- [ ] ` / `- [x] ` task-list marker, returning `(checked, text)`.
+fn strip_task_item(line: &str) -> Option<(bool, &str)> {
+    let rest = strip_bullet(line)?;
+    if let Some(rest) = rest.strip_prefix("[ ] ") {
+        Some((false, rest))
+    } else if let Some(rest) = rest
+        .strip_prefix("[x] ")
+        .or_else(|| rest.strip_prefix("[X] "))
+    {
+        Some((true, rest))
+    } else {
+        None
+    }
+}
+
+/// Strip a `> ` (or `>`) blockquote marker, returning the quoted text.
+fn strip_blockquote(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix('>')?;
+    Some(rest.strip_prefix(' ').unwrap_or(rest))
 }
 
 /// Push `text` as a single bold run (used for headings).
@@ -278,6 +417,22 @@ fn parse_inline(line: &str) -> Vec<CommentBlock> {
             }
         }
 
+        // Link: [text](url). The link text may contain inline marks, so parse
+        // it recursively and attach the URL to every resulting run.
+        if c == '[' {
+            if let Some((text_end, url_start, url_end)) = find_link(&chars, i) {
+                flush_plain(&mut plain, &mut runs);
+                let text: String = chars[i + 1..text_end].iter().collect();
+                let url: String = chars[url_start..url_end].iter().collect();
+                for mut run in parse_inline(&text) {
+                    run.attributes.link = Some(url.clone());
+                    runs.push(run);
+                }
+                i = url_end + 1;
+                continue;
+            }
+        }
+
         // Bold: **...**. The inner content may itself contain inline code, so
         // parse it recursively and mark every resulting run bold (a run can
         // carry both `bold` and `code` where they overlap, e.g. **`x`**).
@@ -291,6 +446,23 @@ fn parse_inline(line: &str) -> Vec<CommentBlock> {
                 }
                 i = close + 2;
                 continue;
+            }
+        }
+
+        // Italic: *...* or _..._ (single delimiter, not part of a `**` pair —
+        // bold is handled above so any remaining lone `*` is italic).
+        if c == '*' || c == '_' {
+            if let Some(close) = find_char(&chars, i + 1, c) {
+                if close > i + 1 {
+                    flush_plain(&mut plain, &mut runs);
+                    let inner: String = chars[i + 1..close].iter().collect();
+                    for mut run in parse_inline(&inner) {
+                        run.attributes.italic = true;
+                        runs.push(run);
+                    }
+                    i = close + 1;
+                    continue;
+                }
             }
         }
 
@@ -317,6 +489,147 @@ fn find_double_star(chars: &[char], from: usize) -> Option<usize> {
         j += 1;
     }
     None
+}
+
+/// Parse a `[text](url)` link starting at `open` (the `[`). Returns
+/// `(text_end, url_start, url_end)` as char indices, where `text_end` is the
+/// `]`, `url_start` is the first URL char, and `url_end` is the `)`.
+fn find_link(chars: &[char], open: usize) -> Option<(usize, usize, usize)> {
+    let close_br = find_char(chars, open + 1, ']')?;
+    if chars.get(close_br + 1) != Some(&'(') {
+        return None;
+    }
+    let url_start = close_br + 2;
+    let close_paren = find_char(chars, url_start, ')')?;
+    Some((close_br, url_start, close_paren))
+}
+
+// =============================================================================
+// GFM tables → aligned monospace code-block (ClickUp comments have no table
+// mark). Columns size to content; cell data is never truncated.
+// =============================================================================
+
+/// True when a line looks like a GFM table row (`| ... |`).
+fn is_table_row(line: &str) -> bool {
+    let l = line.trim();
+    l.starts_with('|') && l.matches('|').count() >= 2
+}
+
+/// Split a `| a | b |` row into trimmed cells.
+fn split_table_row(line: &str) -> Vec<String> {
+    let l = line.trim();
+    let l = l.strip_prefix('|').unwrap_or(l);
+    let l = l.strip_suffix('|').unwrap_or(l);
+    l.split('|').map(|c| c.trim().to_string()).collect()
+}
+
+/// True when every cell is a separator (`---`, `:--`, `--:`, `:-:`).
+fn is_separator_row(cells: &[String]) -> bool {
+    !cells.is_empty()
+        && cells.iter().all(|c| {
+            let t = c.trim();
+            !t.is_empty() && t.contains('-') && t.chars().all(|ch| ch == '-' || ch == ':')
+        })
+}
+
+#[derive(Clone, Copy)]
+enum Align {
+    Left,
+    Right,
+    Center,
+}
+
+fn parse_align(cell: &str) -> Align {
+    let t = cell.trim();
+    match (t.starts_with(':'), t.ends_with(':')) {
+        (true, true) => Align::Center,
+        (false, true) => Align::Right,
+        _ => Align::Left,
+    }
+}
+
+/// Display width: most chars = 1, CJK/fullwidth/emoji = 2. Cyrillic counts as
+/// 1, so Russian table columns align correctly. No `unicode-width` dep.
+fn display_width(s: &str) -> usize {
+    s.chars().map(char_width).sum()
+}
+
+fn char_width(ch: char) -> usize {
+    let c = ch as u32;
+    let double = (0x1100..=0x115F).contains(&c)
+        || (0x2E80..=0xA4CF).contains(&c)
+        || (0xAC00..=0xD7A3).contains(&c)
+        || (0xF900..=0xFAFF).contains(&c)
+        || (0xFF00..=0xFF60).contains(&c)
+        || (0xFFE0..=0xFFE6).contains(&c)
+        || (0x1F300..=0x1FAFF).contains(&c)
+        || (0x20000..=0x3FFFD).contains(&c);
+    if double { 2 } else { 1 }
+}
+
+/// Pad a cell to `width` display columns per alignment. Never truncates: the
+/// width is always the column's content width, so cell data is preserved
+/// verbatim (read-back stays a valid GFM table for downstream LLMs).
+fn pad_cell(cell: &str, width: usize, align: Align) -> String {
+    let w = display_width(cell);
+    let pad = width.saturating_sub(w);
+    match align {
+        Align::Left => format!("{}{}", cell, " ".repeat(pad)),
+        Align::Right => format!("{}{}", " ".repeat(pad), cell),
+        Align::Center => {
+            let left = pad / 2;
+            format!("{}{}{}", " ".repeat(left), cell, " ".repeat(pad - left))
+        }
+    }
+}
+
+/// Render GFM table rows to aligned monospace lines (one string per line).
+fn render_table(rows: &[String]) -> Vec<String> {
+    let parsed: Vec<Vec<String>> = rows.iter().map(|r| split_table_row(r)).collect();
+    let ncols = parsed.iter().map(|c| c.len()).max().unwrap_or(0);
+    if ncols == 0 {
+        return Vec::new();
+    }
+
+    let mut aligns = vec![Align::Left; ncols];
+    let mut data: Vec<Vec<String>> = Vec::new();
+    for cells in &parsed {
+        if is_separator_row(cells) {
+            for (i, c) in cells.iter().enumerate().take(ncols) {
+                aligns[i] = parse_align(c);
+            }
+        } else {
+            let mut row = cells.clone();
+            row.resize(ncols, String::new());
+            data.push(row);
+        }
+    }
+    if data.is_empty() {
+        return Vec::new();
+    }
+
+    // Column widths sized to content (never below, so no truncation).
+    let mut width = vec![0usize; ncols];
+    for row in &data {
+        for (i, cell) in row.iter().enumerate() {
+            width[i] = width[i].max(display_width(cell));
+        }
+    }
+
+    let mut out: Vec<String> = Vec::new();
+    for (ri, row) in data.iter().enumerate() {
+        let cells: Vec<String> = row
+            .iter()
+            .enumerate()
+            .map(|(i, cell)| pad_cell(cell, width[i], aligns[i]))
+            .collect();
+        out.push(format!("| {} |", cells.join(" | ")));
+        if ri == 0 {
+            let dividers: Vec<String> = width.iter().map(|w| "-".repeat(*w)).collect();
+            out.push(format!("|-{}-|", dividers.join("-|-")));
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -457,8 +770,18 @@ mod tests {
 
     #[test]
     fn heading_becomes_bold() {
+        // h2 → leading ▸ glyph (bold) + bold heading text.
         let blocks = markdown_to_comment_blocks("## Done");
-        assert_eq!(blocks[0].text, "Done");
+        assert_eq!(blocks[0].text, "\u{25B8} ");
+        assert!(blocks[0].attributes.bold);
+        assert_eq!(blocks[1].text, "Done");
+        assert!(blocks[1].attributes.bold);
+    }
+
+    #[test]
+    fn h3_heading_has_no_glyph() {
+        let blocks = markdown_to_comment_blocks("### Sub");
+        assert_eq!(blocks[0].text, "Sub");
         assert!(blocks[0].attributes.bold);
     }
 
@@ -510,5 +833,111 @@ mod tests {
     #[test]
     fn empty_body_yields_no_blocks() {
         assert!(markdown_to_comment_blocks("").is_empty());
+    }
+
+    // --- additions: italic, links, task lists, blockquote, hr, tables ---
+
+    #[test]
+    fn italic_run() {
+        let blocks = markdown_to_comment_blocks("a *b* c");
+        assert_eq!(blocks[0], plain("a "));
+        assert_eq!(blocks[1].text, "b");
+        assert!(blocks[1].attributes.italic && !blocks[1].attributes.bold);
+        assert_eq!(blocks[2], plain(" c"));
+    }
+
+    #[test]
+    fn italic_underscore() {
+        let blocks = markdown_to_comment_blocks("_x_");
+        assert_eq!(blocks[0].text, "x");
+        assert!(blocks[0].attributes.italic);
+    }
+
+    #[test]
+    fn bold_not_swallowed_by_italic() {
+        // `**b**` must stay bold, not be parsed as two italic `*` pairs.
+        let blocks = markdown_to_comment_blocks("**b**");
+        assert_eq!(blocks[0].text, "b");
+        assert!(blocks[0].attributes.bold && !blocks[0].attributes.italic);
+    }
+
+    #[test]
+    fn link_run() {
+        let blocks = markdown_to_comment_blocks("see [docs](https://x.io) now");
+        assert_eq!(blocks[0], plain("see "));
+        assert_eq!(blocks[1].text, "docs");
+        assert_eq!(blocks[1].attributes.link.as_deref(), Some("https://x.io"));
+        assert_eq!(blocks[2], plain(" now"));
+    }
+
+    #[test]
+    fn task_list_checked_unchecked() {
+        let blocks = markdown_to_comment_blocks("- [ ] todo\n- [x] done");
+        assert_eq!(
+            blocks[1].attributes.list.as_ref().map(|l| l.list.as_str()),
+            Some("unchecked")
+        );
+        assert_eq!(
+            blocks[3].attributes.list.as_ref().map(|l| l.list.as_str()),
+            Some("checked")
+        );
+    }
+
+    #[test]
+    fn blockquote_is_italic_with_gutter() {
+        let blocks = markdown_to_comment_blocks("> quoted");
+        assert_eq!(blocks[0].text, "| ");
+        assert_eq!(blocks[1].text, "quoted");
+        assert!(blocks[1].attributes.italic);
+    }
+
+    #[test]
+    fn horizontal_rule() {
+        let blocks = markdown_to_comment_blocks("---");
+        assert_eq!(blocks[0].text, "\u{2500}".repeat(10));
+    }
+
+    #[test]
+    fn table_cyrillic_aligns() {
+        let md = "| Проверка | Результат |\n|---|---|\n| meet | OK |";
+        let blocks = markdown_to_comment_blocks(md);
+        let lines: Vec<&str> = blocks
+            .iter()
+            .filter(|b| b.text != "\n")
+            .map(|b| b.text.as_str())
+            .collect();
+        assert_eq!(lines.len(), 3); // header, divider, one data row
+        assert_eq!(lines[0], "| Проверка | Результат |");
+        assert!(lines[1].starts_with("|-"));
+        assert_eq!(lines[2], "| meet     | OK        |");
+        // table lines carry the code-block block attribute (on the newline runs)
+        assert!(
+            blocks
+                .iter()
+                .any(|b| b.text == "\n" && b.attributes.code_block.is_some())
+        );
+    }
+
+    #[test]
+    fn wide_table_preserves_content() {
+        let wide = "x".repeat(200);
+        let md = format!("| {wide} | b |\n|---|---|\n| y | z |");
+        let rendered: String = markdown_to_comment_blocks(&md)
+            .iter()
+            .map(|b| b.text.as_str())
+            .collect();
+        assert!(rendered.contains(&wide), "wide cell preserved");
+        assert!(!rendered.contains('\u{2026}'), "no truncation ellipsis");
+    }
+
+    #[test]
+    fn cyrillic_bold_no_panic() {
+        // char-based parser must not panic on multi-byte UTF-8 next to a mark.
+        let blocks = markdown_to_comment_blocks("жирный **текст** конец");
+        assert!(
+            blocks
+                .iter()
+                .any(|b| b.attributes.bold && b.text == "текст")
+        );
     }
 }

--- a/crates/plugins/format-pipeline/.public-api/baseline.txt
+++ b/crates/plugins/format-pipeline/.public-api/baseline.txt
@@ -1,12 +1,12 @@
 pub mod devboy_format_pipeline
 pub mod devboy_format_pipeline::adaptive_config
 pub enum devboy_format_pipeline::adaptive_config::ConfigError
-pub devboy_format_pipeline::adaptive_config::ConfigError::Io(std::io::error::Error)
+pub devboy_format_pipeline::adaptive_config::ConfigError::Io(core::io::error::Error)
 pub devboy_format_pipeline::adaptive_config::ConfigError::Parse(toml::de::Error)
 pub devboy_format_pipeline::adaptive_config::ConfigError::Serialize(toml::ser::Error)
 pub devboy_format_pipeline::adaptive_config::ConfigError::UnsupportedSchemaVersion(u32)
-impl core::convert::From<std::io::error::Error> for devboy_format_pipeline::adaptive_config::ConfigError
-pub fn devboy_format_pipeline::adaptive_config::ConfigError::from(source: std::io::error::Error) -> Self
+impl core::convert::From<core::io::error::Error> for devboy_format_pipeline::adaptive_config::ConfigError
+pub fn devboy_format_pipeline::adaptive_config::ConfigError::from(source: core::io::error::Error) -> Self
 impl core::convert::From<toml::de::Error> for devboy_format_pipeline::adaptive_config::ConfigError
 pub fn devboy_format_pipeline::adaptive_config::ConfigError::from(source: toml::de::Error) -> Self
 impl core::convert::From<toml::ser::Error> for devboy_format_pipeline::adaptive_config::ConfigError
@@ -1365,12 +1365,12 @@ impl core::marker::UnsafeUnpin for devboy_format_pipeline::telemetry::Shape
 impl core::panic::unwind_safe::RefUnwindSafe for devboy_format_pipeline::telemetry::Shape
 impl core::panic::unwind_safe::UnwindSafe for devboy_format_pipeline::telemetry::Shape
 pub enum devboy_format_pipeline::telemetry::TelemetryError
-pub devboy_format_pipeline::telemetry::TelemetryError::Io(std::io::error::Error)
+pub devboy_format_pipeline::telemetry::TelemetryError::Io(core::io::error::Error)
 pub devboy_format_pipeline::telemetry::TelemetryError::Serde(serde_json::error::Error)
+impl core::convert::From<core::io::error::Error> for devboy_format_pipeline::telemetry::TelemetryError
+pub fn devboy_format_pipeline::telemetry::TelemetryError::from(source: core::io::error::Error) -> Self
 impl core::convert::From<serde_json::error::Error> for devboy_format_pipeline::telemetry::TelemetryError
 pub fn devboy_format_pipeline::telemetry::TelemetryError::from(source: serde_json::error::Error) -> Self
-impl core::convert::From<std::io::error::Error> for devboy_format_pipeline::telemetry::TelemetryError
-pub fn devboy_format_pipeline::telemetry::TelemetryError::from(source: std::io::error::Error) -> Self
 impl core::error::Error for devboy_format_pipeline::telemetry::TelemetryError
 pub fn devboy_format_pipeline::telemetry::TelemetryError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for devboy_format_pipeline::telemetry::TelemetryError


### PR DESCRIPTION
Closes #300

ClickUp comments rendered markdown as literal text (`comment_text` is plain). This adds a hand-rolled markdown -> ClickUp comment-blocks converter: inline styles, lists (block attr on newline run), fenced code, headings as bold+glyph, GFM tables as aligned monospace code-block; `comment_text` omitted to avoid duplicate render. Verified against real ClickUp API + UI.

125 tests / clippy -D warnings / fmt all green; public-api baseline regenerated.