### PR TITLE
fix(deps): drop all RustSec ignores via ratatui/keepass/wayland-scanner upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `devboy-tools` are recorded here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Security / Dependencies
+
+- Eliminate all RustSec advisory ignores (#308). Upgrade `ratatui` 0.29 → 0.30
+  (drops the unmaintained `paste`, RUSTSEC-2024-0436), and `keepass` 0.12 → 0.13
+  + `wayland-scanner` → 0.31.11 (both now pull `quick-xml >= 0.41`, fixing the
+  RUSTSEC-2026-0194 / -0195 DoS advisories). `deny.toml` `[advisories].ignore`
+  is now empty. No first-party API/behavior changes.
+
 ## [0.32.0] - 2026-07-25
 
 ### Added — OAuth 2.1 for proxy MCP upstreams (#307)

--- a/crates/devboy-cli/Cargo.toml
+++ b/crates/devboy-cli/Cargo.toml
@@ -39,7 +39,7 @@ devboy-secrets-agent = { workspace = true }
 devboy-secrets-ui = { workspace = true }
 devboy-token-catalog = { workspace = true }
 regex.workspace = true
-ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 crossterm = "0.28"
 devboy-secret-keychain = { workspace = true }
 devboy-secret-local-vault = { workspace = true }

--- a/crates/devboy-secrets-ui/Cargo.toml
+++ b/crates/devboy-secrets-ui/Cargo.toml
@@ -41,7 +41,7 @@ chrono = { version = "0.4", default-features = false, features = ["std"] }
 # the test target carries. Keeping the deps direct and the gate
 # in code is the simplest configuration that keeps both
 # `--no-default-features` and the default build green.
-ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 crossterm = "0.28"
 # `egui` is fully optional and only activated by the `gui` feature.
 # Unlike `ratatui` (which is referenced by the always-compiled

--- a/crates/plugins/secrets/kdbx/Cargo.toml
+++ b/crates/plugins/secrets/kdbx/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { workspace = true, features = ["sync"] }
 # KDBX 4 parser/serializer. `save_kdbx4` enables the writer used
 # by the K14 metadata-edit surface (notes / tags / expires-at on
 # existing entries — never passwords / protected fields).
-keepass = { version = "0.12", default-features = false, features = ["save_kdbx4"] }
+keepass = { version = "0.13", default-features = false, features = ["save_kdbx4"] }
 # Used to format `NaiveDateTime` fields from `keepass::Times`
 # into ISO 8601 strings so they round-trip through the rest of
 # the framework's `String`-typed metadata channels (IndexEntry
@@ -38,7 +38,7 @@ tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 # `save_kdbx4` lets tests construct synthetic KDBX fixtures on the
 # fly instead of committing a binary blob to the repo.
-keepass = { version = "0.12", default-features = false, features = ["save_kdbx4"] }
+keepass = { version = "0.13", default-features = false, features = ["save_kdbx4"] }
 
 [lints]
 workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -26,27 +26,12 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-# `paste` is unmaintained but still functional and pulled in transitively
-# by ratatui (the TUI for devboy-cli / devboy-secrets-ui; no published
-# successor). Compile-time proc-macro only — no runtime exposure. Tracked
-# upstream; revisit when ratatui drops the dependency.
-#
-# quick-xml RUSTSEC-2026-0194 / -0195 — DoS (quadratic runtime / unbounded
-# namespace allocation) via *maliciously-crafted* XML, patched in >= 0.41.0.
-# Not reachable in our threat model: quick-xml enters only via
-#   - `keepass` (kdbx backend) — parses the user's own local `.kdbx` password
-#     database, a trusted local file the user supplies, never network input;
-#   - `wayland-scanner` — a build-time proc-macro parsing trusted Wayland
-#     protocol XML at compile time (Linux GUI `devboy-secrets-ui-bin` only).
-# No devboy-tools runtime path feeds untrusted XML to quick-xml; the MCP/CLI
-# network surfaces are JSON. Both parents pin older majors (`keepass ^0.40`,
-# `wayland-scanner ^0.39`), so the >= 0.41 bump needs upstream releases.
-# Revisit when keepass / wayland-scanner bump their quick-xml requirement.
-ignore = [
-    "RUSTSEC-2024-0436",
-    "RUSTSEC-2026-0194",
-    "RUSTSEC-2026-0195",
-]
+# No ignored advisories. The previously-ignored issues were eliminated by
+# upstream upgrades (#308): ratatui 0.30 drops the unmaintained `paste`
+# (RUSTSEC-2024-0436); keepass 0.13 + wayland-scanner 0.31.11 pull
+# quick-xml >= 0.41, fixing RUSTSEC-2026-0194 / -0195. Keep this empty —
+# any new advisory should be fixed (or explicitly re-justified), not ignored.
+ignore = []
 
 # ---------------------------------------------------------------------------
 # Licenses


### PR DESCRIPTION
## What

Eliminates **all three** RustSec advisory ignores by upgrading the deps whose upstreams now ship the fixes.

| Advisory | Was | Fix |
|---|---|---|
| RUSTSEC-2024-0436 (`paste` unmaintained) | ratatui 0.29 pulled `paste` | **ratatui 0.29 → 0.30.2** drops `paste` entirely (we use it in zero first-party code) |
| RUSTSEC-2026-0194 / -0195 (`quick-xml` DoS) | quick-xml 0.39 (wayland-scanner) + 0.40 (keepass), both < 0.41 | **keepass 0.12 → 0.13** + **wayland-scanner → 0.31.11** both require `quick-xml ^0.41` |

`deny.toml` `[advisories].ignore` is now **empty**.

## Verification

Fresh dependency resolve (matching CI, which doesn't commit `Cargo.lock`):
- `paste` — **gone**; `quick-xml` — **0.41.0 only**; ratatui 0.30.2 / keepass 0.13.17 / wayland-scanner 0.31.11.
- `cargo deny check advisories` → **advisories ok** (empty ignore).
- clippy `-D warnings`, fmt, tests all green (secrets-ui 141 / kdbx 23 / cli 30). GUI bin builds.
- **No first-party code changes** — ratatui 0.30 + keepass 0.13 needed no API fixes in our usage.

Follow-up to #307. Closes #308.
