### PR TITLE
docs: clarify wayland-scanner transitive + fold dep note into 0.32.0 (#309 review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@ All notable changes to `devboy-tools` are recorded here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-07-25
+
 ### Security / Dependencies
 
-- Eliminate all RustSec advisory ignores (#308). Upgrade `ratatui` 0.29 → 0.30
-  (drops the unmaintained `paste`, RUSTSEC-2024-0436), and `keepass` 0.12 → 0.13
-  + `wayland-scanner` → 0.31.11 (both now pull `quick-xml >= 0.41`, fixing the
-  RUSTSEC-2026-0194 / -0195 DoS advisories). `deny.toml` `[advisories].ignore`
-  is now empty. No first-party API/behavior changes.
-
-## [0.32.0] - 2026-07-25
+- Eliminate all RustSec advisory ignores (#308). Bump `ratatui` 0.29 → 0.30
+  (drops the unmaintained `paste`, RUSTSEC-2024-0436) and `keepass` 0.12 → 0.13
+  (which requires `quick-xml >= 0.41`); `wayland-scanner` (transitive, via
+  eframe) now resolves to >= 0.31.11, also on `quick-xml >= 0.41` — together
+  fixing the RUSTSEC-2026-0194 / -0195 DoS advisories. `deny.toml`
+  `[advisories].ignore` is now empty. No first-party API/behavior changes.
 
 ### Added — OAuth 2.1 for proxy MCP upstreams (#307)
 

--- a/deny.toml
+++ b/deny.toml
@@ -27,10 +27,12 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 # No ignored advisories. The previously-ignored issues were eliminated by
-# upstream upgrades (#308): ratatui 0.30 drops the unmaintained `paste`
-# (RUSTSEC-2024-0436); keepass 0.13 + wayland-scanner 0.31.11 pull
-# quick-xml >= 0.41, fixing RUSTSEC-2026-0194 / -0195. Keep this empty —
-# any new advisory should be fixed (or explicitly re-justified), not ignored.
+# dependency upgrades (#308): ratatui 0.30 (direct) drops the unmaintained
+# `paste` (RUSTSEC-2024-0436); keepass 0.13 (direct) requires quick-xml >= 0.41,
+# and wayland-scanner (transitive, via eframe) now resolves to >= 0.31.11 which
+# also requires quick-xml >= 0.41 — together fixing RUSTSEC-2026-0194 / -0195.
+# Keep this empty — a new advisory should be fixed (or explicitly re-justified),
+# not ignored.
 ignore = []
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses the two Copilot review comments on #309 (deny.toml + CHANGELOG): `wayland-scanner` is transitive (via eframe), not a direct bump — reworded to say it *resolves* to >= 0.31.11. Only `ratatui`/`keepass` are direct. Also folds the dep-upgrade note from [Unreleased] into the unpublished [0.32.0] release. Docs-only, no code/behavior change.