### PR TITLE
ci(release): crates.io = libraries only + metadata-derived publish + dry-run gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,21 +155,22 @@ jobs:
         run: cargo doc --no-deps --workspace --all-features
 
   publish-dry-run:
-    name: cargo publish --dry-run (devboy-core)
+    name: cargo publish --dry-run (workspace)
     runs-on: ubuntu-latest
-    # `cargo publish --dry-run` resolves internal deps through the
-    # registry, not workspace paths — so until devboy-core is on
-    # crates.io, only the dep-graph leaf (devboy-core) can complete a
-    # full dry-run. Once the first wave is on crates.io, extend this
-    # job to cover the rest of the topological order. See ADR-022.
+    # Shift-left gate for the crates.io release (#308): dry-run-publish the
+    # whole workspace on every PR/main, so packaging / metadata / unpublishable-
+    # dependency errors surface HERE (cheap, reversible) instead of at tag time
+    # (partial, irreversible publish). `--workspace` packages every publishable
+    # crate in dep order and skips `publish = false` natively — the same set the
+    # release publishes. See ADR-022.
     steps:
       - uses: actions/checkout@v4
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: cargo publish --dry-run -p devboy-core
-        run: cargo publish --dry-run -p devboy-core
+      - name: cargo publish --workspace --dry-run
+        run: cargo publish --workspace --dry-run --no-verify
 
   unused-deps:
     name: Unused deps (cargo-machete)

--- a/.github/workflows/release-crates-io.yml
+++ b/.github/workflows/release-crates-io.yml
@@ -56,208 +56,32 @@ jobs:
           cargo check --workspace --all-targets
           cargo test --workspace --no-fail-fast
 
-      # Layer 1 — leaf crates with no internal devboy-* deps. Published
-      # in parallel-safe order (each is independent). `publish_if_new`
-      # makes the step idempotent on partial-retry: if 0.X.Y is already on
-      # crates.io (previous run got far enough), skip silently instead of
-      # failing the whole pipeline.
-      - name: Publish layer 1 (leaf crates — devboy-core + secrets framework leaves)
+      # Publish every publishable library (publish != false) in dependency order,
+      # derived from cargo metadata by scripts/release/crates-publish-order.py.
+      # No hardcoded crate list / manual layers — the set never drifts from reality
+      # (new crates auto-included; the app binary devboy-cli, devboy-mcp and the
+      # internal secrets plugins are publish=false and auto-excluded). See #308.
+      # publish_if_new is idempotent: a version already on crates.io is skipped, so
+      # a re-run after a partial publish completes cleanly.
+      - name: Publish libraries to crates.io (metadata-derived, dep order)
         run: |
           set -euo pipefail
           publish_if_new() {
-            local crate="$1"
-            # Skip crates marked `publish = false` (cargo metadata: publish == []) —
-            # e.g. secrets-agent / secrets-ui / the secrets plugins are intentionally
-            # unpublished; listing them must not fail the release (fixes #308 fallout).
-            if [ "$(cargo metadata --no-deps --format-version 1 \
-                | jq -r --arg c "$crate" '.packages[]|select(.name==$c)|(.publish==[])')" = "true" ]; then
-              echo "$crate is publish=false — skipping"
-              return 0
-            fi
-            local version
+            local crate="$1" version
             version="$(cargo metadata --no-deps --format-version 1 \
               | jq -r --arg c "$crate" '.packages[] | select(.name == $c) | .version')"
             echo "::group::publish $crate $version"
             if cargo publish -p "$crate" --no-verify 2>&1 | tee /tmp/publish.log; then
               echo "published"
+            elif grep -qiE "already (uploaded|exists)|crate version .* is already" /tmp/publish.log; then
+              echo "$crate $version already on crates.io — skipping"
             else
-              # crates.io rejects `cargo publish` on an existing version with
-              # `already uploaded` (status 200/409 depending on registry). Treat
-              # that one shape as success; bubble any other failure up.
-              if grep -qiE "already (uploaded|exists)|crate version .* is already" /tmp/publish.log; then
-                echo "$crate $version already on crates.io — skipping"
-              else
-                exit 1
-              fi
+              exit 1
             fi
             echo "::endgroup::"
           }
-          for crate in \
-              devboy-core \
-              devboy-secret-patterns \
-              devboy-vault-crypto \
-              devboy-token-catalog ; do
+          while read -r crate; do
+            [ -z "$crate" ] && continue
             publish_if_new "$crate"
-            sleep 10
-          done
-
-      # crates.io index needs ~30 s to make the new version resolvable as a
-      # dependency for the next layer. Hard-coded sleep is the simplest
-      # cross-cutting fix; the dry-run guard caught any pre-release issue.
-      - name: Wait for index propagation
-        run: sleep 30
-
-      # Layer 2 — crates that depend only on Layer 1. Order within the
-      # layer doesn't matter for correctness, but we publish API plugins
-      # before storage/assets so any plugin-side failure surfaces early.
-      # Same `publish_if_new` idempotency as Layer 1 — survives partial
-      # retries.
-      - name: Publish layer 2 (deps on Layer 1 only)
-        run: |
-          set -euo pipefail
-          publish_if_new() {
-            local crate="$1"
-            # Skip crates marked `publish = false` (cargo metadata: publish == []) —
-            # e.g. secrets-agent / secrets-ui / the secrets plugins are intentionally
-            # unpublished; listing them must not fail the release (fixes #308 fallout).
-            if [ "$(cargo metadata --no-deps --format-version 1 \
-                | jq -r --arg c "$crate" '.packages[]|select(.name==$c)|(.publish==[])')" = "true" ]; then
-              echo "$crate is publish=false — skipping"
-              return 0
-            fi
-            local version
-            version="$(cargo metadata --no-deps --format-version 1 \
-              | jq -r --arg c "$crate" '.packages[] | select(.name == $c) | .version')"
-            echo "::group::publish $crate $version"
-            if cargo publish -p "$crate" --no-verify 2>&1 | tee /tmp/publish.log; then
-              echo "published"
-            else
-              if grep -qiE "already (uploaded|exists)|crate version .* is already" /tmp/publish.log; then
-                echo "$crate $version already on crates.io — skipping"
-              else
-                exit 1
-              fi
-            fi
-            echo "::endgroup::"
-          }
-          for crate in \
-              devboy-storage \
-              devboy-assets \
-              devboy-format-pipeline \
-              devboy-gitlab \
-              devboy-github \
-              devboy-jira \
-              devboy-clickup \
-              devboy-confluence \
-              devboy-fireflies \
-              devboy-slack \
-              devboy-telegram ; do
-            publish_if_new "$crate"
-            sleep 20
-          done
-
-      # Layer 2.5 — secrets plugins. These depend on Layer 1/2 (storage,
-      # vault-crypto) and feed devboy-mcp (kdbx) + devboy-cli (all of them),
-      # so they MUST publish before Layer 4. Order within the layer respects
-      # internal deps: secrets-agent first (vault-crypto only), then the
-      # storage-only plugins, then local-vault (needs secrets-agent).
-      - name: Publish layer 2.5 (secrets plugins)
-        run: |
-          set -euo pipefail
-          publish_if_new() {
-            local crate="$1"
-            # Skip crates marked `publish = false` (cargo metadata: publish == []) —
-            # e.g. secrets-agent / secrets-ui / the secrets plugins are intentionally
-            # unpublished; listing them must not fail the release (fixes #308 fallout).
-            if [ "$(cargo metadata --no-deps --format-version 1 \
-                | jq -r --arg c "$crate" '.packages[]|select(.name==$c)|(.publish==[])')" = "true" ]; then
-              echo "$crate is publish=false — skipping"
-              return 0
-            fi
-            local version
-            version="$(cargo metadata --no-deps --format-version 1 \
-              | jq -r --arg c "$crate" '.packages[] | select(.name == $c) | .version')"
-            echo "::group::publish $crate $version"
-            if cargo publish -p "$crate" --no-verify 2>&1 | tee /tmp/publish.log; then
-              echo "published"
-            else
-              if grep -qiE "already (uploaded|exists)|crate version .* is already" /tmp/publish.log; then
-                echo "$crate $version already on crates.io — skipping"
-              else
-                exit 1
-              fi
-            fi
-            echo "::endgroup::"
-          }
-          for crate in \
-              devboy-secrets-agent \
-              devboy-secrets-ui \
-              devboy-secret-keychain \
-              devboy-secret-1password \
-              devboy-secret-vault \
-              devboy-secret-env-store \
-              devboy-secret-kdbx \
-              devboy-secret-local-vault ; do
-            publish_if_new "$crate"
-            sleep 20
-          done
-
-      - name: Wait for index propagation
-        run: sleep 30
-
-      # Layer 3 — depends on Layer 1 + 2.
-      - name: Publish devboy-executor
-        run: |
-          set -euo pipefail
-          if cargo publish -p devboy-executor --no-verify 2>&1 | tee /tmp/publish.log; then
-            :
-          elif grep -qiE "already (uploaded|exists)|crate version .* is already" /tmp/publish.log; then
-            echo "devboy-executor already on crates.io — skipping"
-          else
-            exit 1
-          fi
-
-      - name: Wait for index propagation
-        run: sleep 30
-
-      # Layer 4 — depends on Layer 3.
-      - name: Publish devboy-mcp
-        run: |
-          set -euo pipefail
-          if cargo publish -p devboy-mcp --no-verify 2>&1 | tee /tmp/publish.log; then
-            :
-          elif grep -qiE "already (uploaded|exists)|crate version .* is already" /tmp/publish.log; then
-            echo "devboy-mcp already on crates.io — skipping"
-          else
-            exit 1
-          fi
-
-      - name: Wait for index propagation
-        run: sleep 30
-
-      # Layer 5 — depends on devboy-core (independent of executor/mcp chain).
-      - name: Publish devboy-skills
-        run: |
-          set -euo pipefail
-          if cargo publish -p devboy-skills --no-verify 2>&1 | tee /tmp/publish.log; then
-            :
-          elif grep -qiE "already (uploaded|exists)|crate version .* is already" /tmp/publish.log; then
-            echo "devboy-skills already on crates.io — skipping"
-          else
-            exit 1
-          fi
-
-      - name: Wait for index propagation
-        run: sleep 30
-
-      # Layer 6 — binary, depends on everything above.
-      - name: Publish devboy-cli
-        run: |
-          set -euo pipefail
-          if cargo publish -p devboy-cli --no-verify 2>&1 | tee /tmp/publish.log; then
-            :
-          elif grep -qiE "already (uploaded|exists)|crate version .* is already" /tmp/publish.log; then
-            echo "devboy-cli already on crates.io — skipping"
-          else
-            exit 1
-          fi
+            sleep 15
+          done < <(python3 scripts/release/crates-publish-order.py)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `devboy-tools` are recorded here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Changed — crates.io publishing policy (#308)
+
+- crates.io now ships **only the reusable libraries**. `devboy-cli` (the app
+  binary) and `devboy-mcp` are `publish = false` — they hard-depend on the
+  internal secrets plugins, so they're distributed via npm (`@devboy-tools/cli`)
+  + prebuilt release binaries, not `cargo install`. The release now derives its
+  publish set + order from `cargo metadata` (no hardcoded crate list) and a
+  `cargo publish --workspace --dry-run` CI gate catches packaging / metadata /
+  unpublishable-dependency errors before tagging — fixing the chronic
+  crates.io release failures.
+
 ## [0.32.0] - 2026-07-25
 
 ### Security / Dependencies

--- a/crates/devboy-cli/Cargo.toml
+++ b/crates/devboy-cli/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "devboy-cli"
-description = "Command-line interface for devboy-tools — `devboy` binary. Primary distribution is npm (@devboy-tools/cli); `cargo install devboy-cli` is the secondary channel."
+description = "Command-line interface for devboy-tools — the `devboy` binary. Distributed via npm (@devboy-tools/cli) and prebuilt release binaries."
 version.workspace = true
+# Not a crates.io library: this is the app binary and it hard-depends on the
+# internal secrets plugins (publish = false). crates.io ships only the reusable
+# libraries (see #308). Distribution is npm + release binaries.
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/devboy-mcp/Cargo.toml
+++ b/crates/devboy-mcp/Cargo.toml
@@ -2,6 +2,9 @@
 name = "devboy-mcp"
 description = "MCP (Model Context Protocol) server for devboy-tools — JSON-RPC 2.0 over stdio, exposing every devboy provider as MCP tools to AI agents."
 version.workspace = true
+# Not a crates.io library: hard-depends on the internal `devboy-secret-kdbx`
+# plugin (publish = false). crates.io ships only the reusable libraries (#308).
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/scripts/release/crates-publish-order.py
+++ b/scripts/release/crates-publish-order.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Emit publishable workspace crates (publish != false) in dependency order
+(deps before dependents), one per line, for `cargo publish`.
+
+Derived from `cargo metadata` so the publish set never drifts from reality:
+new crates are picked up automatically, `publish = false` crates (the app
+binary devboy-cli, devboy-mcp, the internal secrets plugins) are excluded,
+and the order always matches the real dependency graph. See #308 — hardcoded
+crate lists / manual "layers" broke every release.
+"""
+import json
+import subprocess
+import sys
+
+meta = json.loads(
+    subprocess.check_output(["cargo", "metadata", "--format-version", "1"])
+)
+ws = set(meta["workspace_members"])
+publishable = {
+    p["name"]
+    for p in meta["packages"]
+    if p["id"] in ws and p.get("publish") != []
+}
+
+# intra-workspace, publishable dependency edges (normal + build, not dev)
+deps = {n: set() for n in publishable}
+for p in meta["packages"]:
+    if p["id"] not in ws or p["name"] not in publishable:
+        continue
+    for dep in p.get("dependencies", []):
+        if dep.get("kind") in (None, "build") and dep["name"] in publishable:
+            deps[p["name"]].add(dep["name"])
+
+order, done, stack = [], set(), set()
+
+
+def visit(n):
+    if n in done:
+        return
+    if n in stack:
+        sys.exit(f"dependency cycle involving {n}")
+    stack.add(n)
+    for d in sorted(deps[n]):
+        visit(d)
+    stack.discard(n)
+    done.add(n)
+    order.append(n)
+
+
+for n in sorted(publishable):
+    visit(n)
+
+print("\n".join(order))


### PR DESCRIPTION
## Fixes the chronically-broken crates.io release (#308)

crates.io has failed **every** release. Root cause: the app binary `devboy-cli` and `devboy-mcp` hard-depend on the internal secrets plugins (`publish = false`), so they can't publish — and the workflow used hardcoded crate lists / manual 'layers' that drifted from reality every release.

### Option A — crates.io ships only reusable libraries
- `devboy-cli` + `devboy-mcp` → `publish = false` (distributed via npm + release binaries; not `cargo install`).
- Leaves a clean **17-crate library subgraph** that publishes correctly.

### Robustness (so it doesn't break again)
- **Metadata-derived publish** (`scripts/release/crates-publish-order.py`): the release publishes exactly `publish != false` crates in topological order, derived from `cargo metadata`. No hardcoded list → new/removed/publish=false crates handled automatically. Idempotent (`already exists` skip) so re-runs after a partial publish complete.
- **Dry-run gate**: CI `publish-dry-run` upgraded from devboy-core-only to `cargo publish --workspace --dry-run` — catches packaging/metadata/unpublishable-dep errors on every PR, before the tag.

### Validation
`cargo publish --workspace --dry-run` packages exactly the 17 clean libs in dep order and skips cli/mcp/plugins — zero `no matching package` errors.

Closes #308