### PR TITLE
ci(release): skip publish=false crates in crates.io publish

### DIFF
--- a/.github/workflows/release-crates-io.yml
+++ b/.github/workflows/release-crates-io.yml
@@ -66,6 +66,14 @@ jobs:
           set -euo pipefail
           publish_if_new() {
             local crate="$1"
+            # Skip crates marked `publish = false` (cargo metadata: publish == []) —
+            # e.g. secrets-agent / secrets-ui / the secrets plugins are intentionally
+            # unpublished; listing them must not fail the release (fixes #308 fallout).
+            if [ "$(cargo metadata --no-deps --format-version 1 \
+                | jq -r --arg c "$crate" '.packages[]|select(.name==$c)|(.publish==[])')" = "true" ]; then
+              echo "$crate is publish=false — skipping"
+              return 0
+            fi
             local version
             version="$(cargo metadata --no-deps --format-version 1 \
               | jq -r --arg c "$crate" '.packages[] | select(.name == $c) | .version')"
@@ -109,6 +117,14 @@ jobs:
           set -euo pipefail
           publish_if_new() {
             local crate="$1"
+            # Skip crates marked `publish = false` (cargo metadata: publish == []) —
+            # e.g. secrets-agent / secrets-ui / the secrets plugins are intentionally
+            # unpublished; listing them must not fail the release (fixes #308 fallout).
+            if [ "$(cargo metadata --no-deps --format-version 1 \
+                | jq -r --arg c "$crate" '.packages[]|select(.name==$c)|(.publish==[])')" = "true" ]; then
+              echo "$crate is publish=false — skipping"
+              return 0
+            fi
             local version
             version="$(cargo metadata --no-deps --format-version 1 \
               | jq -r --arg c "$crate" '.packages[] | select(.name == $c) | .version')"
@@ -150,6 +166,14 @@ jobs:
           set -euo pipefail
           publish_if_new() {
             local crate="$1"
+            # Skip crates marked `publish = false` (cargo metadata: publish == []) —
+            # e.g. secrets-agent / secrets-ui / the secrets plugins are intentionally
+            # unpublished; listing them must not fail the release (fixes #308 fallout).
+            if [ "$(cargo metadata --no-deps --format-version 1 \
+                | jq -r --arg c "$crate" '.packages[]|select(.name==$c)|(.publish==[])')" = "true" ]; then
+              echo "$crate is publish=false — skipping"
+              return 0
+            fi
             local version
             version="$(cargo metadata --no-deps --format-version 1 \
               | jq -r --arg c "$crate" '.packages[] | select(.name == $c) | .version')"


### PR DESCRIPTION
## Problem

The v0.32.0 crates.io release failed at `Publish layer 2.5` with `error: devboy-secrets-agent cannot be published` — that crate (and secrets-ui + all secrets plugins) is `publish = false`, added by the secrets epic (#247). The publish loop still lists them and `publish_if_new` only tolerated "already exists", so `cargo publish` on an unpublishable crate aborted the whole release.

**Partial-publish fallout:** `devboy-core` + `devboy-storage` published at 0.32.0 (irreversible) before the abort; the rest (mcp/cli/executor/skills) never published.

## Fix

Guard `publish_if_new` to skip crates whose cargo-metadata `publish` field is `[]` (publish=false). Verified locally: secrets-agent/kdbx → skip, core/cli → publish. Idempotent "already exists" handling means re-running the release will skip the already-published core/storage and complete mcp/cli/etc.

Note: crates.io release has failed on **every** tag historically — this addresses the current blocker; a re-run will confirm whether anything remains.

Refs #308