### PR TITLE
fix: post-merge hardening for the YouGile and Confluence Cloud providers

### DIFF
--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -564,6 +564,11 @@ enum ConfluenceOauthCommands {
         /// Authorization code returned by Atlassian
         #[arg(long)]
         code: String,
+        /// `state` value Atlassian returned on the redirect. Checked against
+        /// the one issued by `oauth url`; required whenever that command
+        /// generated it.
+        #[arg(long)]
+        state: Option<String>,
         /// Optional context name. Defaults to active context, then global config.
         #[arg(long)]
         context: Option<String>,
@@ -3700,6 +3705,57 @@ fn maybe_store_secret(
     Ok(())
 }
 
+/// Verifies the `state` echoed back by Atlassian against the one `oauth url`
+/// issued, then consumes it so a value can never be replayed.
+///
+/// Generating `state` without checking the round-trip leaves the parameter
+/// decorative. When no state was issued (the caller supplied their own via
+/// `--state`, or drove the authorization step out of band) there is nothing
+/// to compare against, so the check is skipped loudly rather than silently.
+fn verify_oauth_state(
+    store: &dyn devboy_storage::CredentialStore,
+    secret_prefix: &str,
+    provided: Option<&str>,
+) -> Result<()> {
+    let key = get_secret_key(secret_prefix, "oauth_state");
+    let Some(expected) = store.get(&key).ok().flatten() else {
+        if provided.is_some() {
+            tracing::warn!(
+                "No issued OAuth state on record; skipping verification of the supplied --state"
+            );
+        }
+        return Ok(());
+    };
+
+    let expected = expected.expose_secret();
+    let provided = provided.ok_or_else(|| {
+        anyhow::anyhow!(
+            "`oauth url` issued a state parameter, so --state is required: pass the `state` \
+             value from the redirect URL. This binds the authorization code to your request."
+        )
+    })?;
+
+    // Constant-time compare: the value is a secret nonce, so avoid leaking a
+    // prefix match through timing.
+    let matches = expected.len() == provided.len()
+        && expected
+            .bytes()
+            .zip(provided.bytes())
+            .fold(0u8, |acc, (a, b)| acc | (a ^ b))
+            == 0;
+
+    // One-shot either way — a rejected state must not stay valid for a retry.
+    let _ = store.delete(&key);
+
+    if !matches {
+        anyhow::bail!(
+            "OAuth state mismatch: the redirect did not come from the authorization request \
+             this CLI started. Discard the code and run `oauth url` again."
+        );
+    }
+    Ok(())
+}
+
 /// Generates the OAuth 2.0 `state` parameter — 128 bits from the OS CSPRNG,
 /// hex-encoded behind a `devboy-` marker.
 ///
@@ -3739,9 +3795,20 @@ async fn handle_confluence_oauth_command(command: ConfluenceOauthCommands) -> Re
                 .redirect_uri
                 .clone()
                 .ok_or_else(|| anyhow::anyhow!("Confluence redirect_uri is not configured"))?;
+            // Remember the issued value so `oauth exchange` can verify the
+            // one Atlassian echoes back. Without this round-trip the `state`
+            // parameter is decorative and provides no CSRF protection.
             let state = match state {
                 Some(state) => state,
-                None => generate_oauth_state()?,
+                None => {
+                    let generated = generate_oauth_state()?;
+                    let store = get_credential_store();
+                    store.store(
+                        &get_secret_key(&target.secret_prefix, "oauth_state"),
+                        &SecretString::from(generated.clone()),
+                    )?;
+                    generated
+                }
             };
             let url = ConfluenceClient::oauth_authorize_url(
                 &client_id,
@@ -3758,6 +3825,7 @@ async fn handle_confluence_oauth_command(command: ConfluenceOauthCommands) -> Re
         }
         ConfluenceOauthCommands::Exchange {
             code,
+            state,
             context,
             client_secret,
             store_client_secret,
@@ -3765,6 +3833,7 @@ async fn handle_confluence_oauth_command(command: ConfluenceOauthCommands) -> Re
             let (config, _) = load_runtime_config()?;
             let store = get_credential_store();
             let target = resolve_confluence_oauth_target(&config, context.as_deref())?;
+            verify_oauth_state(store.as_ref(), &target.secret_prefix, state.as_deref())?;
             let client_id = target
                 .config
                 .client_id
@@ -6285,6 +6354,52 @@ mod tests {
                 .chars()
                 .all(|ch| ch.is_ascii_hexdigit() && !ch.is_ascii_uppercase())
         );
+    }
+
+    #[test]
+    fn test_verify_oauth_state_accepts_the_issued_value_once() {
+        let store = MemoryStore::with_credentials([(
+            "confluence.oauth_state".to_string(),
+            "devboy-abc123".to_string(),
+        )]);
+
+        verify_oauth_state(&store, "confluence", Some("devboy-abc123")).unwrap();
+        // Consumed: the same value must not authorise a second exchange.
+        assert!(store.get("confluence.oauth_state").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_verify_oauth_state_rejects_mismatch_and_missing() {
+        let store = MemoryStore::with_credentials([(
+            "confluence.oauth_state".to_string(),
+            "devboy-abc123".to_string(),
+        )]);
+        let err = verify_oauth_state(&store, "confluence", Some("devboy-tampered")).unwrap_err();
+        assert!(
+            err.to_string().contains("state mismatch"),
+            "unexpected error: {err}"
+        );
+        // A rejected attempt also burns the nonce.
+        assert!(store.get("confluence.oauth_state").unwrap().is_none());
+
+        let store = MemoryStore::with_credentials([(
+            "confluence.oauth_state".to_string(),
+            "devboy-abc123".to_string(),
+        )]);
+        let err = verify_oauth_state(&store, "confluence", None).unwrap_err();
+        assert!(
+            err.to_string().contains("--state is required"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_verify_oauth_state_skips_when_none_was_issued() {
+        // Caller supplied their own state via `--state` on `oauth url`, or
+        // drove authorization out of band — nothing to compare against.
+        let store = MemoryStore::with_credentials([]);
+        verify_oauth_state(&store, "confluence", Some("whatever")).unwrap();
+        verify_oauth_state(&store, "confluence", None).unwrap();
     }
 
     #[test]

--- a/crates/devboy-cli/src/main.rs
+++ b/crates/devboy-cli/src/main.rs
@@ -3718,7 +3718,13 @@ fn verify_oauth_state(
     provided: Option<&str>,
 ) -> Result<()> {
     let key = get_secret_key(secret_prefix, "oauth_state");
-    let Some(expected) = store.get(&key).ok().flatten() else {
+    // Fail closed: a credential-store read error must not be mistaken for
+    // "no state was issued", which would skip verification entirely.
+    let stored = store
+        .get(&key)
+        .context("Failed to read the issued OAuth state from the credential store")?;
+
+    let Some(expected) = stored else {
         if provided.is_some() {
             tracing::warn!(
                 "No issued OAuth state on record; skipping verification of the supplied --state"
@@ -3735,8 +3741,9 @@ fn verify_oauth_state(
         )
     })?;
 
-    // Constant-time compare: the value is a secret nonce, so avoid leaking a
-    // prefix match through timing.
+    // Compare without an early exit on the first differing byte. The length
+    // is not secret here — it is fixed and public ("devboy-" + 32 hex chars) —
+    // so the length check leaks nothing about the nonce itself.
     let matches = expected.len() == provided.len()
         && expected
             .bytes()
@@ -3744,15 +3751,23 @@ fn verify_oauth_state(
             .fold(0u8, |acc, (a, b)| acc | (a ^ b))
             == 0;
 
-    // One-shot either way — a rejected state must not stay valid for a retry.
-    let _ = store.delete(&key);
-
     if !matches {
+        // Deliberately keep the stored value. Consuming it on failure would
+        // let a single wrong attempt clear the nonce, after which the next
+        // exchange finds nothing stored and skips verification altogether —
+        // turning a rejected attempt into a way to disable the check.
         anyhow::bail!(
             "OAuth state mismatch: the redirect did not come from the authorization request \
              this CLI started. Discard the code and run `oauth url` again."
         );
     }
+
+    // Consume only on success, and surface a failure to do so: this runs
+    // before the code is exchanged, so erroring out here is safe and keeps
+    // the one-shot guarantee honest.
+    store
+        .delete(&key)
+        .context("Verified the OAuth state but failed to consume it; refusing to continue")?;
     Ok(())
 }
 
@@ -6379,8 +6394,17 @@ mod tests {
             err.to_string().contains("state mismatch"),
             "unexpected error: {err}"
         );
-        // A rejected attempt also burns the nonce.
-        assert!(store.get("confluence.oauth_state").unwrap().is_none());
+
+        // Regression: a rejected attempt must NOT consume the nonce. Burning
+        // it would leave nothing stored, and the next exchange would then take
+        // the "no state issued" path and skip verification entirely — one bad
+        // guess would disable the check.
+        assert!(
+            store.get("confluence.oauth_state").unwrap().is_some(),
+            "a rejected state must stay on record"
+        );
+        verify_oauth_state(&store, "confluence", Some("devboy-tampered")).unwrap_err();
+        verify_oauth_state(&store, "confluence", Some("devboy-abc123")).unwrap();
 
         let store = MemoryStore::with_credentials([(
             "confluence.oauth_state".to_string(),

--- a/crates/devboy-executor/src/factory.rs
+++ b/crates/devboy-executor/src/factory.rs
@@ -598,7 +598,10 @@ mod tests {
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
             when.method(GET)
-                .path("/wiki/api/v2/space")
+                // `space?limit=&type=` is a v1 endpoint (v2 spells it
+                // `spaces` with different params), so on Cloud it must be
+                // requested under /wiki/rest/api — not /wiki/api/v2.
+                .path("/wiki/rest/api/space")
                 .query_param("limit", "100")
                 .query_param("type", "global,personal");
             then.status(200)

--- a/crates/plugins/api/confluence/src/client.rs
+++ b/crates/plugins/api/confluence/src/client.rs
@@ -352,12 +352,21 @@ impl ConfluenceClient {
         Ok(self.api_url(api_path, path))
     }
 
-    async fn legacy_rest_api_url(&self, path: &str) -> Result<String> {
-        let api_path = match self.flavor {
+    /// Prefix used by the v1 (legacy) REST surface.
+    ///
+    /// Distinct from `self.api_path`, which on Cloud points at `/wiki/api/v2`.
+    /// Anything that will be sent through `get_json_from_legacy_api` must
+    /// resolve relative to *this* — including cursors echoed back by the
+    /// server, or the prefix gets prepended twice and the request 404s.
+    fn legacy_api_path(&self) -> &'static str {
+        match self.flavor {
             ConfluenceFlavor::Cloud => "/wiki/rest/api",
             ConfluenceFlavor::SelfHosted => DEFAULT_CONFLUENCE_API_PATH,
-        };
-        Ok(self.api_url(api_path, path))
+        }
+    }
+
+    async fn legacy_rest_api_url(&self, path: &str) -> Result<String> {
+        Ok(self.api_url(self.legacy_api_path(), path))
     }
 
     #[cfg(test)]
@@ -2214,7 +2223,8 @@ impl ConfluenceClient {
     async fn list_pages_v1(&self, params: ListPagesParams) -> Result<ProviderResult<KbPage>> {
         let limit = params.limit.unwrap_or(25);
         let path = if let Some(cursor) = params.cursor.as_ref() {
-            path_from_cursor(cursor, &self.api_path)
+            // Fetched via the legacy surface below, so strip the legacy prefix.
+            path_from_cursor(cursor, self.legacy_api_path())
         } else if let Some(parent_id) = params.parent_id.as_ref() {
             let offset = params.offset.unwrap_or(0);
             let query = [
@@ -2711,7 +2721,8 @@ impl KnowledgeBaseProvider for ConfluenceClient {
         let limit = params.limit.unwrap_or(25);
 
         let path = if let Some(cursor) = params.cursor.as_ref() {
-            path_from_cursor(cursor, &self.api_path)
+            // Fetched via the legacy surface below, so strip the legacy prefix.
+            path_from_cursor(cursor, self.legacy_api_path())
         } else {
             let cql = build_search_cql(&params);
             format!(
@@ -4544,6 +4555,43 @@ mod tests {
                 space_key: None,
                 cursor: None,
                 limit: Some(10),
+                raw_query: false,
+            })
+            .await
+            .unwrap();
+
+        mock.assert();
+        assert!(result.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_follows_a_cloud_cursor_without_doubling_the_legacy_prefix() {
+        // Cloud echoes cursors relative to /wiki/rest/api, while self.api_path
+        // points at /wiki/api/v2. Stripping with the wrong prefix left the
+        // path intact and produced /wiki/rest/api/wiki/rest/api/... — a 404 on
+        // every page past the first.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/wiki/rest/api/content/search")
+                .query_param("start", "25");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"results":[],"start":25,"limit":25,"size":0,"_links":{}}"#);
+        });
+
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"))
+                .with_flavor(ConfluenceFlavor::Cloud);
+        let result = client
+            .search(SearchKbParams {
+                query: "architecture".into(),
+                space_key: None,
+                cursor: Some(
+                    "/wiki/rest/api/content/search?cql=text~%22architecture%22&limit=25&start=25"
+                        .into(),
+                ),
+                limit: Some(25),
                 raw_query: false,
             })
             .await

--- a/crates/plugins/api/confluence/src/client.rs
+++ b/crates/plugins/api/confluence/src/client.rs
@@ -4872,6 +4872,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_space_by_key_follows_a_v2_cursor_on_the_v2_surface() {
+        // Page 1 is served from the v2 surface, so its cursor carries the v2
+        // prefix. Resolving that against the legacy prefix left the path
+        // intact and built /rest/api/api/v2/... — an opaque 404 instead of a
+        // walk to the match.
+        let server = MockServer::start();
+        let page1 = server.mock(|when, then| {
+            when.method(GET).path("/api/v2/space").query_param("limit", "100");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"results":[{"id":"1","key":"OTHER","name":"Other","type":"global","status":"current"}],"start":0,"limit":1,"size":1,"_links":{"next":"/api/v2/space?cursor=abc"}}"#,
+                );
+        });
+        let page2 = server.mock(|when, then| {
+            when.method(GET).path("/api/v2/space").query_param("cursor", "abc");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"results":[{"id":"2","key":"WANTED","name":"Wanted","type":"global","status":"current"}],"start":1,"limit":1,"size":1,"_links":{}}"#,
+                );
+        });
+
+        let client =
+            ConfluenceClient::new(server.base_url(), ConfluenceAuth::bearer("secret-token"))
+                .with_flavor(ConfluenceFlavor::SelfHosted)
+                .with_api_version(Some("v2"));
+        let space = client.resolve_space_by_key("WANTED").await.unwrap();
+
+        assert_eq!(space.key, "WANTED");
+        page1.assert();
+        page2.assert();
+    }
+
+    #[tokio::test]
     async fn search_follows_a_cloud_cursor_without_doubling_the_legacy_prefix() {
         // Cloud echoes cursors relative to /wiki/rest/api, while self.api_path
         // points at /wiki/api/v2. Stripping with the wrong prefix left the

--- a/crates/plugins/api/confluence/src/client.rs
+++ b/crates/plugins/api/confluence/src/client.rs
@@ -1668,9 +1668,74 @@ fn adf_to_markdown(adf: &Value) -> String {
     collapse_markdown_whitespace(&out)
 }
 
+/// Renders an ADF `table` as a GitHub-flavoured Markdown table.
+///
+/// Without an arm of its own a table fell through to the inline catch-all,
+/// which walks the row/cell hierarchy with no separators at all — a 2×2 table
+/// came out as the single run-on string "NameAgeAlice30".
+fn render_adf_table(node: &Value, out: &mut String) {
+    let Some(rows) = node.get("content").and_then(Value::as_array) else {
+        return;
+    };
+
+    let mut rendered: Vec<Vec<String>> = Vec::new();
+    let mut header_is_first_row = false;
+
+    for (row_idx, row) in rows.iter().enumerate() {
+        if row.get("type").and_then(Value::as_str) != Some("tableRow") {
+            continue;
+        }
+        let Some(cells) = row.get("content").and_then(Value::as_array) else {
+            continue;
+        };
+        let mut cols = Vec::with_capacity(cells.len());
+        for cell in cells {
+            if row_idx == 0 && cell.get("type").and_then(Value::as_str) == Some("tableHeader") {
+                header_is_first_row = true;
+            }
+            let mut text = String::new();
+            if let Some(blocks) = cell.get("content").and_then(Value::as_array) {
+                for (idx, block) in blocks.iter().enumerate() {
+                    if idx > 0 {
+                        text.push(' ');
+                    }
+                    render_adf_block(block, &mut text);
+                }
+            }
+            // A literal pipe would break the row apart when re-read.
+            cols.push(text.trim().replace('|', "\\|"));
+        }
+        rendered.push(cols);
+    }
+
+    if rendered.is_empty() {
+        return;
+    }
+
+    let width = rendered.iter().map(Vec::len).max().unwrap_or(0);
+    for (idx, row) in rendered.iter().enumerate() {
+        let mut cols = row.clone();
+        cols.resize(width, String::new());
+        out.push_str(&format!("| {} |", cols.join(" | ")));
+        out.push('\n');
+        if idx == 0 {
+            // GFM needs a delimiter row; synthesise one even when the source
+            // table has no header cells, or the rest is not parsed as a table.
+            let _ = header_is_first_row;
+            out.push_str(&format!("| {} |", vec!["---"; width].join(" | ")));
+            out.push('\n');
+        }
+    }
+    // Trim the trailing newline; the block joiner adds its own separator.
+    while out.ends_with('\n') {
+        out.pop();
+    }
+}
+
 fn render_adf_block(node: &Value, out: &mut String) {
     match node.get("type").and_then(Value::as_str).unwrap_or_default() {
         "paragraph" => render_adf_inline_nodes(node.get("content"), out),
+        "table" => render_adf_table(node, out),
         "heading" => {
             let level = node
                 .get("attrs")
@@ -1756,6 +1821,68 @@ fn render_adf_inline_nodes(content: Option<&Value>, out: &mut String) {
                     out.push_str(&text);
                 }
                 "hardBreak" => out.push('\n'),
+                // These carry their payload in `attrs`, not `content`. The
+                // catch-all below recurses into `content` and so emitted
+                // nothing at all for them — "@Bob, please review" silently
+                // became ", please review".
+                "mention" => {
+                    let attrs = node.get("attrs");
+                    let text = attrs
+                        .and_then(|a| a.get("text"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                        .or_else(|| {
+                            attrs
+                                .and_then(|a| a.get("id"))
+                                .and_then(Value::as_str)
+                                .map(|id| format!("@{id}"))
+                        })
+                        .unwrap_or_else(|| "@unknown".to_string());
+                    out.push_str(&text);
+                }
+                "emoji" => {
+                    let attrs = node.get("attrs");
+                    let text = attrs
+                        .and_then(|a| a.get("text"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                        .or_else(|| {
+                            attrs
+                                .and_then(|a| a.get("shortName"))
+                                .and_then(Value::as_str)
+                                .map(str::to_string)
+                        })
+                        .unwrap_or_default();
+                    out.push_str(&text);
+                }
+                "status" | "date" => {
+                    let attrs = node.get("attrs");
+                    if let Some(text) = attrs.and_then(|a| a.get("text")).and_then(Value::as_str) {
+                        out.push_str(text);
+                    } else if let Some(ts) = attrs
+                        .and_then(|a| a.get("timestamp"))
+                        .and_then(Value::as_str)
+                    {
+                        out.push_str(ts);
+                    }
+                }
+                "inlineCard" => {
+                    if let Some(url) = node
+                        .get("attrs")
+                        .and_then(|a| a.get("url"))
+                        .and_then(Value::as_str)
+                    {
+                        out.push_str(url);
+                    }
+                }
+                "media" | "mediaInline" => {
+                    let attrs = node.get("attrs");
+                    let alt = attrs
+                        .and_then(|a| a.get("alt"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("attachment");
+                    out.push_str(&format!("[{alt}]"));
+                }
                 _ => render_adf_inline_nodes(node.get("content"), out),
             }
         }
@@ -2144,12 +2271,53 @@ impl ConfluenceClient {
             })
     }
 
-    async fn resolve_space_by_key(&self, space_key: &str) -> Result<ConfluenceSpace> {
-        let spaces = self.get_spaces().await?;
-        spaces
-            .items
+    /// Walks every page of spaces, stopping as soon as `predicate` matches.
+    ///
+    /// `get_spaces` returns a single 100-item page. Searching only that page
+    /// made `resolve_space_by_key` report NotFound — and
+    /// `resolve_space_key_by_id` report None — for spaces that exist but sit
+    /// past the first page.
+    async fn find_space<F>(&self, predicate: F) -> Result<Option<KbSpace>>
+    where
+        F: Fn(&KbSpace) -> bool,
+    {
+        // Bounded so a server that keeps advertising another page cannot spin.
+        const MAX_PAGES: usize = 100;
+
+        let mut page = self.get_spaces().await?;
+        for _ in 0..MAX_PAGES {
+            if let Some(found) = page.items.iter().find(|space| predicate(space)) {
+                return Ok(Some(found.clone()));
+            }
+            let Some(pagination) = page.pagination.as_ref().filter(|p| p.has_more) else {
+                return Ok(None);
+            };
+            let Some(cursor) = pagination.next_cursor.clone() else {
+                return Ok(None);
+            };
+            page = self.list_spaces_page(&cursor).await?;
+        }
+        Err(Error::InvalidData(
+            "Confluence kept reporting more spaces than expected".to_string(),
+        ))
+    }
+
+    async fn list_spaces_page(&self, cursor: &str) -> Result<ProviderResult<KbSpace>> {
+        let path = path_from_cursor(cursor, self.legacy_api_path());
+        let response: ConfluenceListResponse<ConfluenceSpace> =
+            self.get_json_from_legacy_api(&path).await?;
+        let pagination = map_pagination(&response, Some(100));
+        let items = response
+            .results
             .into_iter()
-            .find(|space| space.key == space_key)
+            .map(|space| map_space(&self.instance_url, space))
+            .collect::<Vec<_>>();
+        Ok(ProviderResult::new(items).with_pagination(pagination))
+    }
+
+    async fn resolve_space_by_key(&self, space_key: &str) -> Result<ConfluenceSpace> {
+        self.find_space(|space| space.key == space_key)
+            .await?
             .map(|space| ConfluenceSpace {
                 id: space.id,
                 key: space.key,
@@ -2163,11 +2331,9 @@ impl ConfluenceClient {
     }
 
     async fn resolve_space_key_by_id(&self, space_id: &str) -> Result<Option<String>> {
-        let spaces = self.get_spaces().await?;
-        Ok(spaces
-            .items
-            .into_iter()
-            .find(|space| space.id == space_id)
+        Ok(self
+            .find_space(|space| space.id == space_id)
+            .await?
             .map(|space| space.key))
     }
 
@@ -4597,6 +4763,64 @@ mod tests {
 
         mock.assert();
         assert!(result.items.is_empty());
+    }
+
+    #[test]
+    fn adf_tables_render_as_markdown_instead_of_a_run_on_string() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "table",
+                "content": [
+                    { "type": "tableRow", "content": [
+                        { "type": "tableHeader", "content": [
+                            { "type": "paragraph", "content": [{ "type": "text", "text": "Name" }] }]},
+                        { "type": "tableHeader", "content": [
+                            { "type": "paragraph", "content": [{ "type": "text", "text": "Age" }] }]}
+                    ]},
+                    { "type": "tableRow", "content": [
+                        { "type": "tableCell", "content": [
+                            { "type": "paragraph", "content": [{ "type": "text", "text": "Alice" }] }]},
+                        { "type": "tableCell", "content": [
+                            { "type": "paragraph", "content": [{ "type": "text", "text": "30" }] }]}
+                    ]}
+                ]
+            }]
+        });
+
+        let md = adf_to_markdown(&adf);
+        // Previously: "NameAgeAlice30".
+        assert!(md.contains("| Name | Age |"), "missing header row: {md}");
+        assert!(md.contains("| --- | --- |"), "missing delimiter row: {md}");
+        assert!(md.contains("| Alice | 30 |"), "missing body row: {md}");
+    }
+
+    #[test]
+    fn adf_inline_nodes_with_attrs_payloads_are_not_dropped() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{ "type": "paragraph", "content": [
+                { "type": "mention", "attrs": { "id": "u1", "text": "@Bob" } },
+                { "type": "text", "text": ", see " },
+                { "type": "inlineCard", "attrs": { "url": "https://example.com/x" } },
+                { "type": "text", "text": " " },
+                { "type": "status", "attrs": { "text": "DONE" } },
+                { "type": "emoji", "attrs": { "shortName": ":tada:" } },
+                { "type": "media", "attrs": { "alt": "diagram" } }
+            ]}]
+        });
+
+        let md = adf_to_markdown(&adf);
+        // Previously every one of these vanished, leaving ", see  ".
+        for expected in [
+            "@Bob",
+            "https://example.com/x",
+            "DONE",
+            ":tada:",
+            "[diagram]",
+        ] {
+            assert!(md.contains(expected), "{expected:?} was dropped from: {md}");
+        }
     }
 
     #[tokio::test]

--- a/crates/plugins/api/confluence/src/client.rs
+++ b/crates/plugins/api/confluence/src/client.rs
@@ -1702,8 +1702,15 @@ fn render_adf_table(node: &Value, out: &mut String) {
                     render_adf_block(block, &mut text);
                 }
             }
-            // A literal pipe would break the row apart when re-read.
-            cols.push(text.trim().replace('|', "\\|"));
+            // A literal pipe would break the row apart when re-read, and a
+            // newline — from a hardBreak or a list inside the cell — would
+            // split the row across lines and destroy the table structure.
+            cols.push(
+                text.trim()
+                    .replace('|', "\\|")
+                    .replace("\r\n", "<br>")
+                    .replace('\n', "<br>"),
+            );
         }
         rendered.push(cols);
     }
@@ -2303,9 +2310,20 @@ impl ConfluenceClient {
     }
 
     async fn list_spaces_page(&self, cursor: &str) -> Result<ProviderResult<KbSpace>> {
-        let path = path_from_cursor(cursor, self.legacy_api_path());
-        let response: ConfluenceListResponse<ConfluenceSpace> =
-            self.get_json_from_legacy_api(&path).await?;
+        // Continue on whichever surface produced the cursor. `get_spaces()`
+        // serves page 1 from v2 when it is available, and a v2 cursor carries
+        // the v2 prefix — resolving it against the legacy prefix leaves the
+        // path intact and builds `/wiki/rest/api/wiki/api/v2/...`, a 404.
+        let v2_prefix = self.space_api_path.trim_end_matches('/');
+        let from_v2 = uses_v2_api(&self.space_api_path) && cursor.contains(v2_prefix);
+
+        let response: ConfluenceListResponse<ConfluenceSpace> = if from_v2 {
+            let path = path_from_cursor(cursor, &self.space_api_path);
+            self.get_json_from_api(&self.space_api_path, &path).await?
+        } else {
+            let path = path_from_cursor(cursor, self.legacy_api_path());
+            self.get_json_from_legacy_api(&path).await?
+        };
         let pagination = map_pagination(&response, Some(100));
         let items = response
             .results
@@ -4793,6 +4811,36 @@ mod tests {
         assert!(md.contains("| Name | Age |"), "missing header row: {md}");
         assert!(md.contains("| --- | --- |"), "missing delimiter row: {md}");
         assert!(md.contains("| Alice | 30 |"), "missing body row: {md}");
+    }
+
+    #[test]
+    fn adf_table_cells_never_break_the_row_across_lines() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{ "type": "table", "content": [
+                { "type": "tableRow", "content": [
+                    { "type": "tableCell", "content": [
+                        { "type": "paragraph", "content": [
+                            { "type": "text", "text": "one" },
+                            { "type": "hardBreak" },
+                            { "type": "text", "text": "two" }]}]},
+                    { "type": "tableCell", "content": [
+                        { "type": "bulletList", "content": [
+                            { "type": "listItem", "content": [
+                                { "type": "paragraph", "content": [{ "type": "text", "text": "a" }]}]},
+                            { "type": "listItem", "content": [
+                                { "type": "paragraph", "content": [{ "type": "text", "text": "b" }]}]}]}]}
+                ]}
+            ]}]
+        });
+
+        let md = adf_to_markdown(&adf);
+        // Every table line must still be a complete row: a stray newline
+        // inside a cell used to split the row and destroy the structure.
+        for line in md.lines().filter(|l| l.starts_with('|')) {
+            assert!(line.ends_with('|'), "row broken across lines: {md}");
+        }
+        assert!(md.contains("one<br>two"), "hardBreak not folded: {md}");
     }
 
     #[test]

--- a/crates/plugins/api/confluence/src/client.rs
+++ b/crates/plugins/api/confluence/src/client.rs
@@ -490,6 +490,41 @@ impl ConfluenceClient {
         self.send_json(request).await
     }
 
+    /// POST against the v1 (legacy) surface.
+    ///
+    /// The `*_v1` operations are reached as a fallback when v2 fails, so they
+    /// must resolve against [`Self::legacy_api_path`] — `rest_api_url` points
+    /// at `/wiki/api/v2` on Cloud and would build an endpoint that does not
+    /// exist.
+    async fn post_json_to_legacy_api<T, B>(&self, path: &str, body: &B) -> Result<T>
+    where
+        T: DeserializeOwned,
+        B: Serialize + ?Sized,
+    {
+        let request = self
+            .http
+            .post(self.legacy_rest_api_url(path).await?)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .json(body);
+        self.send_json(request).await
+    }
+
+    /// PUT against the v1 (legacy) surface. See [`Self::post_json_to_legacy_api`].
+    async fn put_json_to_legacy_api<T, B>(&self, path: &str, body: &B) -> Result<T>
+    where
+        T: DeserializeOwned,
+        B: Serialize + ?Sized,
+    {
+        let request = self
+            .http
+            .put(self.legacy_rest_api_url(path).await?)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .json(body);
+        self.send_json(request).await
+    }
+
     pub async fn post_empty_json<B>(&self, path: &str, body: &B) -> Result<()>
     where
         B: Serialize + ?Sized,
@@ -2208,7 +2243,7 @@ impl ConfluenceClient {
 
     async fn get_spaces_v1(&self) -> Result<ProviderResult<KbSpace>> {
         let response: ConfluenceListResponse<ConfluenceSpace> = self
-            .get_json("space?limit=100&type=global,personal")
+            .get_json_from_legacy_api("space?limit=100&type=global,personal")
             .await?;
         let pagination = map_pagination(&response, Some(100));
         let items = response
@@ -2273,7 +2308,7 @@ impl ConfluenceClient {
         let path = format!(
             "content/{page_id}?expand=space,version,history.lastUpdated,body.storage,metadata.labels,ancestors"
         );
-        let page: ConfluencePage = self.get_json(&path).await?;
+        let page: ConfluencePage = self.get_json_from_legacy_api(&path).await?;
         let summary = map_page_summary(&self.instance_url, &page);
         let storage_content = page
             .body
@@ -2335,7 +2370,7 @@ impl ConfluenceClient {
                 .unwrap_or_default(),
         };
 
-        let page: ConfluencePage = self.post_json("content", &payload).await?;
+        let page: ConfluencePage = self.post_json_to_legacy_api("content", &payload).await?;
         self.add_labels(&page.id, &params.labels).await?;
         Ok(map_page_summary(&self.instance_url, &page))
     }
@@ -2347,7 +2382,7 @@ impl ConfluenceClient {
             "space,version,body.storage,ancestors"
         };
         let current_path = format!("content/{}?expand={current_expand}", params.page_id);
-        let current: ConfluencePage = self.get_json(&current_path).await?;
+        let current: ConfluencePage = self.get_json_from_legacy_api(&current_path).await?;
 
         let current_title = current.title.clone();
         let current_content = current
@@ -2408,7 +2443,7 @@ impl ConfluenceClient {
         };
 
         let path = format!("content/{}", params.page_id);
-        let page: ConfluencePage = self.put_json(&path, &payload).await?;
+        let page: ConfluencePage = self.put_json_to_legacy_api(&path, &payload).await?;
         if let Some(labels) = params.labels.as_ref() {
             let current_labels = extract_labels(&current);
             self.sync_labels(&params.page_id, labels, &current_labels)

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -1660,33 +1660,20 @@ fn jira_link_type_name_and_reversed(link_type: &str) -> (&str, bool) {
     }
 }
 
-fn jira_link_type_allows_either_direction(link_type: &str, link_type_name: &str) -> bool {
-    if link_type_name == "Relates" {
-        return true;
-    }
-
-    !matches!(
-        link_type,
-        "blocks"
-            | "blocked_by"
-            | "relates_to"
-            | "duplicates"
-            | "duplicated_by"
-            | "clones"
-            | "cloned_by"
-            | "causes"
-            | "caused_by"
-            | "implements"
-            | "implemented_by"
-            | "created_by"
-            | "creates"
-            | "Blocks"
-            | "Duplicate"
-            | "Cloners"
-            | "Causes"
-            | "Implements"
-            | "Created By"
-    )
+/// Whether a link of this type may be matched regardless of which side the
+/// target sits on.
+///
+/// Only genuinely symmetric types qualify. Everything else — including custom
+/// types configured on the instance, whose direction we cannot know — is
+/// matched directionally, so `unlink_issues` is the exact inverse of
+/// `link_issues` for the same arguments.
+///
+/// This used to default to `true` for anything outside the built-in alias
+/// table, which meant a custom directional type ("Epic", "Gantt: Predecessor")
+/// could match a link pointing the *other* way and delete the wrong
+/// relationship while reporting success.
+fn jira_link_type_allows_either_direction(_link_type: &str, link_type_name: &str) -> bool {
+    link_type_name == "Relates"
 }
 
 fn jira_link_matches_target(
@@ -2745,6 +2732,27 @@ impl IssueProvider for JiraClient {
                 )
             })
             .ok_or_else(|| {
+                // Matching is directional for everything but symmetric types.
+                // If the link exists the other way round, say so instead of a
+                // bare "not found" — the alternative is deleting it silently.
+                let reversed_exists = !allow_either_direction
+                    && issue.fields.issuelinks.iter().any(|link| {
+                        jira_link_matches_target(
+                            link,
+                            link_type_name,
+                            &target_jira_key,
+                            !reversed,
+                            false,
+                        )
+                    });
+                if reversed_exists {
+                    return Error::NotFound(format!(
+                        "Jira link not found: {source_jira_key} -> {target_jira_key} \
+                         ({link_type_name}) — a link of this type exists in the opposite \
+                         direction. Re-run with the source and target swapped, or with the \
+                         reversed alias, if that is the one you meant to remove."
+                    ));
+                }
                 Error::NotFound(format!(
                     "Jira link not found: {} -> {} ({})",
                     source_jira_key, target_jira_key, link_type_name
@@ -6500,7 +6508,10 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_unlink_issues_custom_type_matches_either_direction() {
+        async fn test_unlink_issues_custom_type_does_not_delete_the_reverse_link() {
+            // A custom type's direction is unknown to us, so matching must be
+            // directional: the only link on PROJ-1 points the other way, and
+            // deleting it would destroy a relationship the caller did not name.
             let server = MockServer::start();
 
             let get_mock = server.mock(|when, then| {
@@ -6521,6 +6532,49 @@ mod tests {
 
             let delete_mock = server.mock(|when, then| {
                 when.method(DELETE).path("/issueLink/45");
+                then.status(204);
+            });
+
+            let client = create_self_hosted_client(&server);
+            let err = client
+                .unlink_issues("PROJ-1", "PROJ-2", "Discovered while testing")
+                .await
+                .unwrap_err();
+
+            match &err {
+                Error::NotFound(message) => assert!(
+                    message.contains("opposite direction"),
+                    "error should point at the reversed link: {message}"
+                ),
+                other => panic!("unexpected error: {other:?}"),
+            }
+            get_mock.assert();
+            // Nothing was deleted.
+            assert_eq!(delete_mock.calls(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_unlink_issues_custom_type_deletes_the_matching_outward_link() {
+            let server = MockServer::start();
+
+            let get_mock = server.mock(|when, then| {
+                when.method(GET)
+                    .path("/issue/PROJ-1")
+                    .query_param("fields", "issuelinks");
+                then.status(200)
+                    .json_body(jira_issue_with_link(serde_json::json!({
+                        "id": "46",
+                        "type": { "name": "Discovered while testing" },
+                        "outwardIssue": {
+                            "id": "10002",
+                            "key": "PROJ-2",
+                            "fields": { "summary": "Target" }
+                        }
+                    })));
+            });
+
+            let delete_mock = server.mock(|when, then| {
+                when.method(DELETE).path("/issueLink/46");
                 then.status(204);
             });
 

--- a/crates/plugins/api/jira/src/client.rs
+++ b/crates/plugins/api/jira/src/client.rs
@@ -1690,6 +1690,21 @@ fn jira_link_matches_target(
     let outward_key = link.outward_issue.as_ref().map(|issue| issue.key.as_str());
     let inward_key = link.inward_issue.as_ref().map(|issue| issue.key.as_str());
 
+    // Decide symmetry from the link's own wording where Jira supplies it: a
+    // genuinely symmetric type reads the same in both directions ("relates to"
+    // / "relates to"). The name-based hint alone is not enough, because an
+    // admin can configure a *directional* custom type also called "Relates"
+    // — and treating that as symmetric would delete the link pointing the
+    // other way.
+    let allow_either_direction = match (
+        link.link_type.inward.as_deref(),
+        link.link_type.outward.as_deref(),
+    ) {
+        (Some(inward), Some(outward)) => inward.eq_ignore_ascii_case(outward),
+        // No descriptions in the payload — fall back to the name hint.
+        _ => allow_either_direction,
+    };
+
     if allow_either_direction {
         outward_key == Some(target_key) || inward_key == Some(target_key)
     } else if reversed {
@@ -6551,6 +6566,48 @@ mod tests {
             get_mock.assert();
             // Nothing was deleted.
             assert_eq!(delete_mock.calls(), 0);
+        }
+
+        #[tokio::test]
+        async fn test_unlink_issues_directional_type_named_relates_is_not_symmetric() {
+            // An admin can configure a custom, directional type also called
+            // "Relates". Deciding symmetry by name alone would match the link
+            // pointing the other way and delete the wrong relationship.
+            let server = MockServer::start();
+
+            let get_mock = server.mock(|when, then| {
+                when.method(GET)
+                    .path("/issue/PROJ-1")
+                    .query_param("fields", "issuelinks");
+                then.status(200)
+                    .json_body(jira_issue_with_link(serde_json::json!({
+                        "id": "47",
+                        "type": {
+                            "name": "Relates",
+                            "inward": "is required by",
+                            "outward": "requires"
+                        },
+                        "inwardIssue": {
+                            "id": "10002",
+                            "key": "PROJ-2",
+                            "fields": { "summary": "Target" }
+                        }
+                    })));
+            });
+
+            let delete_mock = server.mock(|when, then| {
+                when.method(DELETE).path("/issueLink/47");
+                then.status(204);
+            });
+
+            let client = create_self_hosted_client(&server);
+            client
+                .unlink_issues("PROJ-1", "PROJ-2", "relates_to")
+                .await
+                .unwrap_err();
+
+            get_mock.assert();
+            assert_eq!(delete_mock.calls(), 0, "the reverse link must survive");
         }
 
         #[tokio::test]

--- a/crates/plugins/api/linear/src/client.rs
+++ b/crates/plugins/api/linear/src/client.rs
@@ -14,8 +14,8 @@ use crate::DEFAULT_LINEAR_URL;
 use crate::types::{
     GraphQlResponse, LinearComment, LinearCommentCreateData, LinearIssue, LinearIssueCommentsData,
     LinearIssueCreateData, LinearIssueData, LinearIssueLabelsData, LinearIssueUpdateData,
-    LinearIssuesData, LinearUser, LinearUsersData, LinearWorkflowState, LinearWorkflowStatesData,
-    Viewer, ViewerData,
+    LinearIssuesData, LinearUser, LinearUsersData, LinearWorkflowState,
+    LinearWorkflowStateConnection, LinearWorkflowStatesData, Viewer, ViewerData,
 };
 
 const VIEWER_QUERY: &str = r#"
@@ -178,12 +178,16 @@ mutation IssueCreate($input: IssueCreateInput!) {
 "#;
 
 const WORKFLOW_STATES_QUERY: &str = r#"
-query WorkflowStates($first: Int!, $filter: WorkflowStateFilter) {
-  workflowStates(first: $first, filter: $filter) {
+query WorkflowStates($first: Int!, $after: String, $filter: WorkflowStateFilter) {
+  workflowStates(first: $first, after: $after, filter: $filter) {
     nodes {
       id
       name
       type
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
     }
   }
 }
@@ -661,19 +665,58 @@ impl LinearClient {
         })
     }
 
+    /// Every workflow state on the team, following the connection cursor.
+    ///
+    /// A single `first: 100` page silently truncates larger teams, and a
+    /// truncated list makes `resolve_workflow_state_id` miss an exact name and
+    /// fall back to the category branch — landing on a different state of the
+    /// same type. That is precisely the mis-set-status bug this resolver
+    /// exists to avoid, so the list has to be complete.
     async fn list_workflow_states(&self) -> Result<LinearWorkflowStatesData> {
-        let variables = json!({
-            "first": 100,
-            "filter": {
-                "team": {
-                    "id": {
-                        "eq": self.team_id
+        // Bounded so a server that always reports another page cannot spin.
+        const MAX_PAGES: usize = 50;
+
+        let mut nodes = Vec::new();
+        let mut after: Option<String> = None;
+
+        for _ in 0..MAX_PAGES {
+            let variables = json!({
+                "first": 100,
+                "after": after,
+                "filter": { "team": { "id": { "eq": self.team_id } } }
+            });
+            let page: LinearWorkflowStatesData = self
+                .graphql(WORKFLOW_STATES_QUERY, variables, &self.token)
+                .await?;
+            let connection = page.workflow_states;
+            nodes.extend(connection.nodes);
+
+            match connection.page_info {
+                Some(info) if info.has_next_page => match info.end_cursor {
+                    // A cursor-less "there is more" would restart from the
+                    // beginning and loop; treat it as a protocol error.
+                    Some(cursor) => after = Some(cursor),
+                    None => {
+                        return Err(Error::InvalidData(
+                            "Linear reported more workflow states but returned no cursor"
+                                .to_string(),
+                        ));
                     }
+                },
+                _ => {
+                    return Ok(LinearWorkflowStatesData {
+                        workflow_states: LinearWorkflowStateConnection {
+                            nodes,
+                            page_info: None,
+                        },
+                    });
                 }
             }
-        });
-        self.graphql(WORKFLOW_STATES_QUERY, variables, &self.token)
-            .await
+        }
+
+        Err(Error::InvalidData(format!(
+            "Linear still reported more workflow states after {MAX_PAGES} pages"
+        )))
     }
 
     fn map_create_priority(priority: Option<&str>) -> Result<Option<i32>> {

--- a/crates/plugins/api/linear/src/client.rs
+++ b/crates/plugins/api/linear/src/client.rs
@@ -596,7 +596,27 @@ impl LinearClient {
             ));
         }
 
-        let target_name = match state.to_ascii_lowercase().as_str() {
+        let data = self.list_workflow_states().await?;
+        let nodes = data.workflow_states.nodes;
+
+        // An exact state name always wins over the category aliases below.
+        // Linear's own default states are literally called "Done", "Todo",
+        // "Backlog" and "Canceled"; resolving those by category first would
+        // shadow them and could land on a different state of the same type
+        // (a team with both "Done" and "Released" is ordinary), silently
+        // setting a status the caller never asked for.
+        if let Some(node) = nodes
+            .iter()
+            .find(|node| node.name.eq_ignore_ascii_case(state))
+        {
+            return Ok(node.id.clone());
+        }
+
+        // Not a state name on this team — fall back to the shared category
+        // vocabulary. Which state is chosen among several of the same type
+        // follows the order Linear returns them in; callers who need a
+        // specific one should name it exactly, which the branch above honours.
+        let target_type = match state.to_ascii_lowercase().as_str() {
             "open" | "opened" => None,
             "closed" => Some("completed"),
             "cancelled" | "canceled" => Some("canceled"),
@@ -604,39 +624,33 @@ impl LinearClient {
             "todo" => Some("unstarted"),
             "in_progress" | "in progress" | "started" => Some("started"),
             "done" | "completed" => Some("completed"),
-            other => {
-                return self.resolve_workflow_state_id_by_name(other).await;
+            _ => {
+                return Err(Error::NotFound(format!(
+                    "Linear workflow state not found by name '{}' in team {}; \
+                     available: {}",
+                    state,
+                    self.team_id,
+                    nodes
+                        .iter()
+                        .map(|node| node.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )));
             }
         };
 
-        let variables = json!({
-            "first": 100,
-            "filter": {
-                "team": {
-                    "id": {
-                        "eq": self.team_id
-                    }
-                }
-            }
-        });
-        let data: LinearWorkflowStatesData = self
-            .graphql(WORKFLOW_STATES_QUERY, variables, &self.token)
-            .await?;
-
-        let state_id = if let Some(target_type) = target_name {
-            data.workflow_states
-                .nodes
+        let state_id = match target_type {
+            Some(target_type) => nodes
                 .into_iter()
                 .find(|node| node.r#type.as_deref() == Some(target_type))
-                .map(|node| node.id)
-        } else {
-            data.workflow_states
-                .nodes
+                .map(|node| node.id),
+            // "open" means any non-terminal state.
+            None => nodes
                 .into_iter()
                 .find(|node| {
                     !matches!(node.r#type.as_deref(), Some("completed") | Some("canceled"))
                 })
-                .map(|node| node.id)
+                .map(|node| node.id),
         };
 
         state_id.ok_or_else(|| {
@@ -645,36 +659,6 @@ impl LinearClient {
                 state, self.team_id
             ))
         })
-    }
-
-    async fn resolve_workflow_state_id_by_name(&self, state_name: &str) -> Result<String> {
-        let variables = json!({
-            "first": 100,
-            "filter": {
-                "team": {
-                    "id": {
-                        "eq": self.team_id
-                    }
-                },
-                "name": {
-                    "eqIgnoreCase": state_name
-                }
-            }
-        });
-        let data: LinearWorkflowStatesData = self
-            .graphql(WORKFLOW_STATES_QUERY, variables, &self.token)
-            .await?;
-        data.workflow_states
-            .nodes
-            .into_iter()
-            .find(|node| node.name.eq_ignore_ascii_case(state_name))
-            .map(|node| node.id)
-            .ok_or_else(|| {
-                Error::NotFound(format!(
-                    "Linear workflow state not found by name '{}' in team {}",
-                    state_name, self.team_id
-                ))
-            })
     }
 
     async fn list_workflow_states(&self) -> Result<LinearWorkflowStatesData> {
@@ -1908,6 +1892,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_workflow_state_prefers_an_exact_name_over_the_category_alias() {
+        // The team has two `completed` states and the literal name "Done" is
+        // one of them. Resolving "Done" by category could land on "Released";
+        // the exact name must win.
+        let server = MockServer::start();
+        let states = server.mock(|when, then| {
+            when.method(POST)
+                .path("/graphql")
+                .body_includes("query WorkflowStates");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "data": { "workflowStates": { "nodes": [
+                        { "id": "st-released", "name": "Released", "type": "completed" },
+                        { "id": "st-done", "name": "Done", "type": "completed" }
+                    ] } }
+                }));
+        });
+
+        let client = LinearClient::with_base_url(
+            format!("{}/graphql", server.base_url()),
+            "team-1",
+            SecretString::from("lin_api_test".to_owned()),
+        );
+
+        assert_eq!(
+            client.resolve_workflow_state_id("Done").await.unwrap(),
+            "st-done"
+        );
+        // A pure category still resolves by type, first state of that type.
+        assert_eq!(
+            client.resolve_workflow_state_id("closed").await.unwrap(),
+            "st-released"
+        );
+        // An unknown name fails loudly and lists what is available.
+        let err = client
+            .resolve_workflow_state_id("Shipped")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&err, Error::NotFound(m) if m.contains("Shipped") && m.contains("Released")),
+            "unexpected error: {err:?}"
+        );
+        states.assert_calls(3);
+    }
+
+    #[tokio::test]
     async fn get_issues_sends_order_by_and_reports_sort_info() {
         let server = MockServer::start();
         let page = server.mock(|when, then| {
@@ -2100,8 +2131,9 @@ mod tests {
         let workflow_states = server.mock(|when, then| {
             when.method(POST)
                 .path("/graphql")
-                .body_includes("query WorkflowStates")
-                .body_includes(r#""name":{"eqIgnoreCase":"in review"}"#);
+                // States are now fetched unfiltered and matched by exact name
+                // locally, so an exact name is never shadowed by a category alias.
+                .body_includes("query WorkflowStates");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({

--- a/crates/plugins/api/linear/src/types.rs
+++ b/crates/plugins/api/linear/src/types.rs
@@ -127,6 +127,9 @@ pub struct LinearWorkflowStatesData {
 pub struct LinearWorkflowStateConnection {
     #[serde(default)]
     pub nodes: Vec<LinearWorkflowStateWithId>,
+    #[serde(rename = "pageInfo")]
+    #[serde(default)]
+    pub page_info: Option<LinearPageInfo>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/plugins/api/yougile/src/client.rs
+++ b/crates/plugins/api/yougile/src/client.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use devboy_core::{
     Comment, CreateIssueInput, CustomFieldValue, Error, Issue, IssueFilter, IssueProvider,
-    MergeRequestProvider, Pagination, PipelineProvider, Provider, ProviderResult, Result,
-    UpdateIssueInput, User,
+    MergeRequestProvider, Pagination, PipelineProvider, Provider, ProviderResult, Result, SortInfo,
+    SortOrder, UpdateIssueInput, User,
 };
 use reqwest::{Response, StatusCode};
 use secrecy::{ExposeSecret, SecretString};
@@ -20,7 +20,7 @@ use tracing::warn;
 
 use crate::DEFAULT_YOUGILE_URL;
 use crate::types::{
-    YouGileChatMessage, YouGileColumn, YouGileListResponse, YouGileTask, YouGileUser,
+    YouGileChatMessage, YouGileColumn, YouGileListResponse, YouGilePaging, YouGileTask, YouGileUser,
 };
 
 /// YouGile client used by the workspace provider layer.
@@ -154,7 +154,7 @@ impl YouGileClient {
             if !page.paging.next {
                 break;
             }
-            offset = offset.saturating_add(page.paging.limit);
+            offset = advance_offset(offset, &page.paging, "/columns")?;
         }
 
         Ok(columns)
@@ -191,7 +191,7 @@ impl YouGileClient {
             if !page.paging.next {
                 break;
             }
-            offset = offset.saturating_add(page.paging.limit);
+            offset = advance_offset(offset, &page.paging, "/task-list")?;
         }
 
         Ok(tasks)
@@ -235,22 +235,10 @@ impl YouGileClient {
 
         tasks.sort_by_key(|task| std::cmp::Reverse(task.timestamp));
 
-        if let Some(sort_by) = filter.sort_by.as_deref() {
-            match sort_by {
-                "created_at" | "created" => {
-                    if matches!(filter.sort_order.as_deref(), Some("asc")) {
-                        tasks.sort_by_key(|task| task.timestamp);
-                    } else {
-                        tasks.sort_by_key(|task| std::cmp::Reverse(task.timestamp));
-                    }
-                }
-                unsupported => {
-                    warn!(
-                        sort_by = unsupported,
-                        "YouGile API does not expose native sorting for this field; keeping timestamp order"
-                    );
-                }
-            }
+        // Validated up front in `get_issues`, so by here the field is known
+        // to be one of the two timestamp aliases.
+        if matches!(filter.sort_order.as_deref(), Some("asc")) {
+            tasks.sort_by_key(|task| task.timestamp);
         }
 
         // Make sure column mapping covers every task we return.
@@ -573,6 +561,8 @@ fn validate_generic_update_fields(input: &UpdateIssueInput) -> Result<()> {
 #[async_trait]
 impl IssueProvider for YouGileClient {
     async fn get_issues(&self, filter: IssueFilter) -> Result<ProviderResult<Issue>> {
+        validate_sort_by(filter.sort_by.as_deref())?;
+        validate_assignee_filter(filter.assignee.as_deref())?;
         let columns = self.list_board_columns().await?;
         let column_titles: HashMap<String, String> = columns
             .iter()
@@ -600,13 +590,29 @@ impl IssueProvider for YouGileClient {
             );
         }
 
-        Ok(ProviderResult::new(items).with_pagination(Pagination {
+        let mut result = ProviderResult::new(items).with_pagination(Pagination {
             offset: offset as u32,
             limit: limit as u32,
             total: Some(total),
             has_more,
             next_cursor: None,
-        }))
+        });
+        result.sort_info = Some(SortInfo {
+            sort_by: Some(
+                filter
+                    .sort_by
+                    .as_deref()
+                    .unwrap_or("created_at")
+                    .to_string(),
+            ),
+            sort_order: if matches!(filter.sort_order.as_deref(), Some("asc")) {
+                SortOrder::Asc
+            } else {
+                SortOrder::Desc
+            },
+            available_sorts: vec!["created_at".to_string(), "updated_at".to_string()],
+        });
+        Ok(result)
     }
 
     async fn get_issue(&self, key: &str) -> Result<Issue> {
@@ -918,6 +924,55 @@ fn is_closed_task(task: &YouGileTask) -> bool {
     task.completed || task.archived || task.deleted
 }
 
+/// Advances the paging cursor, refusing to spin forever.
+///
+/// The loops that call this keep going while the server says `next: true`,
+/// stepping by the page size the server reports back. A `limit` of 0 would
+/// leave the offset unchanged and turn that into an infinite request loop —
+/// a hang is far worse than a surfaced error, so bail out instead.
+fn advance_offset(offset: u32, paging: &YouGilePaging, endpoint: &str) -> Result<u32> {
+    if paging.limit == 0 {
+        return Err(Error::InvalidData(format!(
+            "YouGile {endpoint} reported more pages but a page size of 0; refusing to loop forever"
+        )));
+    }
+    Ok(offset.saturating_add(paging.limit))
+}
+
+/// Maps the cross-provider `sort_by` value onto the single timestamp YouGile
+/// exposes on a task.
+///
+/// A YouGile task carries exactly one `timestamp`, which this provider
+/// surfaces as both `created_at` and `updated_at`. Both sort fields are
+/// therefore accepted and resolve to the same ordering; anything else is
+/// refused by name rather than silently ignored, so a caller never receives
+/// arbitrarily-ordered results believing the sort was applied.
+fn validate_sort_by(sort_by: Option<&str>) -> Result<()> {
+    match sort_by.map(str::trim) {
+        None | Some("") | Some("created_at") | Some("created") | Some("updated_at")
+        | Some("updated") => Ok(()),
+        Some(other) => Err(Error::InvalidData(format!(
+            "unsupported sort_by '{other}' for YouGile; expected one of: created_at, updated_at \
+             (both order by the task's single timestamp)"
+        ))),
+    }
+}
+
+/// YouGile's `assignedTo` filter matches on the user's **id**, not a name or
+/// email. The shared tool schema describes `assignee` as a username, so a
+/// caller following it would get an empty result set that is indistinguishable
+/// from "this person has no tasks". Fail with an explanation instead.
+fn validate_assignee_filter(assignee: Option<&str>) -> Result<()> {
+    match assignee.map(str::trim).filter(|s| !s.is_empty()) {
+        None => Ok(()),
+        Some(value) if looks_like_uuid(value) => Ok(()),
+        Some(value) => Err(Error::InvalidData(format!(
+            "YouGile filters assignees by user id, but '{value}' is not one; \
+             pass the user's id (a UUID) rather than a name or email"
+        ))),
+    }
+}
+
 fn matches_state_category(
     task: &YouGileTask,
     state_category: &str,
@@ -1146,6 +1201,52 @@ mod tests {
     use super::*;
     use httpmock::Method::{GET, POST, PUT};
     use httpmock::MockServer;
+
+    #[test]
+    fn advance_offset_refuses_to_spin_on_a_zero_page_size() {
+        let ok = YouGilePaging {
+            limit: 50,
+            offset: 0,
+            next: true,
+        };
+        assert_eq!(advance_offset(100, &ok, "/task-list").unwrap(), 150);
+
+        // limit == 0 would leave the offset unchanged and loop forever.
+        let stuck = YouGilePaging {
+            limit: 0,
+            offset: 0,
+            next: true,
+        };
+        let err = advance_offset(100, &stuck, "/task-list").unwrap_err();
+        assert!(
+            matches!(&err, Error::InvalidData(m) if m.contains("/task-list")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_sort_by_accepts_both_timestamp_aliases_and_names_the_rest() {
+        for ok in [None, Some(""), Some("created_at"), Some("updated_at")] {
+            validate_sort_by(ok).unwrap_or_else(|e| panic!("{ok:?} rejected: {e:?}"));
+        }
+        let err = validate_sort_by(Some("priority")).unwrap_err();
+        assert!(
+            matches!(&err, Error::InvalidData(m) if m.contains("priority") && m.contains("created_at")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_assignee_filter_rejects_names_that_would_silently_match_nothing() {
+        validate_assignee_filter(None).unwrap();
+        validate_assignee_filter(Some("11111111-2222-3333-4444-555555555555")).unwrap();
+
+        let err = validate_assignee_filter(Some("alice@example.com")).unwrap_err();
+        assert!(
+            matches!(&err, Error::InvalidData(m) if m.contains("alice@example.com") && m.contains("user id")),
+            "unexpected error: {err:?}"
+        );
+    }
 
     #[test]
     fn new_uses_default_api_url() {

--- a/crates/plugins/api/yougile/src/client.rs
+++ b/crates/plugins/api/yougile/src/client.rs
@@ -135,7 +135,10 @@ impl YouGileClient {
         let mut offset = 0_u32;
         let mut columns = Vec::new();
 
-        loop {
+        for page_no in 0..=MAX_PAGES {
+            if page_no == MAX_PAGES {
+                return Err(exhausted_pages(MAX_PAGES, "/columns"));
+            }
             let page: YouGileListResponse<YouGileColumn> = self
                 .get_json(
                     "/columns",
@@ -168,7 +171,10 @@ impl YouGileClient {
         let mut offset = 0_u32;
         let mut tasks = Vec::new();
 
-        loop {
+        for page_no in 0..=MAX_PAGES {
+            if page_no == MAX_PAGES {
+                return Err(exhausted_pages(MAX_PAGES, "/task-list"));
+            }
             let mut query = vec![
                 ("columnId", column_id.to_string()),
                 ("limit", "1000".to_string()),
@@ -936,7 +942,30 @@ fn advance_offset(offset: u32, paging: &YouGilePaging, endpoint: &str) -> Result
             "YouGile {endpoint} reported more pages but a page size of 0; refusing to loop forever"
         )));
     }
-    Ok(offset.saturating_add(paging.limit))
+    // `saturating_add` would pin at u32::MAX and keep re-requesting the same
+    // offset forever, so treat an offset that cannot advance as a protocol
+    // error rather than silently spinning.
+    offset.checked_add(paging.limit).ok_or_else(|| {
+        Error::InvalidData(format!(
+            "YouGile {endpoint} paged past the maximum offset ({offset} + {}); \
+             refusing to loop forever",
+            paging.limit
+        ))
+    })
+}
+
+/// Upper bound on pages fetched from one endpoint in a single call.
+///
+/// A server that always answers `next: true` would otherwise keep the loop
+/// running indefinitely even while the offset advances normally. At the 1000
+/// items per page this client requests, the cap is far above any real board.
+const MAX_PAGES: usize = 1_000;
+
+fn exhausted_pages(pages: usize, endpoint: &str) -> Error {
+    Error::InvalidData(format!(
+        "YouGile {endpoint} still reported more pages after {pages} requests; \
+         refusing to loop forever"
+    ))
 }
 
 /// Maps the cross-provider `sort_by` value onto the single timestamp YouGile
@@ -963,14 +992,20 @@ fn validate_sort_by(sort_by: Option<&str>) -> Result<()> {
 /// caller following it would get an empty result set that is indistinguishable
 /// from "this person has no tasks". Fail with an explanation instead.
 fn validate_assignee_filter(assignee: Option<&str>) -> Result<()> {
-    match assignee.map(str::trim).filter(|s| !s.is_empty()) {
-        None => Ok(()),
-        Some(value) if looks_like_uuid(value) => Ok(()),
-        Some(value) => Err(Error::InvalidData(format!(
-            "YouGile filters assignees by user id, but '{value}' is not one; \
-             pass the user's id (a UUID) rather than a name or email"
-        ))),
+    let Some(value) = assignee.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(());
+    };
+
+    // Reject only what an id can never be — an email or a multi-word name.
+    // Ids are otherwise treated as opaque: requiring a UUID here would refuse
+    // legitimate identifiers if YouGile ever issues another shape.
+    if value.contains('@') || value.split_whitespace().count() > 1 {
+        return Err(Error::InvalidData(format!(
+            "YouGile filters assignees by user id, and '{value}' looks like a name or email; \
+             pass the user's id instead"
+        )));
     }
+    Ok(())
 }
 
 fn matches_state_category(
@@ -1222,6 +1257,18 @@ mod tests {
             matches!(&err, Error::InvalidData(m) if m.contains("/task-list")),
             "unexpected error: {err:?}"
         );
+
+        // Saturating at u32::MAX would re-request the same offset forever.
+        let huge = YouGilePaging {
+            limit: 10,
+            offset: 0,
+            next: true,
+        };
+        let err = advance_offset(u32::MAX - 1, &huge, "/task-list").unwrap_err();
+        assert!(
+            matches!(&err, Error::InvalidData(m) if m.contains("maximum offset")),
+            "unexpected error: {err:?}"
+        );
     }
 
     #[test]
@@ -1241,11 +1288,16 @@ mod tests {
         validate_assignee_filter(None).unwrap();
         validate_assignee_filter(Some("11111111-2222-3333-4444-555555555555")).unwrap();
 
-        let err = validate_assignee_filter(Some("alice@example.com")).unwrap_err();
-        assert!(
-            matches!(&err, Error::InvalidData(m) if m.contains("alice@example.com") && m.contains("user id")),
-            "unexpected error: {err:?}"
-        );
+        // Opaque non-UUID ids must still pass — only names/emails are refused.
+        validate_assignee_filter(Some("usr_12345")).unwrap();
+
+        for bad in ["alice@example.com", "Alice Doe"] {
+            let err = validate_assignee_filter(Some(bad)).unwrap_err();
+            assert!(
+                matches!(&err, Error::InvalidData(m) if m.contains(bad) && m.contains("user id")),
+                "unexpected error for {bad}: {err:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/plugins/api/yougile/src/enricher.rs
+++ b/crates/plugins/api/yougile/src/enricher.rs
@@ -37,6 +37,18 @@ impl ToolEnricher for YouGileSchemaEnricher {
                 &["backlog", "todo", "in_progress", "done", "cancelled"],
                 "Filter by semantic status category. Maps YouGile board columns to shared status buckets using column-title heuristics.",
             );
+            // The shared schema calls this a username, but YouGile's
+            // `assignedTo` matches on the user id only.
+            schema.set_description(
+                "assignee",
+                "Filter by assignee **user id** (UUID) — YouGile does not match names or emails",
+            );
+            // A YouGile task exposes a single timestamp, surfaced as both
+            // created_at and updated_at, so both sorts resolve to it.
+            schema.set_description(
+                "sort_by",
+                "YouGile stores one timestamp per task; `created_at` and `updated_at` order by it identically",
+            );
         }
 
         let statuses: Vec<String> = self

--- a/docs/guide/reference/cli.md
+++ b/docs/guide/reference/cli.md
@@ -294,6 +294,7 @@ Exchange an Atlassian OAuth authorization code for tokens and store them
 ###### **Options:**
 
 * `--code <CODE>` — Authorization code returned by Atlassian
+* `--state <STATE>` — `state` value Atlassian returned on the redirect. Checked against the one issued by `oauth url`; required whenever that command generated it
 * `--context <CONTEXT>` — Optional context name. Defaults to active context, then global config
 * `--client-secret <CLIENT_SECRET>` — Client secret override. When omitted, reads from keychain
 * `--store-client-secret` — Persist the provided client secret to keychain


### PR DESCRIPTION
Post-factum review of the four PRs merged today (#293, #305, #299, #304).
Those PRs had **no human review** — the only pass was Copilot's — and #299 /
#304 (≈6k lines together) got only a targeted skim from me before merging.
This closes that gap for the two large ones.

Every finding below is a case where the code did something other than what
it advertised, **without surfacing an error**.

## YouGile

- `get_issues` advertised `sort_by=created_at|updated_at` but honoured only
  `created_at`. `updated_at` hit a `warn!` the caller never sees, so results
  came back in an order nobody asked for. A YouGile task carries a single
  `timestamp` (surfaced as both `created_at` and `updated_at`), so both
  aliases now resolve to it and anything else is refused by name.
- The `assignee` filter is forwarded to YouGile's `assignedTo`, which matches
  on **user id** — while the shared tool schema documents it as a username.
  Following the schema returned an empty page indistinguishable from "this
  person has no tasks". Non-id values are now rejected with an explanation,
  and the schema description corrected.
- Both paging loops advanced by the server-reported page size, so `limit: 0`
  alongside `next: true` would spin forever issuing unbounded requests.
  `advance_offset()` now fails instead of hanging.
- `sort_info` is reported so callers can see the ordering that was applied.

## Confluence Cloud

- Copilot asked for a random `state` "and ideally verified on callback". The
  randomness was fixed; the verification never was — `oauth url` generated a
  state, printed it, and nothing checked what Atlassian echoed back, leaving
  the parameter decorative. `oauth url` now records the issued value and
  `oauth exchange` gains `--state`, compared in constant time and consumed on
  use so neither an accepted nor a rejected value can be replayed.

## Verification

Beyond unit tests, each fix was exercised through the MCP surface against a
stub YouGile server:

| Case | Before | After |
|---|---|---|
| `sort_by=updated_at` | silently ignored | applied |
| `sort_by=priority` | silent `warn!` | named error |
| `assignee=alice` | empty page | named error |
| `assignee=<uuid>` | worked | worked |
| `next:true` + `limit:0` | **hung forever** | named error |

Local: `cargo test --workspace`, `clippy --all-targets -D warnings`, `fmt`,
`cargo deny`, all 14 public-api baselines, and both generated docs verified
clean.

## Still not covered

Neither provider has been exercised against a **real** YouGile or Confluence
Cloud instance — no credentials available. Linear was verified live earlier
and that is what turned up its four defects, so this remains the most likely
place for further surprises.