### PR TITLE
fix(confluence): render storage-format tables instead of running cells together

### DIFF
--- a/crates/plugins/api/confluence/src/client.rs
+++ b/crates/plugins/api/confluence/src/client.rs
@@ -1896,6 +1896,27 @@ fn render_adf_inline_nodes(content: Option<&Value>, out: &mut String) {
     }
 }
 
+/// Adds the GFM delimiter row after the first row of each table block.
+///
+/// A markdown table without `| --- |` under its first row is not parsed as a
+/// table at all, so the rows would render as literal pipe-laden text.
+fn insert_gfm_header_delimiter(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut previous_was_row = false;
+
+    for line in input.split_inclusive('\n') {
+        let trimmed = line.trim();
+        let is_row = trimmed.starts_with('|') && trimmed.ends_with('|');
+        out.push_str(line);
+        if is_row && !previous_was_row {
+            let columns = trimmed.matches('|').count().saturating_sub(1).max(1);
+            out.push_str(&format!("| {} |\n", vec!["---"; columns].join(" | ")));
+        }
+        previous_was_row = is_row;
+    }
+    out
+}
+
 fn confluence_storage_to_markdown(storage: &str) -> String {
     let with_code_blocks = replace_confluence_code_macros(storage);
     let with_links = replace_anchor_tags(&with_code_blocks);
@@ -1941,8 +1962,25 @@ fn confluence_storage_to_markdown(storage: &str) -> String {
         .replace("<h5>", "##### ")
         .replace("</h5>", "\n\n")
         .replace("<h6>", "###### ")
-        .replace("</h6>", "\n\n");
+        .replace("</h6>", "\n\n")
+        // Tables were falling through to the tag stripper, which drops every
+        // tag without inserting anything — so a row's cells ran together into
+        // one string ("NameAgeAlice30"). Emit GFM delimiters instead. This is
+        // the storage-format twin of the ADF table handling.
+        .replace("<table>", "\n")
+        .replace("</table>", "\n")
+        .replace("<tbody>", "")
+        .replace("</tbody>", "")
+        .replace("<thead>", "")
+        .replace("</thead>", "")
+        .replace("<tr>", "|")
+        .replace("</tr>", "\n")
+        .replace("<th>", " ")
+        .replace("</th>", " |")
+        .replace("<td>", " ")
+        .replace("</td>", " |");
 
+    let markdownish = insert_gfm_header_delimiter(&markdownish);
     let text = strip_html_tags_preserve_layout(&markdownish);
     collapse_markdown_whitespace(&decode_html_entities(&text))
 }
@@ -4781,6 +4819,23 @@ mod tests {
 
         mock.assert();
         assert!(result.items.is_empty());
+    }
+
+    #[test]
+    fn storage_tables_render_as_markdown_instead_of_a_run_on_string() {
+        // Self-hosted pages arrive as storage format, whose tables used to be
+        // stripped tag-by-tag with nothing in their place — the twin of the
+        // ADF defect, and this path shipped in v0.32.0.
+        let storage = "<table><tbody>\
+            <tr><th>Name</th><th>Age</th></tr>\
+            <tr><td>Alice</td><td>30</td></tr>\
+            </tbody></table>";
+
+        let md = confluence_storage_to_markdown(storage);
+        assert!(!md.contains("NameAge"), "cells ran together: {md}");
+        assert!(md.contains("| Name | Age |"), "missing header row: {md}");
+        assert!(md.contains("| --- | --- |"), "missing delimiter row: {md}");
+        assert!(md.contains("| Alice | 30 |"), "missing body row: {md}");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #313, prompted by asking a simple question: which of the defects
we fixed today were already in a **released** version?

Answer: most were not — Linear, YouGile, Confluence Cloud and Jira
`unlink_issues` all landed after v0.32.0, so no published release ever carried
those bugs. But two Confluence functions predate them, and one still had the
defect after #313.

## What this fixes

`confluence_storage_to_markdown` handles paragraphs, lists, headings and inline
formatting, then hands whatever is left to `strip_html_tags_preserve_layout` —
which removes every tag and inserts nothing in its place. Table markup was never
handled, so a table's cells ran together:

```
<table><tr><th>Name</th><th>Age</th></tr><tr><td>Alice</td><td>30</td></tr></table>
→ "NameAgeAlice30"
```

Silent: no error, no truncation marker, just a plausible-looking string.

This is the storage-format twin of the ADF table defect fixed in #313. That fix
covered only the Cloud path — the fourth time in this review series that a fix
addressed half of its defect class, and the first where the missed half was
already **shipped**: `confluence_storage_to_markdown` and
`strip_html_tags_preserve_layout` are both present in the v0.32.0 tag, so
self-hosted Confluence users have this behaviour today.

## Approach

Table tags now emit GFM row syntax in the same replacement chain as the other
block elements, and `insert_gfm_header_delimiter` adds the `| --- |` row after
the first row of each table block — without it markdown does not recognise the
rows as a table at all and renders them as literal pipe-laden text.

## Verification

New test `storage_tables_render_as_markdown_instead_of_a_run_on_string` asserts
the header, delimiter and body rows, and explicitly that `NameAge` no longer
appears. Full workspace tests, `clippy --all-targets -D warnings` and `fmt` are
clean.

Still not exercised against a live Confluence instance — no credentials
available.